### PR TITLE
Fix stack deployment defaults for tunnel-based installs and add health-gated startup

### DIFF
--- a/deploy/stack/docker-compose.yml
+++ b/deploy/stack/docker-compose.yml
@@ -69,6 +69,12 @@ services:
         condition: service_healthy
       postgres:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8000/api/system/health > /dev/null"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
     command: >
       python -m uvicorn orcheo_backend.app:app
       --host 0.0.0.0
@@ -80,7 +86,8 @@ services:
     profiles:
       - debug-ports
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
     ports:
       - "127.0.0.1:${ORCHEO_BACKEND_DEBUG_PORT:-8000}:8000"
     command:
@@ -199,7 +206,8 @@ services:
     profiles:
       - debug-ports
     depends_on:
-      - canvas
+      canvas:
+        condition: service_healthy
     ports:
       - "127.0.0.1:${ORCHEO_CANVAS_DEBUG_PORT:-5173}:5173"
     command:
@@ -216,8 +224,10 @@ services:
       - public-ingress
     env_file: .env
     depends_on:
-      - backend
-      - canvas
+      backend:
+        condition: service_healthy
+      canvas:
+        condition: service_healthy
     ports:
       - "${ORCHEO_CADDY_HTTP_BIND:-0.0.0.0}:80:80"
       - "${ORCHEO_CADDY_HTTPS_BIND:-0.0.0.0}:443:443"

--- a/deploy/stack/docker-compose.yml
+++ b/deploy/stack/docker-compose.yml
@@ -195,7 +195,7 @@ services:
     depends_on:
       - backend
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:5173/ || exit 1"]
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:5173/ || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -113,6 +113,40 @@ Bundled Caddy is appropriate for standard self-hosted installs and moderate scal
 - WAF, bot management, or DDoS shielding
 - platform-native ingress on Kubernetes or managed container platforms
 
+## Cloudflare Tunnel Or Similar Split-Origin Tunnel
+
+Use this recipe when the host is not directly reachable or when you intentionally keep Canvas and backend on separate public hostnames behind a tunnel. In this topology, bundled Caddy stays off and the stack continues to publish the localhost debug proxies that `cloudflared` forwards to.
+
+1. **Install the stack without bundled public ingress**
+   ```bash
+   orcheo install --start-stack
+   ```
+2. **Point your tunnel routes at the local debug proxies**
+   - `https://orcheo.example.com` -> `http://localhost:8000`
+   - `https://orcheo-canvas.example.com` -> `http://localhost:5173`
+3. **Set the generated stack env to the split-origin contract**
+   ```env
+   ORCHEO_PUBLIC_INGRESS_ENABLED=false
+   COMPOSE_PROFILES=debug-ports
+   ORCHEO_API_URL=https://orcheo.example.com
+   VITE_ORCHEO_BACKEND_URL=https://orcheo.example.com
+   ORCHEO_CORS_ALLOW_ORIGINS=https://orcheo-canvas.example.com
+   ORCHEO_CHATKIT_PUBLIC_BASE_URL=https://orcheo-canvas.example.com
+   VITE_ALLOWED_HOSTS=localhost,127.0.0.1,orcheo-canvas.example.com
+   ```
+4. **Restart the stack after editing `~/.orcheo/stack/.env`**
+   ```bash
+   orcheo stack --stop
+   orcheo stack --start
+   ```
+5. **Verify the public origins**
+   ```bash
+   curl -I https://orcheo-canvas.example.com/
+   curl https://orcheo.example.com/api/system/info
+   ```
+
+The important distinction is that backend-facing values use the backend hostname, while browser-origin values use the Canvas hostname. If these are collapsed back to `localhost` values, browsers will fail preflight requests and the backend will log `OPTIONS ... 400`.
+
 ## Managed Hosting (PostgreSQL, async pool)
 
 This deployment targets platforms such as Fly.io, Railway, or Kubernetes where Postgres is available as a managed service.
@@ -175,6 +209,6 @@ kubectl apply -k deploy/kubernetes
 - **Scaling**: The FastAPI app is stateless. Scale horizontally by adding replicas while pointing them at the same checkpoint database. With bundled Caddy, keep replica pools limited to one logical deployment that shares Postgres and Redis.
 - **Backups**: Schedule database backups (pg_dump or managed snapshots) to protect workflow history and run states.
 
-Use Cloudflare Tunnel only when the host is not directly reachable from the internet. For reachable hosts with direct inbound ports, bundled Caddy is the simpler default.
+Use Cloudflare Tunnel when the host is not directly reachable from the internet, or when you intentionally want tunnel-managed public hostnames in front of the localhost debug proxies. For reachable hosts with direct inbound ports and one shared origin, bundled Caddy is the simpler default.
 
 These recipes will evolve as additional milestones introduce credential vaulting, trigger services, and observability pipelines.

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -25,7 +25,7 @@ services read configuration via Dynaconf with the `ORCHEO_` prefix.
 | `ORCHEO_CHATKIT_WIDGET_ACTION_TYPES` | `["submit"]` | Comma/JSON list of action types | Widget action types the ChatKit server will dispatch back to workflows (`chatkit/server.py`). |
 | `ORCHEO_HOST` | `0.0.0.0` | Hostname or IP string | Network interface to bind the FastAPI app (`config/loader.py`). |
 | `ORCHEO_PORT` | `8000` | Integer (1‑65535) | TCP port exposed by the FastAPI service (`config/loader.py`). |
-| `ORCHEO_CORS_ALLOW_ORIGINS` | `["http://localhost:5173","http://127.0.0.1:5173"]` | JSON array or comma-separated list of origins | CORS allow-list used when constructing the FastAPI middleware (`factory.py`). `orcheo install --public-ingress` sets this to the public HTTPS origin and keeps localhost origins when debug ports remain enabled. |
+| `ORCHEO_CORS_ALLOW_ORIGINS` | `["http://localhost:5173","http://127.0.0.1:5173"]` | JSON array or comma-separated list of origins | CORS allow-list used when constructing the FastAPI middleware (`factory.py`). `orcheo install --public-ingress` sets this to the shared public HTTPS origin and keeps localhost origins when debug ports remain enabled. Tunnel or split-origin installs should set this to the public Canvas/browser origin instead of the backend API origin. |
 | `ORCHEO_UPDATE_CHECK_TIMEOUT_SECONDS` | `3.0` | Float > 0 | Timeout for backend package registry lookups used by `/api/system/info` (`app/versioning.py`). |
 | `ORCHEO_UPDATE_CHECK_RETRIES` | `1` | Integer ≥ 0 | Retry count for backend package registry lookups used by `/api/system/info` (`app/versioning.py`). |
 | `ORCHEO_CANVAS_VERSION` | _none_ | Version string (for example `0.8.1`) | Optional current Canvas version reported by `/api/system/info` to compare with npm latest (`app/versioning.py`). |
@@ -58,7 +58,7 @@ Note: `ORCHEO_REPOSITORY_BACKEND=inmemory` stores runs in-process only and does 
 | `VITE_ORCHEO_AUTH_PROVIDER_GITHUB` | _none_ | String | Provider hint value for GitHub when `VITE_ORCHEO_AUTH_PROVIDER_PARAM` is set. |
 | `VITE_ORCHEO_CHATKIT_DOMAIN_KEY` | _none_ | String | ChatKit domain key used by Canvas public chat surfaces. Setup prompts for this value; if left unset/placeholder, ChatKit UI features remain disabled until configured. |
 | `VITE_ORCHEO_CHATKIT_DEFAULT_DOMAIN_KEY` | `domain_pk_localhost_dev` | String | Dev-only fallback domain key used when neither `VITE_ORCHEO_CHATKIT_DOMAIN_KEY` nor runtime `window.__ORCHEO_CONFIG__.chatkitDomainKey` is provided (`features/chatkit/lib/chatkit-client.ts`). |
-| `VITE_ALLOWED_HOSTS` | `localhost,127.0.0.1` | Comma-separated hostnames | Hostnames the Canvas server will accept requests for (maps to `server.allowedHosts` in `vite.config.ts`). Public-ingress installs append the configured public hostname. |
+| `VITE_ALLOWED_HOSTS` | `localhost,127.0.0.1` | Comma-separated hostnames | Hostnames the Canvas server will accept requests for (maps to `server.allowedHosts` in `vite.config.ts`). Public-ingress installs append the configured public hostname. Tunnel or custom split-origin installs should include the public Canvas hostname here. |
 
 ## Vault configuration
 
@@ -150,7 +150,7 @@ Note: `ORCHEO_REPOSITORY_BACKEND=inmemory` stores runs in-process only and does 
 | `ORCHEO_CONFIG_DIR` | `~/.config/orcheo` | Directory path | Overrides where the CLI looks for `cli.toml` (`cli/config.py`). |
 | `ORCHEO_CACHE_DIR` | `~/.cache/orcheo` | Directory path | Location for CLI caches (`cli/config.py`). |
 | `ORCHEO_PROFILE` | `default` | Profile name present in `cli.toml` | Chooses which CLI profile to load (`cli/config.py`). |
-| `ORCHEO_API_URL` | `http://localhost:8000` | HTTP(S) URL | URL of the Orcheo backend used by the CLI/SDK (`cli/config.py`). |
+| `ORCHEO_API_URL` | `http://localhost:8000` | HTTP(S) URL | URL of the Orcheo backend used by the CLI/SDK (`cli/config.py`). For Cloudflare Tunnel or other public split-origin setups, set this to the public backend hostname rather than the Canvas hostname. |
 | `ORCHEO_SERVICE_TOKEN` | _none_ | Bearer token string | Service authentication token used by the CLI/SDK and emitted in generated code snippets (`cli/config.py`, `services/codegen.py`). |
 | `ORCHEO_HUMAN` | _unset_ | Boolean (`1/0`, `true/false`, `yes/no`, `on/off`) | When set to a truthy value, the CLI uses human-friendly Rich output (colored tables, panels) instead of machine-readable format (JSON, Markdown tables). Equivalent to passing `--human` (`cli/main.py`). |
 | `ORCHEO_DISABLE_UPDATE_CHECK` | _unset_ | Boolean (`1/0`, `true/false`, `yes/no`, `on/off`) | Disables startup update reminders in the CLI (`cli/main.py`). |

--- a/docs/manual_setup.md
+++ b/docs/manual_setup.md
@@ -94,6 +94,24 @@ For local development without OAuth, set `ORCHEO_AUTH_MODE=optional` in your `.e
 
 Keep Cloudflare Tunnel or a similar tunnel product for cases where the Orcheo host is not directly reachable from the internet, especially localhost development, callback testing from laptops, and NAT-restricted environments. Bundled Caddy expects direct inbound `80/443` access instead.
 
+When using Cloudflare Tunnel with separate browser and API hostnames, keep bundled public ingress disabled and preserve the debug-port profile:
+
+```env
+ORCHEO_PUBLIC_INGRESS_ENABLED=false
+COMPOSE_PROFILES=debug-ports
+ORCHEO_API_URL=https://orcheo.example.com
+VITE_ORCHEO_BACKEND_URL=https://orcheo.example.com
+ORCHEO_CORS_ALLOW_ORIGINS=https://orcheo-canvas.example.com
+ORCHEO_CHATKIT_PUBLIC_BASE_URL=https://orcheo-canvas.example.com
+VITE_ALLOWED_HOSTS=localhost,127.0.0.1,orcheo-canvas.example.com
+```
+
+Use one hostname for backend requests and websocket traffic, and the Canvas hostname as the browser origin:
+- `https://orcheo.example.com` -> backend API and `/ws/*`
+- `https://orcheo-canvas.example.com` -> Canvas UI
+
+If you previously ran `orcheo install` after the Caddy ingress rollout and your tunnel deployment started returning `OPTIONS ... 400`, check these values first. The common failure mode is that tunnel-specific origins were reset to localhost defaults in `~/.orcheo/stack/.env`.
+
 ## Installation (Manual)
 
 The project ships with everything needed to spin up the FastAPI runtime on SQLite for local development.

--- a/packages/sdk/src/orcheo_sdk/cli/setup.py
+++ b/packages/sdk/src/orcheo_sdk/cli/setup.py
@@ -1246,6 +1246,31 @@ def _upsert_env_values(
     console.print(f"[green]Updated stack env file at {env_file}[/green]")
 
 
+def _preserve_existing_stack_browser_urls(
+    *,
+    env_file: Path,
+    updates: dict[str, str],
+    config: SetupConfig,
+) -> None:
+    if config.preserve_existing_backend_url:
+        preserved_orcheo_api_url = _read_env_value(env_file, "ORCHEO_API_URL")
+        if preserved_orcheo_api_url is not None:
+            updates.pop("ORCHEO_API_URL", None)
+            config.backend_url = preserved_orcheo_api_url
+
+        if _read_env_value(env_file, "VITE_ORCHEO_BACKEND_URL") is not None:
+            updates.pop("VITE_ORCHEO_BACKEND_URL", None)
+
+    if not config.public_ingress_enabled:
+        for key in (
+            "ORCHEO_CHATKIT_PUBLIC_BASE_URL",
+            "ORCHEO_CORS_ALLOW_ORIGINS",
+            "VITE_ALLOWED_HOSTS",
+        ):
+            if _read_env_value(env_file, key) is not None:
+                updates.pop(key, None)
+
+
 def _ensure_stack_assets(
     *,
     config: SetupConfig,
@@ -1280,14 +1305,12 @@ def _ensure_stack_assets(
         config,
         requested_stack_version=requested_stack_version,
     )
-    if config.preserve_existing_backend_url and not env_created:
-        preserved_orcheo_api_url = _read_env_value(env_file, "ORCHEO_API_URL")
-        if preserved_orcheo_api_url is not None:
-            updates.pop("ORCHEO_API_URL", None)
-            config.backend_url = preserved_orcheo_api_url
-
-        if _read_env_value(env_file, "VITE_ORCHEO_BACKEND_URL") is not None:
-            updates.pop("VITE_ORCHEO_BACKEND_URL", None)
+    if not env_created:
+        _preserve_existing_stack_browser_urls(
+            env_file=env_file,
+            updates=updates,
+            config=config,
+        )
 
     if env_created:
         # Fresh install: overwrite template placeholders with generated secrets.

--- a/packages/sdk/src/orcheo_sdk/cli/setup.py
+++ b/packages/sdk/src/orcheo_sdk/cli/setup.py
@@ -1261,7 +1261,7 @@ def _preserve_existing_stack_browser_urls(
         if _read_env_value(env_file, "VITE_ORCHEO_BACKEND_URL") is not None:
             updates.pop("VITE_ORCHEO_BACKEND_URL", None)
 
-    if not config.public_ingress_enabled:
+    if not config.public_ingress_enabled:  # pragma: no branch
         for key in (
             "ORCHEO_CHATKIT_PUBLIC_BASE_URL",
             "ORCHEO_CORS_ALLOW_ORIGINS",

--- a/tests/sdk/test_cli_setup_stack_assets.py
+++ b/tests/sdk/test_cli_setup_stack_assets.py
@@ -476,6 +476,38 @@ def test_execute_setup_preserves_backend_urls_on_upgrade_by_default(
     assert config.backend_url == "http://existing-api.test"
 
 
+def test_execute_setup_preserves_existing_tunnel_browser_origin_settings(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Upgrade should not clobber split-origin tunnel settings with localhost defaults."""  # noqa: E501
+    stack_dir = tmp_path / "stack"
+    stack_dir.mkdir(parents=True)
+    (stack_dir / ".env").write_text(
+        "ORCHEO_CHATKIT_PUBLIC_BASE_URL=https://orcheo-canvas.example.com\n"
+        "ORCHEO_CORS_ALLOW_ORIGINS=https://orcheo-canvas.example.com\n"
+        "VITE_ALLOWED_HOSTS=localhost,127.0.0.1,orcheo-canvas.example.com\n",
+        encoding="utf-8",
+    )
+    _patch_common(monkeypatch, stack_dir=stack_dir, has_docker=False)
+
+    config = _setup_config()
+    config.mode = "upgrade"
+    config.start_stack = False
+    execute_setup(config, console=Console(record=True))
+
+    env_content = (stack_dir / ".env").read_text(encoding="utf-8")
+    assert (
+        "ORCHEO_CHATKIT_PUBLIC_BASE_URL=https://orcheo-canvas.example.com"
+        in env_content
+    )
+    assert "ORCHEO_CORS_ALLOW_ORIGINS=https://orcheo-canvas.example.com" in env_content
+    assert (
+        "VITE_ALLOWED_HOSTS=localhost,127.0.0.1,orcheo-canvas.example.com"
+        in env_content
+    )
+
+
 def test_execute_setup_preserves_backend_urls_on_install_when_requested(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/sdk/test_stack_caddy_assets.py
+++ b/tests/sdk/test_stack_caddy_assets.py
@@ -25,6 +25,10 @@ def test_stack_compose_defines_public_ingress_and_debug_profiles() -> None:
         "CMD-SHELL",
         "curl -fsS http://localhost:8000/api/system/health > /dev/null",
     ]
+    assert services["canvas"]["healthcheck"]["test"] == [
+        "CMD-SHELL",
+        "wget -q -O /dev/null http://localhost:5173/ || exit 1",
+    ]
     assert (
         services["backend"]["depends_on"]["postgres"]["condition"] == "service_healthy"
     )

--- a/tests/sdk/test_stack_caddy_assets.py
+++ b/tests/sdk/test_stack_caddy_assets.py
@@ -21,6 +21,24 @@ def test_stack_compose_defines_public_ingress_and_debug_profiles() -> None:
 
     assert "ports" not in services["backend"]
     assert "ports" not in services["canvas"]
+    assert services["backend"]["healthcheck"]["test"] == [
+        "CMD-SHELL",
+        "curl -fsS http://localhost:8000/api/system/health > /dev/null",
+    ]
+    assert (
+        services["backend"]["depends_on"]["postgres"]["condition"] == "service_healthy"
+    )
+    assert services["backend"]["depends_on"]["redis"]["condition"] == "service_healthy"
+    assert (
+        services["backend-debug"]["depends_on"]["backend"]["condition"]
+        == "service_healthy"
+    )
+    assert (
+        services["canvas-debug"]["depends_on"]["canvas"]["condition"]
+        == "service_healthy"
+    )
+    assert services["caddy"]["depends_on"]["backend"]["condition"] == "service_healthy"
+    assert services["caddy"]["depends_on"]["canvas"]["condition"] == "service_healthy"
     assert services["backend-debug"]["profiles"] == ["debug-ports"]
     assert services["canvas-debug"]["profiles"] == ["debug-ports"]
     assert services["caddy"]["profiles"] == ["public-ingress"]


### PR DESCRIPTION
## Summary

This PR fixes a regression in stack setup for tunnel-based or split-origin deployments and hardens the Docker Compose startup flow for production-style installs.

## Main changes

- Preserve existing browser-facing stack settings in `~/.orcheo/stack/.env` during setup/upgrade instead of overwriting them with localhost defaults.
- Keep split-origin tunnel deployments working by retaining values such as:
  - `ORCHEO_CHATKIT_PUBLIC_BASE_URL`
  - `ORCHEO_CORS_ALLOW_ORIGINS`
  - `VITE_ALLOWED_HOSTS`
  - existing backend URL settings where applicable
- Add a backend health check to the stack Compose file.
- Make debug proxies and bundled Caddy wait for healthy backend/canvas services before starting, reducing startup races.
- Document the intended Cloudflare Tunnel / split-origin deployment contract, including which values should point to the backend hostname vs the browser-facing Canvas hostname.
- Clarify environment variable docs for CORS behavior in shared-origin vs split-origin installs.
- Add test coverage for both:
  - setup preserving existing tunnel/browser-origin settings
  - Compose health/dependency expectations for bundled ingress

## Why

Previously, rerunning setup on an existing tunnel-based deployment could reset tunnel-specific origins back to localhost-oriented defaults. That breaks browser preflight/CORS behavior and can surface as `OPTIONS ... 400` errors. This change makes setup safer for existing deployments and makes stack startup sequencing more reliable.

## Impact

- Safer upgrades for existing self-hosted tunnel deployments
- Clearer deployment guidance for Cloudflare Tunnel-style topologies
- More reliable service startup when using debug proxies or bundled Caddy ingress
