### PR TITLE
Normalize templated RSS sources before fetching feeds

### DIFF
--- a/src/orcheo/nodes/rss.py
+++ b/src/orcheo/nodes/rss.py
@@ -37,7 +37,7 @@ class RSSNode(TaskNode):
     without aborting the remaining feeds.
     """
 
-    sources: list[str] = Field(description="RSS/Atom feed URLs to fetch")
+    sources: list[str] | str = Field(description="RSS/Atom feed URLs to fetch")
     timeout: float = Field(
         default=15.0,
         gt=0.0,
@@ -46,11 +46,17 @@ class RSSNode(TaskNode):
 
     @field_validator("sources", mode="before")
     @classmethod
-    def _normalize_sources(cls, value: list[str] | str) -> list[str]:
-        """Normalize a single feed URL into a list of sources."""
+    def _normalize_sources(cls, value: list[Any] | str) -> list[str]:
+        """Normalize a single feed URL or nested lists into a flat list of sources."""
         if isinstance(value, str):
             return [value]
-        return value
+        flat: list[str] = []
+        for item in value:
+            if isinstance(item, list):
+                flat.extend(item)
+            else:
+                flat.append(item)
+        return flat
 
     # ------------------------------------------------------------------
     # XML helpers
@@ -208,7 +214,16 @@ class RSSNode(TaskNode):
             follow_redirects=True,
             headers=RSS_REQUEST_HEADERS,
         ) as client:
-            for url in self.sources:
+            # Normalize in case template resolution produced a bare string
+            # or nested lists (model_copy in resolved_for_run skips validators).
+            sources = self.sources if isinstance(self.sources, list) else [self.sources]
+            flat_sources: list[str] = []
+            for src in sources:
+                if isinstance(src, list):
+                    flat_sources.extend(src)
+                else:
+                    flat_sources.append(src)
+            for url in flat_sources:
                 docs, error = await self._fetch_source(client, url, now_iso)
                 documents.extend(docs)
                 if error is not None:

--- a/src/orcheo/nodes/rss.py
+++ b/src/orcheo/nodes/rss.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 import datetime
+from collections.abc import Iterable
 from email.utils import parsedate_to_datetime
 from typing import Any
 from xml.etree import ElementTree
@@ -44,19 +45,31 @@ class RSSNode(TaskNode):
         description="HTTP timeout in seconds per feed",
     )
 
-    @field_validator("sources", mode="before")
     @classmethod
-    def _normalize_sources(cls, value: list[Any] | str) -> list[str]:
-        """Normalize a single feed URL or nested lists into a flat list of sources."""
+    def _flatten_sources(cls, value: str | Iterable[Any]) -> list[str]:
+        """Flatten sources into a list of URL strings.
+
+        Handles a bare string, a flat list, nested lists, or other
+        iterables (tuples, sets) that ``resolved_for_run`` may produce
+        because ``model_copy`` bypasses Pydantic field validators.
+        """
         if isinstance(value, str):
             return [value]
         flat: list[str] = []
         for item in value:
-            if isinstance(item, list):
-                flat.extend(item)
-            else:
+            if isinstance(item, str):
                 flat.append(item)
+            elif isinstance(item, Iterable):
+                flat.extend(str(i) for i in item)
+            else:
+                flat.append(str(item))
         return flat
+
+    @field_validator("sources", mode="before")
+    @classmethod
+    def _normalize_sources(cls, value: list[str | list[str]] | str) -> list[str]:
+        """Normalize a single feed URL or nested lists into a flat list of sources."""
+        return cls._flatten_sources(value)
 
     # ------------------------------------------------------------------
     # XML helpers
@@ -214,15 +227,10 @@ class RSSNode(TaskNode):
             follow_redirects=True,
             headers=RSS_REQUEST_HEADERS,
         ) as client:
-            # Normalize in case template resolution produced a bare string
-            # or nested lists (model_copy in resolved_for_run skips validators).
-            sources = self.sources if isinstance(self.sources, list) else [self.sources]
-            flat_sources: list[str] = []
-            for src in sources:
-                if isinstance(src, list):
-                    flat_sources.extend(src)
-                else:
-                    flat_sources.append(src)
+            # Re-flatten because resolved_for_run() uses model_copy(update=…)
+            # which bypasses Pydantic field validators, so self.sources may
+            # be a bare string, tuple, set, or nested list after templating.
+            flat_sources = self._flatten_sources(self.sources)
             for url in flat_sources:
                 docs, error = await self._fetch_source(client, url, now_iso)
                 documents.extend(docs)

--- a/tests/nodes/test_rss.py
+++ b/tests/nodes/test_rss.py
@@ -342,3 +342,26 @@ def test_normalize_date_invalid_string_returns_empty() -> None:
     """_normalize_date returns empty string when both parsers fail (lines 107-109)."""
     result = RSSNode._normalize_date("not-a-date")
     assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# _flatten_sources – targeting uncovered lines 62-65
+# ---------------------------------------------------------------------------
+
+
+def test_flatten_sources_nested_iterable_is_flattened() -> None:
+    """A nested iterable (non-string) is expanded via the elif branch (lines 62-63)."""
+    result = RSSNode._flatten_sources(
+        ["https://a.com/feed.xml", ("https://b.com/feed.xml", "https://c.com/feed.xml")]
+    )
+    assert result == [
+        "https://a.com/feed.xml",
+        "https://b.com/feed.xml",
+        "https://c.com/feed.xml",
+    ]
+
+
+def test_flatten_sources_non_iterable_item_is_stringified() -> None:
+    """A non-string, non-iterable item falls through to the else branch (lines 64-65)."""  # noqa: E501
+    result = RSSNode._flatten_sources(["https://a.com/feed.xml", 42])
+    assert result == ["https://a.com/feed.xml", "42"]


### PR DESCRIPTION
## Summary
- update `RSSNode.sources` to accept either a single feed URL string or a list of feed URLs
- flatten nested source lists during source normalization
- normalize `sources` again inside `run()` so runtime-resolved values are handled correctly even when `resolved_for_run()` bypasses validators

## Why
When RSS sources come from template resolution, the runtime copy path can leave `sources` as a bare string or a nested list instead of a normalized `list[str]`. That makes the RSS node iterate the wrong shape and can break feed fetching.

## Result
- RSS workflows now handle templated single URLs and templated lists more reliably
- the change is limited to source normalization; RSS/Atom parsing behavior is otherwise unchanged
