### PR TITLE
Fix canvas healthcheck host and improve Slack MCP stdio logging

### DIFF
--- a/deploy/stack/.env.example
+++ b/deploy/stack/.env.example
@@ -40,10 +40,10 @@ ORCHEO_CORS_ALLOW_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
 ORCHEO_PUBLIC_INGRESS_ENABLED=false
 # Public hostname served by bundled Caddy when ingress is enabled.
 ORCHEO_PUBLIC_HOST=
-# Preserve localhost debug ports alongside the selected stack mode.
-ORCHEO_PUBLISH_DEBUG_PORTS=true
+# Preserve localhost access ports alongside the selected stack mode.
+ORCHEO_PUBLISH_LOCAL_PORTS=true
 # Compose profiles activated by `orcheo install`.
-COMPOSE_PROFILES=debug-ports
+COMPOSE_PROFILES=local-access
 # Caddy site address; normally the same as ORCHEO_PUBLIC_HOST.
 ORCHEO_CADDY_SITE_ADDRESS=
 # Space-delimited backend upstreams for `/api/*` and `/ws/*` routing.
@@ -99,12 +99,12 @@ VITE_ORCHEO_AUTH_PROVIDER_GITHUB=github
 VITE_ALLOWED_HOSTS=localhost,127.0.0.1
 
 # -----------------------------------------------------------------------------
-# Optional localhost debug port bindings
+# Optional localhost port bindings
 # -----------------------------------------------------------------------------
-ORCHEO_BACKEND_DEBUG_PORT=8000
-ORCHEO_CANVAS_DEBUG_PORT=5173
-ORCHEO_POSTGRES_DEBUG_PORT=5432
-ORCHEO_REDIS_DEBUG_PORT=6379
+ORCHEO_BACKEND_LOCAL_PORT=8000
+ORCHEO_CANVAS_LOCAL_PORT=5173
+ORCHEO_POSTGRES_LOCAL_PORT=5432
+ORCHEO_REDIS_LOCAL_PORT=6379
 
 # -----------------------------------------------------------------------------
 # Optional stack runtime pin

--- a/deploy/stack/docker-compose.yml
+++ b/deploy/stack/docker-compose.yml
@@ -195,7 +195,7 @@ services:
     depends_on:
       - backend
     healthcheck:
-      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:5173/ || exit 1"]
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:5173/ || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/deploy/stack/docker-compose.yml
+++ b/deploy/stack/docker-compose.yml
@@ -6,7 +6,7 @@ services:
   postgres:
     image: postgres:16-alpine
     ports:
-      - "127.0.0.1:${ORCHEO_POSTGRES_DEBUG_PORT:-5432}:5432"
+      - "127.0.0.1:${ORCHEO_POSTGRES_LOCAL_PORT:-5432}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     environment:
@@ -22,7 +22,7 @@ services:
   redis:
     image: redis:7-alpine
     ports:
-      - "127.0.0.1:${ORCHEO_REDIS_DEBUG_PORT:-6379}:6379"
+      - "127.0.0.1:${ORCHEO_REDIS_LOCAL_PORT:-6379}:6379"
     volumes:
       - redis_data:/data
     command: redis-server --appendonly yes --appendfsync everysec
@@ -81,15 +81,15 @@ services:
       --port 8000
       --proxy-headers
 
-  backend-debug:
+  backend-local:
     image: caddy:2
     profiles:
-      - debug-ports
+      - local-access
     depends_on:
       backend:
         condition: service_healthy
     ports:
-      - "127.0.0.1:${ORCHEO_BACKEND_DEBUG_PORT:-8000}:8000"
+      - "127.0.0.1:${ORCHEO_BACKEND_LOCAL_PORT:-8000}:8000"
     command:
       - caddy
       - reverse-proxy
@@ -201,15 +201,15 @@ services:
       retries: 5
       start_period: 10s
 
-  canvas-debug:
+  canvas-local:
     image: caddy:2
     profiles:
-      - debug-ports
+      - local-access
     depends_on:
       canvas:
         condition: service_healthy
     ports:
-      - "127.0.0.1:${ORCHEO_CANVAS_DEBUG_PORT:-5173}:5173"
+      - "127.0.0.1:${ORCHEO_CANVAS_LOCAL_PORT:-5173}:5173"
     command:
       - caddy
       - reverse-proxy

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -83,8 +83,8 @@ This is the standard public self-hosted recipe for Orcheo on a reachable Linux h
    - `https://orcheo.example.com/api/...` -> backend HTTP routes
    - `wss://orcheo.example.com/ws/...` -> backend WebSocket routes
 4. **Inspect the generated stack config when needed**
-   - `COMPOSE_PROFILES=public-ingress,debug-ports` keeps localhost debug proxies for `8000` and `5173`.
-   - `COMPOSE_PROFILES=public-ingress` disables those localhost debug ports so traffic only goes through Caddy.
+   - `COMPOSE_PROFILES=public-ingress,local-access` keeps localhost access proxies for `8000` and `5173`.
+   - `COMPOSE_PROFILES=public-ingress` disables those localhost access ports so traffic only goes through Caddy.
    - `ORCHEO_CADDY_BACKEND_UPSTREAMS` controls the backend upstream pool for `/api/*` and `/ws/*`.
 5. **Verify the public origin**
    ```bash
@@ -115,19 +115,19 @@ Bundled Caddy is appropriate for standard self-hosted installs and moderate scal
 
 ## Cloudflare Tunnel Or Similar Split-Origin Tunnel
 
-Use this recipe when the host is not directly reachable or when you intentionally keep Canvas and backend on separate public hostnames behind a tunnel. In this topology, bundled Caddy stays off and the stack continues to publish the localhost debug proxies that `cloudflared` forwards to.
+Use this recipe when the host is not directly reachable or when you intentionally keep Canvas and backend on separate public hostnames behind a tunnel. In this topology, bundled Caddy stays off and the stack continues to publish the localhost access proxies that `cloudflared` forwards to.
 
 1. **Install the stack without bundled public ingress**
    ```bash
    orcheo install --start-stack
    ```
-2. **Point your tunnel routes at the local debug proxies**
+2. **Point your tunnel routes at the local access proxies**
    - `https://orcheo.example.com` -> `http://localhost:8000`
    - `https://orcheo-canvas.example.com` -> `http://localhost:5173`
 3. **Set the generated stack env to the split-origin contract**
    ```env
    ORCHEO_PUBLIC_INGRESS_ENABLED=false
-   COMPOSE_PROFILES=debug-ports
+   COMPOSE_PROFILES=local-access
    ORCHEO_API_URL=https://orcheo.example.com
    VITE_ORCHEO_BACKEND_URL=https://orcheo.example.com
    ORCHEO_CORS_ALLOW_ORIGINS=https://orcheo-canvas.example.com
@@ -209,6 +209,6 @@ kubectl apply -k deploy/kubernetes
 - **Scaling**: The FastAPI app is stateless. Scale horizontally by adding replicas while pointing them at the same checkpoint database. With bundled Caddy, keep replica pools limited to one logical deployment that shares Postgres and Redis.
 - **Backups**: Schedule database backups (pg_dump or managed snapshots) to protect workflow history and run states.
 
-Use Cloudflare Tunnel when the host is not directly reachable from the internet, or when you intentionally want tunnel-managed public hostnames in front of the localhost debug proxies. For reachable hosts with direct inbound ports and one shared origin, bundled Caddy is the simpler default.
+Use Cloudflare Tunnel when the host is not directly reachable from the internet, or when you intentionally want tunnel-managed public hostnames in front of the localhost access proxies. For reachable hosts with direct inbound ports and one shared origin, bundled Caddy is the simpler default.
 
 These recipes will evolve as additional milestones introduce credential vaulting, trigger services, and observability pipelines.

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -25,7 +25,7 @@ services read configuration via Dynaconf with the `ORCHEO_` prefix.
 | `ORCHEO_CHATKIT_WIDGET_ACTION_TYPES` | `["submit"]` | Comma/JSON list of action types | Widget action types the ChatKit server will dispatch back to workflows (`chatkit/server.py`). |
 | `ORCHEO_HOST` | `0.0.0.0` | Hostname or IP string | Network interface to bind the FastAPI app (`config/loader.py`). |
 | `ORCHEO_PORT` | `8000` | Integer (1‑65535) | TCP port exposed by the FastAPI service (`config/loader.py`). |
-| `ORCHEO_CORS_ALLOW_ORIGINS` | `["http://localhost:5173","http://127.0.0.1:5173"]` | JSON array or comma-separated list of origins | CORS allow-list used when constructing the FastAPI middleware (`factory.py`). `orcheo install --public-ingress` sets this to the shared public HTTPS origin and keeps localhost origins when debug ports remain enabled. Tunnel or split-origin installs should set this to the public Canvas/browser origin instead of the backend API origin. |
+| `ORCHEO_CORS_ALLOW_ORIGINS` | `["http://localhost:5173","http://127.0.0.1:5173"]` | JSON array or comma-separated list of origins | CORS allow-list used when constructing the FastAPI middleware (`factory.py`). `orcheo install --public-ingress` sets this to the shared public HTTPS origin and keeps localhost origins when local access ports remain enabled. Tunnel or split-origin installs should set this to the public Canvas/browser origin instead of the backend API origin. |
 | `ORCHEO_UPDATE_CHECK_TIMEOUT_SECONDS` | `3.0` | Float > 0 | Timeout for backend package registry lookups used by `/api/system/info` (`app/versioning.py`). |
 | `ORCHEO_UPDATE_CHECK_RETRIES` | `1` | Integer ≥ 0 | Retry count for backend package registry lookups used by `/api/system/info` (`app/versioning.py`). |
 | `ORCHEO_CANVAS_VERSION` | _none_ | Version string (for example `0.8.1`) | Optional current Canvas version reported by `/api/system/info` to compare with npm latest (`app/versioning.py`). |
@@ -160,19 +160,19 @@ Note: `ORCHEO_REPOSITORY_BACKEND=inmemory` stores runs in-process only and does 
 | `ORCHEO_POSTGRES_PASSWORD` | _auto-generated on install_ | Non-empty string | PostgreSQL password written to stack `.env` by `orcheo install` and consumed by `deploy/stack/docker-compose.yml` to configure the Postgres service and backend DSN. |
 | `ORCHEO_STACK_ASSET_BASE_URL` | _unset_ | HTTP(S) URL | Optional custom mirror base URL for per-file stack asset downloads. When set, `orcheo install` skips GitHub tag discovery and downloads stack assets from this mirror (`cli/setup.py`). |
 | `ORCHEO_SETUP_HEALTH_POLL_TIMEOUT_SECONDS` | `60` | Integer ≥ 0 | Timeout window used by `orcheo install` when waiting for `docker compose` backend health checks (`cli/setup.py`). |
-| `ORCHEO_PUBLIC_INGRESS_ENABLED` | `false` | Boolean (`1/0`, `true/false`, `yes/no`, `on/off`) | Enables the bundled Caddy ingress profile written by `orcheo install`. When false, the stack stays in the localhost-friendly debug-port profile. |
+| `ORCHEO_PUBLIC_INGRESS_ENABLED` | `false` | Boolean (`1/0`, `true/false`, `yes/no`, `on/off`) | Enables the bundled Caddy ingress profile written by `orcheo install`. When false, the stack stays in the localhost-friendly local-access profile. |
 | `ORCHEO_PUBLIC_HOST` | _unset_ | Hostname | Public hostname served by bundled Caddy. Required when `ORCHEO_PUBLIC_INGRESS_ENABLED=true`. |
-| `ORCHEO_PUBLISH_DEBUG_PORTS` | `true` | Boolean (`1/0`, `true/false`, `yes/no`, `on/off`) | Keeps localhost backend and Canvas debug proxies published while using the selected stack mode. In public-ingress mode, setting this to false leaves Caddy as the only browser entrypoint. |
-| `COMPOSE_PROFILES` | `debug-ports` | Comma-separated Docker Compose profile names | Profiles activated by `orcheo install` and `orcheo stack`. Typical values are `debug-ports`, `public-ingress`, or `public-ingress,debug-ports`. |
+| `ORCHEO_PUBLISH_LOCAL_PORTS` | `true` | Boolean (`1/0`, `true/false`, `yes/no`, `on/off`) | Keeps localhost backend and Canvas access proxies published while using the selected stack mode. In public-ingress mode, setting this to false leaves Caddy as the only browser entrypoint. |
+| `COMPOSE_PROFILES` | `local-access` | Comma-separated Docker Compose profile names | Profiles activated by `orcheo install` and `orcheo stack`. Typical values are `local-access`, `public-ingress`, or `public-ingress,local-access`. |
 | `ORCHEO_CADDY_SITE_ADDRESS` | _unset_ | Hostname or Caddy site address | Site address consumed by `deploy/stack/Caddyfile`. Usually the same value as `ORCHEO_PUBLIC_HOST`. |
 | `ORCHEO_CADDY_BACKEND_UPSTREAMS` | `backend:8000` | Space-delimited `host:port` upstream list | Backend upstream pool used by bundled Caddy for `/api/*` and `/ws/*`. Multiple entries are for replicas of the same logical deployment only. |
 | `ORCHEO_CADDY_CANVAS_UPSTREAM` | `canvas:5173` | `host:port` | Internal Canvas upstream used by bundled Caddy for `/` and SPA routes. |
 | `ORCHEO_CADDY_HTTP_BIND` | `0.0.0.0` | IP string | Host bind address for Caddy's public port `80` in `deploy/stack/docker-compose.yml`. |
 | `ORCHEO_CADDY_HTTPS_BIND` | `0.0.0.0` | IP string | Host bind address for Caddy's public port `443` in `deploy/stack/docker-compose.yml`. |
-| `ORCHEO_BACKEND_DEBUG_PORT` | `8000` | Integer (1‑65535) | Localhost port published by the `backend-debug` proxy profile. |
-| `ORCHEO_CANVAS_DEBUG_PORT` | `5173` | Integer (1‑65535) | Localhost port published by the `canvas-debug` proxy profile. |
-| `ORCHEO_POSTGRES_DEBUG_PORT` | `5432` | Integer (1‑65535) | Localhost port bound for the bundled Postgres service in the stack compose file. |
-| `ORCHEO_REDIS_DEBUG_PORT` | `6379` | Integer (1‑65535) | Localhost port bound for the bundled Redis service in the stack compose file. |
+| `ORCHEO_BACKEND_LOCAL_PORT` | `8000` | Integer (1‑65535) | Localhost port published by the `backend-local` access proxy profile. |
+| `ORCHEO_CANVAS_LOCAL_PORT` | `5173` | Integer (1‑65535) | Localhost port published by the `canvas-local` access proxy profile. |
+| `ORCHEO_POSTGRES_LOCAL_PORT` | `5432` | Integer (1‑65535) | Localhost port bound for the bundled Postgres service in the stack compose file. |
+| `ORCHEO_REDIS_LOCAL_PORT` | `6379` | Integer (1‑65535) | Localhost port bound for the bundled Redis service in the stack compose file. |
 | `ORCHEO_AUTH_ISSUER` | _none_ | OIDC issuer URL | OAuth issuer URL for CLI browser-based login. Can also be set in a `cli.toml` profile via `auth_issuer` (`cli/auth/config.py`). |
 | `ORCHEO_AUTH_CLIENT_ID` | _none_ | String | OAuth client ID for CLI login. Can also be set in a `cli.toml` profile via `auth_client_id` (`cli/auth/config.py`). |
 | `ORCHEO_AUTH_SCOPES` | `openid profile email` | Space-delimited scopes | OAuth scopes requested during CLI login. Can also be set in a `cli.toml` profile via `auth_scopes` (`cli/auth/config.py`). |

--- a/docs/manual_setup.md
+++ b/docs/manual_setup.md
@@ -61,7 +61,7 @@ Use this path on a reachable self-hosted Linux host, such as a cloud VM or an on
 - `ORCHEO_API_URL=https://<host>`
 - `VITE_ORCHEO_BACKEND_URL=https://<host>`
 - `ORCHEO_CHATKIT_PUBLIC_BASE_URL=https://<host>`
-- `ORCHEO_CORS_ALLOW_ORIGINS=https://<host>` plus localhost origins when debug ports stay enabled
+- `ORCHEO_CORS_ALLOW_ORIGINS=https://<host>` plus localhost origins when local access ports stay enabled
 - `VITE_ALLOWED_HOSTS=localhost,127.0.0.1,<host>`
 
 Bundled Caddy is the recommended ingress for reachable self-hosted installs. It is not a replacement for Cloudflare Tunnel when inbound ports are unavailable.
@@ -94,11 +94,11 @@ For local development without OAuth, set `ORCHEO_AUTH_MODE=optional` in your `.e
 
 Keep Cloudflare Tunnel or a similar tunnel product for cases where the Orcheo host is not directly reachable from the internet, especially localhost development, callback testing from laptops, and NAT-restricted environments. Bundled Caddy expects direct inbound `80/443` access instead.
 
-When using Cloudflare Tunnel with separate browser and API hostnames, keep bundled public ingress disabled and preserve the debug-port profile:
+When using Cloudflare Tunnel with separate browser and API hostnames, keep bundled public ingress disabled and preserve the local-access profile:
 
 ```env
 ORCHEO_PUBLIC_INGRESS_ENABLED=false
-COMPOSE_PROFILES=debug-ports
+COMPOSE_PROFILES=local-access
 ORCHEO_API_URL=https://orcheo.example.com
 VITE_ORCHEO_BACKEND_URL=https://orcheo.example.com
 ORCHEO_CORS_ALLOW_ORIGINS=https://orcheo-canvas.example.com

--- a/packages/sdk/src/orcheo_sdk/cli/main.py
+++ b/packages/sdk/src/orcheo_sdk/cli/main.py
@@ -232,7 +232,7 @@ def _run_install_flow(
     chatkit_domain_key: str | None,
     public_ingress: bool | None,
     public_host: str | None,
-    publish_debug_ports: bool | None,
+    publish_local_ports: bool | None,
     start_stack: bool | None,
     install_docker: bool | None,
     install_orcheo_skill: bool | None,
@@ -250,7 +250,7 @@ def _run_install_flow(
         chatkit_domain_key=chatkit_domain_key,
         public_ingress=public_ingress,
         public_host=public_host,
-        publish_debug_ports=publish_debug_ports,
+        publish_local_ports=publish_local_ports,
         start_stack=start_stack,
         install_docker=install_docker,
         install_orcheo_skill=install_orcheo_skill,
@@ -389,12 +389,12 @@ def install_command(
             help="Public hostname served by bundled Caddy in public-ingress mode.",
         ),
     ] = None,
-    publish_debug_ports: Annotated[
+    publish_local_ports: Annotated[
         bool | None,
         typer.Option(
-            "--publish-debug-ports/--hide-debug-ports",
+            "--publish-local-ports/--hide-local-ports",
             help=(
-                "Keep localhost backend/canvas debug ports published alongside the "
+                "Keep localhost backend/canvas access ports published alongside the "
                 "selected install mode."
             ),
         ),
@@ -445,7 +445,7 @@ def install_command(
         chatkit_domain_key=chatkit_domain_key,
         public_ingress=public_ingress,
         public_host=public_host,
-        publish_debug_ports=publish_debug_ports,
+        publish_local_ports=publish_local_ports,
         start_stack=start_stack,
         install_docker=install_docker,
         install_orcheo_skill=install_orcheo_skill,
@@ -508,12 +508,12 @@ def install_upgrade_command(
             help="Public hostname served by bundled Caddy in public-ingress mode.",
         ),
     ] = None,
-    publish_debug_ports: Annotated[
+    publish_local_ports: Annotated[
         bool | None,
         typer.Option(
-            "--publish-debug-ports/--hide-debug-ports",
+            "--publish-local-ports/--hide-local-ports",
             help=(
-                "Keep localhost backend/canvas debug ports published alongside the "
+                "Keep localhost backend/canvas access ports published alongside the "
                 "selected install mode."
             ),
         ),
@@ -562,7 +562,7 @@ def install_upgrade_command(
         chatkit_domain_key=chatkit_domain_key,
         public_ingress=public_ingress,
         public_host=public_host,
-        publish_debug_ports=publish_debug_ports,
+        publish_local_ports=publish_local_ports,
         start_stack=start_stack,
         install_docker=install_docker,
         install_orcheo_skill=install_orcheo_skill,

--- a/packages/sdk/src/orcheo_sdk/cli/setup.py
+++ b/packages/sdk/src/orcheo_sdk/cli/setup.py
@@ -66,7 +66,7 @@ class SetupConfig:
     chatkit_domain_key: str | None
     public_ingress_enabled: bool
     public_host: str | None
-    publish_debug_ports: bool
+    publish_local_ports: bool
     backend_upstreams: str
     canvas_upstream: str
     start_stack: bool
@@ -644,19 +644,19 @@ def _resolve_public_host(
     return _normalize_public_host(typer.prompt("Public hostname"))
 
 
-def _resolve_publish_debug_ports(
-    publish_debug_ports: bool | None,
+def _resolve_publish_local_ports(
+    publish_local_ports: bool | None,
     *,
     public_ingress_enabled: bool,
     yes: bool,
     env_file: Path,
     env_exists: bool,
 ) -> bool:
-    if publish_debug_ports is not None:
-        return publish_debug_ports
+    if publish_local_ports is not None:
+        return publish_local_ports
     if env_exists:
         existing = _parse_bool_value(
-            _read_env_value(env_file, "ORCHEO_PUBLISH_DEBUG_PORTS")
+            _read_env_value(env_file, "ORCHEO_PUBLISH_LOCAL_PORTS")
         )
         if existing is not None:
             return existing
@@ -665,7 +665,7 @@ def _resolve_publish_debug_ports(
     if yes:
         return True
     return typer.confirm(
-        "Keep localhost debug ports for backend and Canvas published?",
+        "Keep localhost backend and Canvas ports published?",
         default=True,
     )
 
@@ -674,7 +674,7 @@ def _resolve_public_ingress_config(
     *,
     public_ingress: bool | None,
     public_host: str | None,
-    publish_debug_ports: bool | None,
+    publish_local_ports: bool | None,
     yes: bool,
     env_file: Path,
     env_exists: bool,
@@ -692,8 +692,8 @@ def _resolve_public_ingress_config(
         env_file=env_file,
         env_exists=env_exists,
     )
-    resolved_publish_debug_ports = _resolve_publish_debug_ports(
-        publish_debug_ports,
+    resolved_publish_local_ports = _resolve_publish_local_ports(
+        publish_local_ports,
         public_ingress_enabled=resolved_public_ingress_enabled,
         yes=yes,
         env_file=env_file,
@@ -702,7 +702,7 @@ def _resolve_public_ingress_config(
     return (
         resolved_public_ingress_enabled,
         resolved_public_host,
-        resolved_publish_debug_ports,
+        resolved_publish_local_ports,
     )
 
 
@@ -764,7 +764,7 @@ def _print_setup_resolution_notes(
     preserve_existing_backend_url: bool,
     resolved_public_ingress_enabled: bool,
     resolved_public_host: str | None,
-    resolved_publish_debug_ports: bool,
+    resolved_publish_local_ports: bool,
 ) -> None:
     if resolved_api_key and not manual_secrets and not yes:
         console.print("[green]Generated API key locally.[/green]")
@@ -784,9 +784,9 @@ def _print_setup_resolution_notes(
             f"{resolved_public_host}. Caddy expects DNS for that hostname and "
             "inbound 80/443 to reach this host.[/cyan]"
         )
-        if not resolved_publish_debug_ports:
+        if not resolved_publish_local_ports:
             console.print(
-                "[cyan]Local backend/canvas debug ports will stay disabled; "
+                "[cyan]Local backend/canvas ports will stay disabled; "
                 "access should go through the public hostname only.[/cyan]"
             )
     if resolved_auth_mode == "oauth":
@@ -1093,8 +1093,8 @@ def _compose_profiles(config: SetupConfig) -> str:
     profiles: list[str] = []
     if config.public_ingress_enabled:
         profiles.append("public-ingress")
-    if config.publish_debug_ports:
-        profiles.append("debug-ports")
+    if config.publish_local_ports:
+        profiles.append("local-access")
     return ",".join(profiles)
 
 
@@ -1102,7 +1102,7 @@ def _build_cors_origins(config: SetupConfig) -> str:
     origins: list[str] = []
     if config.public_ingress_enabled and config.public_host is not None:
         origins.append(f"https://{config.public_host}")
-    if not config.public_ingress_enabled or config.publish_debug_ports:
+    if not config.public_ingress_enabled or config.publish_local_ports:
         origins.extend(
             [
                 "http://localhost:5173",
@@ -1128,7 +1128,7 @@ def _build_chatkit_public_base_url(config: SetupConfig) -> str:
 
 def _build_healthcheck_url(config: SetupConfig) -> str | None:
     if config.public_ingress_enabled:
-        if config.publish_debug_ports:
+        if config.publish_local_ports:
             return "http://localhost:8000"
         return None
     return config.backend_url
@@ -1152,7 +1152,7 @@ def _build_env_updates(
         "VITE_ALLOWED_HOSTS": _build_allowed_hosts(config),
         "ORCHEO_PUBLIC_INGRESS_ENABLED": str(config.public_ingress_enabled).lower(),
         "ORCHEO_PUBLIC_HOST": config.public_host or "",
-        "ORCHEO_PUBLISH_DEBUG_PORTS": str(config.publish_debug_ports).lower(),
+        "ORCHEO_PUBLISH_LOCAL_PORTS": str(config.publish_local_ports).lower(),
         "COMPOSE_PROFILES": _compose_profiles(config),
         "ORCHEO_CADDY_SITE_ADDRESS": config.public_host or "",
         "ORCHEO_CADDY_BACKEND_UPSTREAMS": config.backend_upstreams,
@@ -1337,7 +1337,7 @@ def run_setup(
     chatkit_domain_key: str | None,
     public_ingress: bool | None,
     public_host: str | None,
-    publish_debug_ports: bool | None,
+    publish_local_ports: bool | None,
     start_stack: bool | None,
     install_docker: bool | None,
     install_orcheo_skill: bool | None,
@@ -1359,11 +1359,11 @@ def run_setup(
     (
         resolved_public_ingress_enabled,
         resolved_public_host,
-        resolved_publish_debug_ports,
+        resolved_publish_local_ports,
     ) = _resolve_public_ingress_config(
         public_ingress=public_ingress,
         public_host=public_host,
-        publish_debug_ports=publish_debug_ports,
+        publish_local_ports=publish_local_ports,
         yes=yes,
         env_file=stack_env_file,
         env_exists=has_existing_stack_env,
@@ -1422,7 +1422,7 @@ def run_setup(
         preserve_existing_backend_url=preserve_existing_backend_url,
         resolved_public_ingress_enabled=resolved_public_ingress_enabled,
         resolved_public_host=resolved_public_host,
-        resolved_publish_debug_ports=resolved_publish_debug_ports,
+        resolved_publish_local_ports=resolved_publish_local_ports,
     )
 
     return SetupConfig(
@@ -1433,7 +1433,7 @@ def run_setup(
         chatkit_domain_key=resolved_chatkit_domain_key,
         public_ingress_enabled=resolved_public_ingress_enabled,
         public_host=resolved_public_host,
-        publish_debug_ports=resolved_publish_debug_ports,
+        publish_local_ports=resolved_publish_local_ports,
         backend_upstreams=resolved_backend_upstreams,
         canvas_upstream=resolved_canvas_upstream,
         start_stack=resolved_start_stack,
@@ -1574,7 +1574,7 @@ def _report_stack_health(
     if healthcheck_url is None:
         console.print(
             "[yellow]Skipped backend health polling because public ingress is "
-            "enabled without localhost debug ports. After DNS points "
+            "enabled without localhost access ports. After DNS points "
             f"{config.public_host} at this host and inbound 80/443 are open, "
             f"verify https://{config.public_host} manually.[/yellow]"
         )
@@ -1654,7 +1654,7 @@ def print_summary(config: SetupConfig, *, console: Console) -> None:
         "auth_mode": config.auth_mode,
         "public_ingress_enabled": config.public_ingress_enabled,
         "public_host": config.public_host,
-        "publish_debug_ports": config.publish_debug_ports,
+        "publish_local_ports": config.publish_local_ports,
         "backend_upstreams": config.backend_upstreams,
         "stack_assets_synced": True,
         "stack_started": config.start_stack,

--- a/src/orcheo/nodes/rss.py
+++ b/src/orcheo/nodes/rss.py
@@ -7,10 +7,19 @@ from typing import Any
 from xml.etree import ElementTree
 import httpx
 from langchain_core.runnables import RunnableConfig
-from pydantic import Field
+from pydantic import Field, field_validator
 from orcheo.graph.state import State
 from orcheo.nodes.base import TaskNode
 from orcheo.nodes.registry import NodeMetadata, registry
+
+
+RSS_REQUEST_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (compatible; OrcheoRSS/1.0; +https://orcheo.ai)",
+    "Accept": (
+        "application/rss+xml, application/atom+xml, application/xml, "
+        "text/xml;q=0.9, */*;q=0.8"
+    ),
+}
 
 
 @registry.register(
@@ -28,12 +37,20 @@ class RSSNode(TaskNode):
     without aborting the remaining feeds.
     """
 
-    sources: list[str] | str = Field(description="RSS/Atom feed URLs to fetch")
+    sources: list[str] = Field(description="RSS/Atom feed URLs to fetch")
     timeout: float = Field(
         default=15.0,
-        ge=0.0,
+        gt=0.0,
         description="HTTP timeout in seconds per feed",
     )
+
+    @field_validator("sources", mode="before")
+    @classmethod
+    def _normalize_sources(cls, value: list[str] | str) -> list[str]:
+        """Normalize a single feed URL into a list of sources."""
+        if isinstance(value, str):
+            return [value]
+        return value
 
     # ------------------------------------------------------------------
     # XML helpers
@@ -187,7 +204,10 @@ class RSSNode(TaskNode):
         documents: list[dict[str, Any]] = []
         errors: list[dict[str, str]] = []
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            headers=RSS_REQUEST_HEADERS,
+        ) as client:
             for url in self.sources:
                 docs, error = await self._fetch_source(client, url, now_iso)
                 documents.extend(docs)

--- a/src/orcheo/nodes/rss.py
+++ b/src/orcheo/nodes/rss.py
@@ -13,6 +13,15 @@ from orcheo.nodes.base import TaskNode
 from orcheo.nodes.registry import NodeMetadata, registry
 
 
+RSS_REQUEST_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (compatible; OrcheoRSS/1.0; +https://orcheo.ai)",
+    "Accept": (
+        "application/rss+xml, application/atom+xml, application/xml, "
+        "text/xml;q=0.9, */*;q=0.8"
+    ),
+}
+
+
 @registry.register(
     NodeMetadata(
         name="RSSNode",
@@ -187,7 +196,10 @@ class RSSNode(TaskNode):
         documents: list[dict[str, Any]] = []
         errors: list[dict[str, str]] = []
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            headers=RSS_REQUEST_HEADERS,
+        ) as client:
             for url in self.sources:
                 docs, error = await self._fetch_source(client, url, now_iso)
                 documents.extend(docs)

--- a/src/orcheo/nodes/rss.py
+++ b/src/orcheo/nodes/rss.py
@@ -7,7 +7,7 @@ from typing import Any
 from xml.etree import ElementTree
 import httpx
 from langchain_core.runnables import RunnableConfig
-from pydantic import Field
+from pydantic import Field, field_validator
 from orcheo.graph.state import State
 from orcheo.nodes.base import TaskNode
 from orcheo.nodes.registry import NodeMetadata, registry
@@ -37,12 +37,20 @@ class RSSNode(TaskNode):
     without aborting the remaining feeds.
     """
 
-    sources: list[str] | str = Field(description="RSS/Atom feed URLs to fetch")
+    sources: list[str] = Field(description="RSS/Atom feed URLs to fetch")
     timeout: float = Field(
         default=15.0,
-        ge=0.0,
+        gt=0.0,
         description="HTTP timeout in seconds per feed",
     )
+
+    @field_validator("sources", mode="before")
+    @classmethod
+    def _normalize_sources(cls, value: list[str] | str) -> list[str]:
+        """Normalize a single feed URL into a list of sources."""
+        if isinstance(value, str):
+            return [value]
+        return value
 
     # ------------------------------------------------------------------
     # XML helpers

--- a/src/orcheo/nodes/slack.py
+++ b/src/orcheo/nodes/slack.py
@@ -20,11 +20,11 @@ from orcheo.nodes.registry import NodeMetadata, registry
 
 
 _DEFAULT_STDIO_LOG_PATH = Path("/tmp/orcheo-mcp-stdio.log")
-_STDIO_STREAM_TARGETS: dict[str, TextIO] = {
-    "/dev/stderr": sys.stderr,
-    "/proc/self/fd/2": sys.stderr,
-    "/dev/stdout": sys.stdout,
-    "/proc/self/fd/1": sys.stdout,
+_STDIO_STREAM_TARGETS: dict[str, str] = {
+    "/dev/stderr": "stderr",
+    "/proc/self/fd/2": "stderr",
+    "/dev/stdout": "stdout",
+    "/proc/self/fd/1": "stdout",
 }
 
 
@@ -36,8 +36,9 @@ def _resolve_stdio_log_target(log_path: str | None) -> Path | TextIO:
     normalized = log_path.strip()
     if not normalized:
         return _DEFAULT_STDIO_LOG_PATH
-    if normalized in _STDIO_STREAM_TARGETS:
-        return _STDIO_STREAM_TARGETS[normalized]
+    stream_name = _STDIO_STREAM_TARGETS.get(normalized)
+    if stream_name is not None:
+        return getattr(sys, stream_name)
     return Path(normalized)
 
 

--- a/src/orcheo/nodes/slack.py
+++ b/src/orcheo/nodes/slack.py
@@ -4,11 +4,12 @@ import hashlib
 import hmac
 import json
 import os
+import sys
 import time
 from collections.abc import Mapping
 from dataclasses import asdict
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, TextIO
 from fastmcp import Client
 from fastmcp.client.transports import NpxStdioTransport
 from langchain_core.runnables import RunnableConfig
@@ -16,6 +17,28 @@ from pydantic import BaseModel, Field, field_validator
 from orcheo.graph.state import State
 from orcheo.nodes.base import TaskNode
 from orcheo.nodes.registry import NodeMetadata, registry
+
+
+_DEFAULT_STDIO_LOG_PATH = Path("/tmp/orcheo-mcp-stdio.log")
+_STDIO_STREAM_TARGETS: dict[str, TextIO] = {
+    "/dev/stderr": sys.stderr,
+    "/proc/self/fd/2": sys.stderr,
+    "/dev/stdout": sys.stdout,
+    "/proc/self/fd/1": sys.stdout,
+}
+
+
+def _resolve_stdio_log_target(log_path: str | None) -> Path | TextIO:
+    """Map configured stdio log destinations to a writable transport target."""
+    if log_path is None:
+        return _DEFAULT_STDIO_LOG_PATH
+
+    normalized = log_path.strip()
+    if not normalized:
+        return _DEFAULT_STDIO_LOG_PATH
+    if normalized in _STDIO_STREAM_TARGETS:
+        return _STDIO_STREAM_TARGETS[normalized]
+    return Path(normalized)
 
 
 @registry.register(
@@ -69,8 +92,9 @@ class SlackNode(TaskNode):
             env_vars=env_vars,
         )
         if getattr(transport, "log_file", None) is None:
-            log_path = os.getenv("ORCHEO_MCP_STDIO_LOG", "/tmp/orcheo-mcp-stdio.log")
-            transport.log_file = Path(log_path)
+            transport.log_file = _resolve_stdio_log_target(
+                os.getenv("ORCHEO_MCP_STDIO_LOG")
+            )
         async with Client(transport) as client:
             result = await client.call_tool(self.tool_name, self.kwargs)
 

--- a/tests/nodes/test_rss.py
+++ b/tests/nodes/test_rss.py
@@ -5,6 +5,7 @@ from xml.etree import ElementTree
 import httpx
 import pytest
 from langchain_core.runnables import RunnableConfig
+from pydantic import ValidationError
 from orcheo.nodes.rss import RSS_REQUEST_HEADERS, RSSNode
 
 
@@ -51,6 +52,36 @@ async def test_rss_node_run():
     assert mock_client.get.call_count == 2
     mock_client.get.assert_any_call("https://example.com/feed1.xml", timeout=15.0)
     mock_client.get.assert_any_call("https://example.com/feed2.xml", timeout=15.0)
+
+
+@pytest.mark.asyncio
+async def test_rss_node_normalizes_single_source_string() -> None:
+    """Single source strings should be normalized into a one-item list."""
+    node = RSSNode(name="test_rss", sources="https://example.com/feed.xml")
+
+    mock_resp = Mock()
+    mock_resp.text = "<rss><channel></channel></rss>"
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_resp
+
+    with patch("orcheo.nodes.rss.httpx.AsyncClient") as mock_cls:
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await node.run({}, RunnableConfig())
+
+    assert node.sources == ["https://example.com/feed.xml"]
+    assert result["failed_sources"] == 0
+    mock_client.get.assert_called_once_with(
+        "https://example.com/feed.xml", timeout=15.0
+    )
+
+
+def test_rss_node_rejects_non_positive_timeout() -> None:
+    """Timeouts must be strictly positive."""
+    with pytest.raises(ValidationError, match="greater than 0"):
+        RSSNode(name="test_rss", sources=["https://example.com/feed.xml"], timeout=0.0)
 
 
 @pytest.mark.asyncio

--- a/tests/nodes/test_rss.py
+++ b/tests/nodes/test_rss.py
@@ -5,7 +5,8 @@ from xml.etree import ElementTree
 import httpx
 import pytest
 from langchain_core.runnables import RunnableConfig
-from orcheo.nodes.rss import RSSNode
+from pydantic import ValidationError
+from orcheo.nodes.rss import RSS_REQUEST_HEADERS, RSSNode
 
 
 @pytest.mark.asyncio
@@ -51,6 +52,36 @@ async def test_rss_node_run():
     assert mock_client.get.call_count == 2
     mock_client.get.assert_any_call("https://example.com/feed1.xml", timeout=15.0)
     mock_client.get.assert_any_call("https://example.com/feed2.xml", timeout=15.0)
+
+
+@pytest.mark.asyncio
+async def test_rss_node_normalizes_single_source_string() -> None:
+    """Single source strings should be normalized into a one-item list."""
+    node = RSSNode(name="test_rss", sources="https://example.com/feed.xml")
+
+    mock_resp = Mock()
+    mock_resp.text = "<rss><channel></channel></rss>"
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_resp
+
+    with patch("orcheo.nodes.rss.httpx.AsyncClient") as mock_cls:
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await node.run({}, RunnableConfig())
+
+    assert node.sources == ["https://example.com/feed.xml"]
+    assert result["failed_sources"] == 0
+    mock_client.get.assert_called_once_with(
+        "https://example.com/feed.xml", timeout=15.0
+    )
+
+
+def test_rss_node_rejects_non_positive_timeout() -> None:
+    """Timeouts must be strictly positive."""
+    with pytest.raises(ValidationError, match="greater than 0"):
+        RSSNode(name="test_rss", sources=["https://example.com/feed.xml"], timeout=0.0)
 
 
 @pytest.mark.asyncio
@@ -202,6 +233,32 @@ async def test_rss_node_run_non_2xx_response_is_reported_as_error():
     assert result["errors"][0]["source"] == "https://example.com/protected.xml"
     mock_client.get.assert_called_once_with(
         "https://example.com/protected.xml", timeout=15.0
+    )
+
+
+@pytest.mark.asyncio
+async def test_rss_node_configures_http_client_for_redirects_and_feed_headers():
+    """RSS client should follow redirects and advertise feed-friendly headers."""
+    sources = ["https://example.com/feed.xml"]
+    node = RSSNode(name="test_rss", sources=sources)
+    state = {}
+    config = RunnableConfig()
+
+    mock_resp = Mock()
+    mock_resp.text = "<rss><channel></channel></rss>"
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_resp
+
+    with patch("orcheo.nodes.rss.httpx.AsyncClient") as mock_cls:
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await node.run(state, config)
+
+    mock_cls.assert_called_once_with(
+        follow_redirects=True,
+        headers=RSS_REQUEST_HEADERS,
     )
 
 

--- a/tests/nodes/test_rss.py
+++ b/tests/nodes/test_rss.py
@@ -5,7 +5,7 @@ from xml.etree import ElementTree
 import httpx
 import pytest
 from langchain_core.runnables import RunnableConfig
-from orcheo.nodes.rss import RSSNode
+from orcheo.nodes.rss import RSS_REQUEST_HEADERS, RSSNode
 
 
 @pytest.mark.asyncio
@@ -202,6 +202,32 @@ async def test_rss_node_run_non_2xx_response_is_reported_as_error():
     assert result["errors"][0]["source"] == "https://example.com/protected.xml"
     mock_client.get.assert_called_once_with(
         "https://example.com/protected.xml", timeout=15.0
+    )
+
+
+@pytest.mark.asyncio
+async def test_rss_node_configures_http_client_for_redirects_and_feed_headers():
+    """RSS client should follow redirects and advertise feed-friendly headers."""
+    sources = ["https://example.com/feed.xml"]
+    node = RSSNode(name="test_rss", sources=sources)
+    state = {}
+    config = RunnableConfig()
+
+    mock_resp = Mock()
+    mock_resp.text = "<rss><channel></channel></rss>"
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_resp
+
+    with patch("orcheo.nodes.rss.httpx.AsyncClient") as mock_cls:
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await node.run(state, config)
+
+    mock_cls.assert_called_once_with(
+        follow_redirects=True,
+        headers=RSS_REQUEST_HEADERS,
     )
 
 

--- a/tests/nodes/test_slack.py
+++ b/tests/nodes/test_slack.py
@@ -272,6 +272,30 @@ async def test_slack_node_respects_stdio_log_env(monkeypatch, slack_node):
 
 
 @pytest.mark.asyncio
+async def test_slack_node_uses_default_log_path_for_blank_stdio_log_env(
+    monkeypatch, slack_node
+):
+    monkeypatch.setenv("ORCHEO_MCP_STDIO_LOG", "   ")
+
+    mock_result = MockToolResult(content=[{"text": "Logged"}], is_error=False)
+
+    mock_client = AsyncMock()
+    mock_client.call_tool = AsyncMock(return_value=mock_result)
+
+    mock_context_manager = AsyncMock()
+    mock_context_manager.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_context_manager.__aexit__ = AsyncMock(return_value=None)
+
+    transport = DummyTransport()
+
+    with patch("orcheo.nodes.slack.NpxStdioTransport", return_value=transport):
+        with patch("orcheo.nodes.slack.Client", return_value=mock_context_manager):
+            await slack_node.run({}, None)
+
+    assert transport.log_file == _DEFAULT_STDIO_LOG_PATH
+
+
+@pytest.mark.asyncio
 async def test_slack_node_uses_stderr_stream_for_special_log_device(
     monkeypatch, slack_node
 ):

--- a/tests/nodes/test_slack.py
+++ b/tests/nodes/test_slack.py
@@ -1,5 +1,6 @@
 """Tests for Slack node."""
 
+import io
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -292,3 +293,30 @@ async def test_slack_node_uses_stderr_stream_for_special_log_device(
             await slack_node.run({}, None)
 
     assert transport.log_file is sys.stderr
+
+
+@pytest.mark.asyncio
+async def test_slack_node_resolves_stream_device_against_current_sys_streams(
+    monkeypatch, slack_node
+):
+    monkeypatch.setenv("ORCHEO_MCP_STDIO_LOG", "/dev/stderr")
+
+    replacement_stderr = io.StringIO()
+    monkeypatch.setattr(sys, "stderr", replacement_stderr)
+
+    mock_result = MockToolResult(content=[{"text": "Logged"}], is_error=False)
+
+    mock_client = AsyncMock()
+    mock_client.call_tool = AsyncMock(return_value=mock_result)
+
+    mock_context_manager = AsyncMock()
+    mock_context_manager.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_context_manager.__aexit__ = AsyncMock(return_value=None)
+
+    transport = DummyTransport()
+
+    with patch("orcheo.nodes.slack.NpxStdioTransport", return_value=transport):
+        with patch("orcheo.nodes.slack.Client", return_value=mock_context_manager):
+            await slack_node.run({}, None)
+
+    assert transport.log_file is replacement_stderr

--- a/tests/nodes/test_slack.py
+++ b/tests/nodes/test_slack.py
@@ -1,11 +1,12 @@
 """Tests for Slack node."""
 
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
-from orcheo.nodes.slack import SlackNode
+from orcheo.nodes.slack import _DEFAULT_STDIO_LOG_PATH, SlackNode
 
 
 @dataclass
@@ -243,7 +244,7 @@ async def test_slack_node_sets_log_file_when_missing(slack_node):
             mock_transport_class.assert_called_once()
             mock_client_class.assert_called_once_with(transport)
 
-    assert transport.log_file == Path("/tmp/orcheo-mcp-stdio.log")
+    assert transport.log_file == _DEFAULT_STDIO_LOG_PATH
 
 
 @pytest.mark.asyncio
@@ -267,3 +268,27 @@ async def test_slack_node_respects_stdio_log_env(monkeypatch, slack_node):
             await slack_node.run({}, None)
 
     assert transport.log_file == Path(custom_path)
+
+
+@pytest.mark.asyncio
+async def test_slack_node_uses_stderr_stream_for_special_log_device(
+    monkeypatch, slack_node
+):
+    monkeypatch.setenv("ORCHEO_MCP_STDIO_LOG", "/dev/stderr")
+
+    mock_result = MockToolResult(content=[{"text": "Logged"}], is_error=False)
+
+    mock_client = AsyncMock()
+    mock_client.call_tool = AsyncMock(return_value=mock_result)
+
+    mock_context_manager = AsyncMock()
+    mock_context_manager.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_context_manager.__aexit__ = AsyncMock(return_value=None)
+
+    transport = DummyTransport()
+
+    with patch("orcheo.nodes.slack.NpxStdioTransport", return_value=transport):
+        with patch("orcheo.nodes.slack.Client", return_value=mock_context_manager):
+            await slack_node.run({}, None)
+
+    assert transport.log_file is sys.stderr

--- a/tests/sdk/test_cli_main.py
+++ b/tests/sdk/test_cli_main.py
@@ -411,7 +411,7 @@ def test_run_install_flow_forced_mode(monkeypatch: pytest.MonkeyPatch) -> None:
         chatkit_domain_key=None,
         public_ingress_enabled=False,
         public_host=None,
-        publish_debug_ports=True,
+        publish_local_ports=True,
         backend_upstreams="backend:8000",
         canvas_upstream="canvas:5173",
         start_stack=False,
@@ -458,7 +458,7 @@ def test_run_install_flow_forced_mode(monkeypatch: pytest.MonkeyPatch) -> None:
         chatkit_domain_key=None,
         public_ingress=None,
         public_host=None,
-        publish_debug_ports=None,
+        publish_local_ports=None,
         start_stack=None,
         install_docker=None,
         install_orcheo_skill=None,
@@ -481,7 +481,7 @@ def test_run_install_flow_parses_modes(monkeypatch: pytest.MonkeyPatch) -> None:
         chatkit_domain_key=None,
         public_ingress_enabled=False,
         public_host=None,
-        publish_debug_ports=True,
+        publish_local_ports=True,
         backend_upstreams="backend:8000",
         canvas_upstream="canvas:5173",
         start_stack=False,
@@ -510,7 +510,7 @@ def test_run_install_flow_parses_modes(monkeypatch: pytest.MonkeyPatch) -> None:
         chatkit_domain_key=None,
         public_ingress=None,
         public_host=None,
-        publish_debug_ports=None,
+        publish_local_ports=None,
         start_stack=None,
         install_docker=None,
         install_orcheo_skill=None,
@@ -576,7 +576,7 @@ def test_compose_profile_args(
             [
                 "# comment",
                 "OTHER=value",
-                "COMPOSE_PROFILES= public-ingress , 'debug-ports', \"extra\" ",
+                "COMPOSE_PROFILES= public-ingress , 'local-access', \"extra\" ",
                 "IGNORED=after",
             ]
         ),
@@ -587,7 +587,7 @@ def test_compose_profile_args(
         "--profile",
         "public-ingress",
         "--profile",
-        "debug-ports",
+        "local-access",
         "--profile",
         "extra",
     ]
@@ -600,13 +600,13 @@ def test_compose_profile_args(
     blank_profiles_dir = tmp_path / "stack-blank"
     blank_profiles_dir.mkdir()
     (blank_profiles_dir / ".env").write_text(
-        "COMPOSE_PROFILES=public-ingress, ,debug-ports\n", encoding="utf-8"
+        "COMPOSE_PROFILES=public-ingress, ,local-access\n", encoding="utf-8"
     )
     assert main_mod._compose_profile_args(blank_profiles_dir) == [
         "--profile",
         "public-ingress",
         "--profile",
-        "debug-ports",
+        "local-access",
     ]
 
 

--- a/tests/sdk/test_cli_setup.py
+++ b/tests/sdk/test_cli_setup.py
@@ -429,7 +429,7 @@ def test_build_env_updates(monkeypatch):
         chatkit_domain_key="domain",
         public_ingress_enabled=False,
         public_host=None,
-        publish_debug_ports=True,
+        publish_local_ports=True,
         backend_upstreams="backend:8000",
         canvas_upstream="canvas:5173",
         start_stack=False,
@@ -442,7 +442,7 @@ def test_build_env_updates(monkeypatch):
     assert updates["ORCHEO_CORS_ALLOW_ORIGINS"] == (
         "http://localhost:5173,http://127.0.0.1:5173"
     )
-    assert updates["COMPOSE_PROFILES"] == "debug-ports"
+    assert updates["COMPOSE_PROFILES"] == "local-access"
     assert updates["VITE_ORCHEO_CHATKIT_DOMAIN_KEY"] == "domain"
     assert updates["ORCHEO_STACK_IMAGE"] == f"{setup._STACK_IMAGE_REPOSITORY}:2.0"
     assert defaults["ORCHEO_POSTGRES_PASSWORD"] == "safe"
@@ -459,7 +459,7 @@ def test_build_env_updates_hides_debug_ports_in_local_only_mode(monkeypatch):
         chatkit_domain_key="domain",
         public_ingress_enabled=False,
         public_host=None,
-        publish_debug_ports=False,
+        publish_local_ports=False,
         backend_upstreams="backend:8000",
         canvas_upstream="canvas:5173",
         start_stack=False,
@@ -480,7 +480,7 @@ def test_setup_resolution_helpers_cover_env_branches(
             [
                 "ORCHEO_PUBLIC_INGRESS_ENABLED=true",
                 "ORCHEO_PUBLIC_HOST=Orcheo.Example.com",
-                "ORCHEO_PUBLISH_DEBUG_PORTS=off",
+                "ORCHEO_PUBLISH_LOCAL_PORTS=off",
                 "ORCHEO_CADDY_BACKEND_UPSTREAMS=backend:9000",
                 "ORCHEO_CADDY_CANVAS_UPSTREAM=canvas:6000",
             ]
@@ -505,7 +505,7 @@ def test_setup_resolution_helpers_cover_env_branches(
         == "orcheo.example.com"
     )
     assert (
-        setup._resolve_publish_debug_ports(
+        setup._resolve_publish_local_ports(
             None,
             public_ingress_enabled=True,
             yes=False,
@@ -552,7 +552,7 @@ def test_setup_resolution_helpers_cover_env_branches(
 
     monkeypatch.setattr(setup.typer, "confirm", lambda *args, **kwargs: False)
     assert (
-        setup._resolve_publish_debug_ports(
+        setup._resolve_publish_local_ports(
             None,
             public_ingress_enabled=True,
             yes=False,
@@ -562,7 +562,7 @@ def test_setup_resolution_helpers_cover_env_branches(
         is False
     )
     assert (
-        setup._resolve_publish_debug_ports(
+        setup._resolve_publish_local_ports(
             None,
             public_ingress_enabled=True,
             yes=True,
@@ -647,7 +647,7 @@ def test_ensure_stack_assets_fresh(monkeypatch, tmp_path):
         chatkit_domain_key=None,
         public_ingress_enabled=False,
         public_host=None,
-        publish_debug_ports=True,
+        publish_local_ports=True,
         backend_upstreams="backend:8000",
         canvas_upstream="canvas:5173",
         start_stack=False,
@@ -695,7 +695,7 @@ def test_ensure_stack_assets_existing_env(monkeypatch, tmp_path):
         chatkit_domain_key=None,
         public_ingress_enabled=False,
         public_host=None,
-        publish_debug_ports=True,
+        publish_local_ports=True,
         backend_upstreams="backend:8000",
         canvas_upstream="canvas:5173",
         start_stack=False,
@@ -721,7 +721,7 @@ def test_run_setup_generates_api_key(monkeypatch, tmp_path):
         chatkit_domain_key="domain",
         public_ingress=None,
         public_host=None,
-        publish_debug_ports=None,
+        publish_local_ports=None,
         start_stack=False,
         install_docker=False,
         install_orcheo_skill=False,
@@ -775,7 +775,7 @@ def test_execute_setup_without_start(monkeypatch, tmp_path):
         chatkit_domain_key=None,
         public_ingress_enabled=False,
         public_host=None,
-        publish_debug_ports=True,
+        publish_local_ports=True,
         backend_upstreams="backend:8000",
         canvas_upstream="canvas:5173",
         start_stack=False,
@@ -814,7 +814,7 @@ def test_execute_setup_with_start(monkeypatch, tmp_path):
         chatkit_domain_key=None,
         public_ingress_enabled=False,
         public_host=None,
-        publish_debug_ports=True,
+        publish_local_ports=True,
         backend_upstreams="backend:8000",
         canvas_upstream="canvas:5173",
         start_stack=True,
@@ -850,7 +850,7 @@ def test_execute_setup_missing_docker_command(monkeypatch, tmp_path):
         chatkit_domain_key=None,
         public_ingress_enabled=False,
         public_host=None,
-        publish_debug_ports=True,
+        publish_local_ports=True,
         backend_upstreams="backend:8000",
         canvas_upstream="canvas:5173",
         start_stack=True,
@@ -895,12 +895,12 @@ def test_print_setup_resolution_notes_public_ingress_debug_disabled() -> None:
         preserve_existing_backend_url=False,
         resolved_public_ingress_enabled=True,
         resolved_public_host="orcheo.example.com",
-        resolved_publish_debug_ports=False,
+        resolved_publish_local_ports=False,
     )
 
     output = console.file.getvalue()
     assert "Bundled public ingress enabled for orcheo.example.com" in output
-    assert "Local backend/canvas debug ports will stay disabled" in output
+    assert "Local backend/canvas ports will stay disabled" in output
 
 
 def test_print_summary():
@@ -913,7 +913,7 @@ def test_print_summary():
         chatkit_domain_key=None,
         public_ingress_enabled=False,
         public_host=None,
-        publish_debug_ports=True,
+        publish_local_ports=True,
         backend_upstreams="backend:8000",
         canvas_upstream="canvas:5173",
         start_stack=True,

--- a/tests/sdk/test_cli_setup_stack_assets.py
+++ b/tests/sdk/test_cli_setup_stack_assets.py
@@ -118,7 +118,7 @@ def _setup_config() -> SetupConfig:
         chatkit_domain_key=None,
         public_ingress_enabled=False,
         public_host=None,
-        publish_debug_ports=True,
+        publish_local_ports=True,
         backend_upstreams="backend:8000",
         canvas_upstream="canvas:5173",
         start_stack=True,
@@ -195,7 +195,7 @@ def test_execute_setup_bootstraps_stack_assets(
         "docker",
         "compose",
         "--profile",
-        "debug-ports",
+        "local-access",
         "-f",
         str(stack_dir / "docker-compose.yml"),
         "--project-directory",
@@ -206,7 +206,7 @@ def test_execute_setup_bootstraps_stack_assets(
         "docker",
         "compose",
         "--profile",
-        "debug-ports",
+        "local-access",
         "-f",
         str(stack_dir / "docker-compose.yml"),
         "--project-directory",
@@ -246,7 +246,7 @@ def test_execute_setup_upgrade_pulls_then_starts(
         "docker",
         "compose",
         "--profile",
-        "debug-ports",
+        "local-access",
         "-f",
         str(stack_dir / "docker-compose.yml"),
         "--project-directory",
@@ -257,7 +257,7 @@ def test_execute_setup_upgrade_pulls_then_starts(
         "docker",
         "compose",
         "--profile",
-        "debug-ports",
+        "local-access",
         "-f",
         str(stack_dir / "docker-compose.yml"),
         "--project-directory",
@@ -305,7 +305,7 @@ def test_run_setup_upgrade_preserves_existing_api_key_by_default(
         chatkit_domain_key=None,
         public_ingress=None,
         public_host=None,
-        publish_debug_ports=None,
+        publish_local_ports=None,
         start_stack=None,
         install_docker=None,
         install_orcheo_skill=None,
@@ -333,7 +333,7 @@ def test_run_setup_upgrade_honors_explicit_api_key(
         chatkit_domain_key=None,
         public_ingress=None,
         public_host=None,
-        publish_debug_ports=None,
+        publish_local_ports=None,
         start_stack=None,
         install_docker=None,
         install_orcheo_skill=None,
@@ -368,7 +368,7 @@ def test_run_setup_install_preserves_existing_env_by_default(
         chatkit_domain_key=None,
         public_ingress=None,
         public_host=None,
-        publish_debug_ports=None,
+        publish_local_ports=None,
         start_stack=False,
         install_docker=False,
         install_orcheo_skill=None,
@@ -407,7 +407,7 @@ def test_run_setup_install_explicit_public_ingress_updates_backend_url_defaults(
         chatkit_domain_key=None,
         public_ingress=True,
         public_host="orcheo.example.com",
-        publish_debug_ports=True,
+        publish_local_ports=True,
         start_stack=False,
         install_docker=False,
         install_orcheo_skill=False,
@@ -793,7 +793,7 @@ def test_execute_setup_uses_privileged_docker_after_autoinstall_until_shell_refr
         "docker",
         "compose",
         "--profile",
-        "debug-ports",
+        "local-access",
         "-f",
         str(stack_dir / "docker-compose.yml"),
         "--project-directory",
@@ -805,7 +805,7 @@ def test_execute_setup_uses_privileged_docker_after_autoinstall_until_shell_refr
         "docker",
         "compose",
         "--profile",
-        "debug-ports",
+        "local-access",
         "-f",
         str(stack_dir / "docker-compose.yml"),
         "--project-directory",
@@ -1290,7 +1290,7 @@ def test_setup_build_env_updates_and_warn_missing_branch(
         chatkit_domain_key="domain_pk_live",
         public_ingress_enabled=False,
         public_host=None,
-        publish_debug_ports=True,
+        publish_local_ports=True,
         backend_upstreams="backend:8000",
         canvas_upstream="canvas:5173",
         start_stack=False,
@@ -1300,7 +1300,7 @@ def test_setup_build_env_updates_and_warn_missing_branch(
     updates, defaults = setup_mod._build_env_updates(config)
     assert "ORCHEO_AUTH_BOOTSTRAP_SERVICE_TOKEN" not in updates
     assert "ORCHEO_AUTH_MODE" not in updates
-    assert updates["COMPOSE_PROFILES"] == "debug-ports"
+    assert updates["COMPOSE_PROFILES"] == "local-access"
     assert updates["VITE_ORCHEO_CHATKIT_DOMAIN_KEY"] == "domain_pk_live"
     assert defaults["ORCHEO_POSTGRES_PASSWORD"]
 
@@ -1401,7 +1401,7 @@ def test_run_setup_prints_generated_key_and_oauth_notice(
         chatkit_domain_key=None,
         public_ingress=None,
         public_host=None,
-        publish_debug_ports=None,
+        publish_local_ports=None,
         start_stack=None,
         install_docker=None,
         install_orcheo_skill=None,
@@ -1420,7 +1420,7 @@ def test_run_setup_prints_generated_key_and_oauth_notice(
         chatkit_domain_key=None,
         public_ingress=None,
         public_host=None,
-        publish_debug_ports=None,
+        publish_local_ports=None,
         start_stack=False,
         install_docker=False,
         install_orcheo_skill=None,
@@ -1449,7 +1449,7 @@ def test_run_setup_public_ingress_derives_public_env_contract(
         chatkit_domain_key=None,
         public_ingress=True,
         public_host="orcheo.example.com",
-        publish_debug_ports=True,
+        publish_local_ports=True,
         start_stack=False,
         install_docker=False,
         install_orcheo_skill=False,
@@ -1467,7 +1467,7 @@ def test_run_setup_public_ingress_derives_public_env_contract(
         "https://orcheo.example.com,http://localhost:5173,http://127.0.0.1:5173"
     )
     assert updates["VITE_ALLOWED_HOSTS"] == "localhost,127.0.0.1,orcheo.example.com"
-    assert updates["COMPOSE_PROFILES"] == "public-ingress,debug-ports"
+    assert updates["COMPOSE_PROFILES"] == "public-ingress,local-access"
     assert updates["ORCHEO_CADDY_SITE_ADDRESS"] == "orcheo.example.com"
 
 
@@ -1486,7 +1486,7 @@ def test_run_setup_public_ingress_requires_hostname_with_yes(
             chatkit_domain_key=None,
             public_ingress=True,
             public_host=None,
-            publish_debug_ports=None,
+            publish_local_ports=None,
             start_stack=False,
             install_docker=False,
             install_orcheo_skill=False,
@@ -1504,7 +1504,7 @@ def test_setup_public_ingress_helpers_and_summary(
     config = _setup_config()
     config.public_ingress_enabled = True
     config.public_host = "orcheo.example.com"
-    config.publish_debug_ports = False
+    config.publish_local_ports = False
     config.start_stack = False
     config.backend_url = "https://orcheo.example.com"
 
@@ -1514,7 +1514,7 @@ def test_setup_public_ingress_helpers_and_summary(
     healthcheck_config = _setup_config()
     healthcheck_config.public_ingress_enabled = True
     healthcheck_config.public_host = "orcheo.example.com"
-    healthcheck_config.publish_debug_ports = True
+    healthcheck_config.publish_local_ports = True
     assert (
         setup_mod._build_healthcheck_url(healthcheck_config) == "http://localhost:8000"
     )

--- a/tests/sdk/test_stack_caddy_assets.py
+++ b/tests/sdk/test_stack_caddy_assets.py
@@ -27,7 +27,7 @@ def test_stack_compose_defines_public_ingress_and_debug_profiles() -> None:
     ]
     assert services["canvas"]["healthcheck"]["test"] == [
         "CMD-SHELL",
-        "wget -q -O /dev/null http://localhost:5173/ || exit 1",
+        "wget -q -O /dev/null http://127.0.0.1:5173/ || exit 1",
     ]
     assert (
         services["backend"]["depends_on"]["postgres"]["condition"] == "service_healthy"

--- a/tests/sdk/test_stack_caddy_assets.py
+++ b/tests/sdk/test_stack_caddy_assets.py
@@ -15,7 +15,7 @@ CADDYFILE = STACK_DIR / "Caddyfile"
 ENV_EXAMPLE = STACK_DIR / ".env.example"
 
 
-def test_stack_compose_defines_public_ingress_and_debug_profiles() -> None:
+def test_stack_compose_defines_public_ingress_and_local_access_profiles() -> None:
     compose = yaml.safe_load(COMPOSE_FILE.read_text(encoding="utf-8"))
     services = compose["services"]
 
@@ -34,27 +34,27 @@ def test_stack_compose_defines_public_ingress_and_debug_profiles() -> None:
     )
     assert services["backend"]["depends_on"]["redis"]["condition"] == "service_healthy"
     assert (
-        services["backend-debug"]["depends_on"]["backend"]["condition"]
+        services["backend-local"]["depends_on"]["backend"]["condition"]
         == "service_healthy"
     )
     assert (
-        services["canvas-debug"]["depends_on"]["canvas"]["condition"]
+        services["canvas-local"]["depends_on"]["canvas"]["condition"]
         == "service_healthy"
     )
     assert services["caddy"]["depends_on"]["backend"]["condition"] == "service_healthy"
     assert services["caddy"]["depends_on"]["canvas"]["condition"] == "service_healthy"
-    assert services["backend-debug"]["profiles"] == ["debug-ports"]
-    assert services["canvas-debug"]["profiles"] == ["debug-ports"]
+    assert services["backend-local"]["profiles"] == ["local-access"]
+    assert services["canvas-local"]["profiles"] == ["local-access"]
     assert services["caddy"]["profiles"] == ["public-ingress"]
     assert "./Caddyfile:/etc/caddy/Caddyfile:ro" in services["caddy"]["volumes"]
     assert "caddy_data:/data" in services["caddy"]["volumes"]
     assert "caddy_config:/config" in services["caddy"]["volumes"]
     assert (
-        "127.0.0.1:${ORCHEO_POSTGRES_DEBUG_PORT:-5432}:5432"
+        "127.0.0.1:${ORCHEO_POSTGRES_LOCAL_PORT:-5432}:5432"
         in services["postgres"]["ports"]
     )
     assert (
-        "127.0.0.1:${ORCHEO_REDIS_DEBUG_PORT:-6379}:6379" in services["redis"]["ports"]
+        "127.0.0.1:${ORCHEO_REDIS_LOCAL_PORT:-6379}:6379" in services["redis"]["ports"]
     )
     assert "caddy_data" in compose["volumes"]
     assert "caddy_config" in compose["volumes"]
@@ -79,8 +79,8 @@ def test_env_example_documents_public_ingress_contract() -> None:
 
     assert "ORCHEO_PUBLIC_INGRESS_ENABLED=false" in content
     assert "ORCHEO_PUBLIC_HOST=" in content
-    assert "ORCHEO_PUBLISH_DEBUG_PORTS=true" in content
-    assert "COMPOSE_PROFILES=debug-ports" in content
+    assert "ORCHEO_PUBLISH_LOCAL_PORTS=true" in content
+    assert "COMPOSE_PROFILES=local-access" in content
     assert "ORCHEO_CADDY_BACKEND_UPSTREAMS=backend:8000" in content
     assert "VITE_ALLOWED_HOSTS=localhost,127.0.0.1" in content
 
@@ -101,7 +101,7 @@ def test_stack_compose_config_renders_with_profiles(tmp_path: Path) -> None:
             "docker",
             "compose",
             "--profile",
-            "debug-ports",
+            "local-access",
             "--profile",
             "public-ingress",
             "-f",


### PR DESCRIPTION
## Summary

This PR fixes two deployment/runtime issues:

- updates the Canvas service healthcheck in the stack compose file to use `127.0.0.1` instead of `localhost`, avoiding cases where hostname resolution causes the healthcheck to fail
- improves Slack node MCP stdio logging so special device targets like `/dev/stderr`, `/dev/stdout`, `/proc/self/fd/1`, and `/proc/self/fd/2` are routed to the active process streams instead of being treated as regular file paths
- keeps the existing fallback behavior for stdio logging by centralizing the default log target

## Test updates

- adds Slack node coverage for the default stdio log target, custom log file paths, and stderr stream routing
- updates the stack asset test to match the new Canvas healthcheck command
