### PR TITLE
Remove trace tab loading skeleton state

### DIFF
--- a/apps/canvas/src/features/workflow/pages/workflow-canvas/components/trace-tab-content.test.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-canvas/components/trace-tab-content.test.tsx
@@ -49,7 +49,6 @@ const sampleViewerData2: TraceViewerData = {
 const createProps = (
   overrides: Partial<TraceTabContentProps> = {},
 ): TraceTabContentProps => ({
-  status: "ready",
   error: undefined,
   viewerData: [sampleViewerData],
   activeViewer: sampleViewerData,
@@ -88,20 +87,19 @@ describe("TraceTabContent", () => {
     traceViewerMock.mockReset();
   });
 
-  it("shows loading skeleton when trace is loading", () => {
-    const { container } = render(
+  it("shows empty state when there is no data", () => {
+    render(
       <TraceTabContent
         {...createProps({
-          status: "loading",
           viewerData: [],
           activeViewer: undefined,
         })}
       />,
     );
 
-    expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThan(
-      0,
-    );
+    expect(
+      screen.getByText(/trace data will appear here/i),
+    ).toBeInTheDocument();
     expect(screen.queryByTestId("trace-viewer")).not.toBeInTheDocument();
   });
 
@@ -109,7 +107,6 @@ describe("TraceTabContent", () => {
     render(
       <TraceTabContent
         {...createProps({
-          status: "error",
           error: "Server unavailable",
           viewerData: [],
           activeViewer: undefined,

--- a/apps/canvas/src/features/workflow/pages/workflow-canvas/components/trace-tab-content.test.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-canvas/components/trace-tab-content.test.tsx
@@ -97,9 +97,7 @@ describe("TraceTabContent", () => {
       />,
     );
 
-    expect(
-      screen.getByText(/trace data will appear here/i),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("trace-empty-state")).toBeInTheDocument();
     expect(screen.queryByTestId("trace-viewer")).not.toBeInTheDocument();
   });
 

--- a/apps/canvas/src/features/workflow/pages/workflow-canvas/components/trace-tab-content.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-canvas/components/trace-tab-content.tsx
@@ -156,8 +156,11 @@ export function TraceTabContent({
       )}
 
       {!hasData && !error && (
-        <div className="flex flex-1 items-center justify-center rounded-md border border-dashed border-border text-sm text-muted-foreground">
-          Trace data will appear here once spans are recorded.
+        <div
+          data-testid="trace-empty-state"
+          className="flex flex-1 items-center justify-center rounded-md border border-dashed border-border text-sm text-muted-foreground"
+        >
+          No trace spans recorded yet for this execution.
         </div>
       )}
 

--- a/apps/canvas/src/features/workflow/pages/workflow-canvas/components/trace-tab-content.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-canvas/components/trace-tab-content.tsx
@@ -6,15 +6,12 @@ import type { TraceSpan } from "@evilmartians/agent-prism-types";
 
 import { Alert, AlertDescription, AlertTitle } from "@/design-system/ui/alert";
 import { Button } from "@/design-system/ui/button";
-import { Skeleton } from "@/design-system/ui/skeleton";
 import type { TraceViewerData } from "@features/workflow/components/trace/agent-prism";
 import { TraceViewer } from "@features/workflow/components/trace/agent-prism";
 import { deriveThreadStitchedViewerDataList } from "@features/workflow/pages/workflow-canvas/helpers/trace";
-import type { TraceEntryStatus } from "@features/workflow/pages/workflow-canvas/helpers/trace";
 import type { TraceSpanMetadata } from "@features/workflow/pages/workflow-canvas/helpers/trace";
 
 export interface TraceTabContentProps {
-  status: TraceEntryStatus;
   error?: string;
   viewerData: TraceViewerData[];
   activeViewer?: TraceViewerData;
@@ -58,7 +55,6 @@ const renderArtifactActions = (span: TraceSpan) => {
 };
 
 export function TraceTabContent({
-  status,
   error,
   viewerData,
   activeViewer,
@@ -116,7 +112,6 @@ export function TraceTabContent({
     return displayedViewerData[0]?.traceRecord.id;
   }, [activeViewer, displayedViewerData, isStitchedTimeline]);
 
-  const isLoading = status === "loading" && !activeViewer;
   const hasData = displayedViewerData.length > 0;
 
   return (
@@ -160,14 +155,7 @@ export function TraceTabContent({
         </Alert>
       )}
 
-      {isLoading && (
-        <div className="space-y-4">
-          <Skeleton className="h-12 w-full" />
-          <Skeleton className="h-72 w-full" />
-        </div>
-      )}
-
-      {!isLoading && !hasData && !error && (
+      {!hasData && !error && (
         <div className="flex flex-1 items-center justify-center rounded-md border border-dashed border-border text-sm text-muted-foreground">
           Trace data will appear here once spans are recorded.
         </div>

--- a/apps/canvas/src/features/workflow/pages/workflow-canvas/hooks/controller/build-layout-props.ts
+++ b/apps/canvas/src/features/workflow/pages/workflow-canvas/hooks/controller/build-layout-props.ts
@@ -94,7 +94,6 @@ export function buildWorkflowLayoutProps(
   };
 
   const traceProps: TraceTabContentProps = {
-    status: execution.trace.status,
     error: execution.trace.error,
     viewerData: execution.trace.viewerData,
     activeViewer: execution.trace.activeTraceViewer,


### PR DESCRIPTION
## Summary

This branch simplifies the workflow canvas trace tab by removing its dedicated loading UI and treating the absence of trace data as a normal empty state.

## What Changed

- Removed the trace tab's loading skeleton UI.
- Updated the trace tab to show the standard empty-state message whenever there is no trace data and no error.
- Simplified `TraceTabContent` by removing the unused `status` prop and the related wiring from layout prop construction.
- Updated the trace tab tests to reflect the new behavior, replacing the loading-state assertion with an empty-state assertion.

## Impact

- The trace tab now behaves more consistently when no spans are available yet.
- The component API is smaller and easier to maintain because it no longer depends on trace status just to decide between loading and empty states.
