### PR TITLE
Add LinkedInPostNode with vault-backed token refresh/persistence, and setup docs

### DIFF
--- a/apps/canvas/src/features/vibe/hooks/use-vibe-workflow.test.ts
+++ b/apps/canvas/src/features/vibe/hooks/use-vibe-workflow.test.ts
@@ -7,7 +7,10 @@ import {
   createWorkflowFromTemplate,
   listWorkflows,
 } from "@features/workflow/lib/workflow-storage";
-import { request } from "@features/workflow/lib/workflow-storage-api";
+import {
+  fetchWorkflowVersions,
+  request,
+} from "@features/workflow/lib/workflow-storage-api";
 
 vi.mock("@features/workflow/lib/workflow-storage", () => ({
   createWorkflowFromTemplate: vi.fn(),
@@ -15,6 +18,7 @@ vi.mock("@features/workflow/lib/workflow-storage", () => ({
 }));
 
 vi.mock("@features/workflow/lib/workflow-storage-api", () => ({
+  fetchWorkflowVersions: vi.fn(),
   request: vi.fn(),
 }));
 
@@ -54,38 +58,23 @@ describe("useVibeWorkflow", () => {
   it("re-ingests and updates an existing vibe workflow when the stored template version is outdated, without creating a new workflow", async () => {
     vi.mocked(createWorkflowFromTemplate).mockResolvedValue(undefined);
     vi.mocked(listWorkflows).mockResolvedValue([EXISTING_VIBE_WORKFLOW]);
+    vi.mocked(fetchWorkflowVersions).mockResolvedValue([
+      {
+        id: "workflow-1-version-1",
+        workflow_id: "workflow-1",
+        version: 1,
+        metadata: {
+          source: "canvas-template",
+          template_id: "template-vibe-agent",
+        },
+        notes: "Seeded from the Orcheo Vibe template.",
+        created_by: "canvas-app",
+        created_at: "2026-04-13T09:00:00.000Z",
+        updated_at: "2026-04-13T09:00:00.000Z",
+        graph: {},
+      },
+    ]);
     vi.mocked(request).mockImplementation(async (path, options) => {
-      if (path === "/api/workflows/workflow-1" && !options) {
-        return {
-          id: "workflow-1",
-          name: "Orcheo Vibe",
-          slug: "orcheo-vibe",
-          description: "Managed sidebar workflow.",
-          tags: ["orcheo-vibe-agent", "external-agent"],
-          is_archived: false,
-          is_public: false,
-          require_login: true,
-          published_at: null,
-          published_by: null,
-          created_at: "2026-04-13T09:00:00.000Z",
-          updated_at: "2026-04-13T09:00:00.000Z",
-          latest_version: {
-            id: "workflow-1-version-1",
-            workflow_id: "workflow-1",
-            version: 1,
-            metadata: {
-              source: "canvas-template",
-              template_id: "template-vibe-agent",
-            },
-            notes: "Seeded from the Orcheo Vibe template.",
-            created_by: "canvas-app",
-            created_at: "2026-04-13T09:00:00.000Z",
-            updated_at: "2026-04-13T09:00:00.000Z",
-            graph: {},
-          },
-        };
-      }
-
       if (
         path === "/api/workflows/workflow-1/versions/ingest" &&
         options?.method === "POST"

--- a/apps/canvas/src/features/vibe/hooks/use-vibe-workflow.ts
+++ b/apps/canvas/src/features/vibe/hooks/use-vibe-workflow.ts
@@ -5,11 +5,11 @@ import {
   createWorkflowFromTemplate,
   listWorkflows,
 } from "@features/workflow/lib/workflow-storage";
-import { request } from "@features/workflow/lib/workflow-storage-api";
 import {
-  type ApiWorkflow,
-  type ChatKitSupportedModel,
-} from "@features/workflow/lib/workflow-storage.types";
+  fetchWorkflowVersions,
+  request,
+} from "@features/workflow/lib/workflow-storage-api";
+import { type ChatKitSupportedModel } from "@features/workflow/lib/workflow-storage.types";
 import {
   VIBE_AGENT_TAG,
   VIBE_WORKFLOW_NAME,
@@ -111,8 +111,8 @@ export function useVibeWorkflow(
       return;
     }
 
-    const workflow = await request<ApiWorkflow>(`/api/workflows/${workflowId}`);
-    const latestMetadata = workflow.latest_version?.metadata;
+    const versions = await fetchWorkflowVersions(workflowId);
+    const latestMetadata = versions.at(-1)?.metadata;
     const currentTemplateId = resolveTemplateId(latestMetadata);
     const currentTemplateVersion = resolveTemplateVersion(latestMetadata);
 
@@ -136,8 +136,8 @@ export function useVibeWorkflow(
           template: VIBE_TEMPLATE.metadata,
           canvas: {
             snapshot: {
-              name: workflow.name,
-              description: workflow.description,
+              name: VIBE_TEMPLATE.workflow.name,
+              description: VIBE_TEMPLATE.workflow.description,
               nodes: VIBE_TEMPLATE.workflow.nodes,
               edges: VIBE_TEMPLATE.workflow.edges,
             },

--- a/docs/integrations/linkedin_credentials_setup.md
+++ b/docs/integrations/linkedin_credentials_setup.md
@@ -1,0 +1,37 @@
+# LinkedIn Credentials Setup for Orcheo
+
+This guide explains how to provision the vault credentials required by
+`LinkedInPostNode` without exposing tokens to AI agents.
+
+## Required vault credentials
+
+`LinkedInPostNode` reads three vault-backed credentials at runtime:
+
+| Credential key | Required | Description |
+|---|---|---|
+| `linkedin_access_token` | Yes | OAuth 2.0 access token with the necessary LinkedIn API scopes |
+| `linkedin_refresh_token` | Yes | Refresh token used to renew the access token |
+| `linkedin_id_token` | No | OIDC id token; when present it is used instead of the `/v2/userinfo` endpoint to resolve the posting member's identity |
+
+The node references these as `[[linkedin_access_token]]`, `[[linkedin_refresh_token]]`,
+and `[[linkedin_id_token]]` in its field defaults — Orcheo substitutes the vault
+values at execution time.
+
+## Provisioning tokens with the `linkedin-oauth` skill
+
+The recommended way to create and store these credentials is the
+**`linkedin-oauth`** skill from
+[AI-Colleagues/agent-skills](https://github.com/AI-Colleagues/agent-skills).
+
+The skill handles the full OAuth 2.0 authorization-code flow and **uploads the
+resulting tokens directly to the Orcheo credential vault**, so the raw token
+values are never passed through or visible to AI agents.
+
+Refer to the skill's README for installation and usage instructions.
+
+## Example workflows
+
+End-to-end workflow examples that use `LinkedInPostNode` are available in the
+[AI-Colleagues/orcheo-examples](https://github.com/AI-Colleagues/orcheo-examples)
+repository. These cover common scenarios such as posting as a person and posting
+on behalf of an organization page.

--- a/docs/integrations/linkedin_credentials_setup.md
+++ b/docs/integrations/linkedin_credentials_setup.md
@@ -17,6 +17,23 @@ The node references these as `[[linkedin_access_token]]`, `[[linkedin_refresh_to
 and `[[linkedin_id_token]]` in its field defaults — Orcheo substitutes the vault
 values at execution time.
 
+## Required LinkedIn scopes
+
+To use `LinkedInPostNode`, ensure your LinkedIn application and granted member consent
+include the scopes required by your posting mode:
+
+- `w_member_social` — required for posting as a person.
+- `rw_organization_admin` — required to list approved organization pages via
+  `organizationAcls` when posting as an organization without an explicit
+  `configurable.organization_urn`.
+
+If you resolve member identity via `/v2/userinfo` (no `linkedin_id_token` provided),
+also configure the LinkedIn OpenID Connect product and grant:
+
+- `openid`
+- `profile`
+- `email`
+
 ## Provisioning tokens with the `linkedin-oauth` skill
 
 The recommended way to create and store these credentials is the

--- a/src/orcheo/graph/ingestion/sandbox.py
+++ b/src/orcheo/graph/ingestion/sandbox.py
@@ -74,6 +74,7 @@ TraceFunc = Callable[[FrameType | None, str, object], object]
 
 _SAFE_MODULE_PREFIXES: tuple[str, ...] = (
     "asyncio",
+    "base64",
     "json",
     "langgraph",
     "langchain",

--- a/src/orcheo/nodes/__init__.py
+++ b/src/orcheo/nodes/__init__.py
@@ -33,6 +33,7 @@ from orcheo.nodes.deep_agent import DeepAgentNode
 from orcheo.nodes.gemini import GeminiNode
 from orcheo.nodes.javascript_sandbox import JavaScriptSandboxNode
 from orcheo.nodes.lark import LarkSendMessageNode, LarkTenantAccessTokenNode
+from orcheo.nodes.linkedin import LinkedInPostNode
 from orcheo.nodes.listeners import (
     DiscordBotListenerNode,
     QQBotListenerNode,
@@ -126,6 +127,7 @@ __all__ = [
     "JavaScriptSandboxNode",
     "LarkSendMessageNode",
     "LarkTenantAccessTokenNode",
+    "LinkedInPostNode",
     "DeepAgentNode",
     "DebugNode",
     "SubWorkflowNode",

--- a/src/orcheo/nodes/linkedin.py
+++ b/src/orcheo/nodes/linkedin.py
@@ -22,6 +22,7 @@ _ORG_ACLS_URL = "https://api.linkedin.com/rest/organizationAcls?q=roleAssignee"
 _POSTS_URL = "https://api.linkedin.com/rest/posts"
 _TOKEN_URL = "https://www.linkedin.com/oauth/v2/accessToken"
 _USERINFO_URL = "https://api.linkedin.com/v2/userinfo"
+_ALLOWED_VISIBILITY = frozenset({"PUBLIC", "CONNECTIONS", "LOGGED_IN"})
 
 
 class _LinkedInAuthError(Exception):
@@ -246,12 +247,17 @@ class LinkedInPostNode(TaskNode):
         """Resolve author identity from token context."""
         post_as = str(configurable["post_as"]).strip().lower()
         if post_as == "organization":
-            organization_urn = await self.resolve_organization_urn(
-                state,
-                config,
-                access_token,
-                str(configurable["linkedin_version"]).strip(),
-            )
+            configured_organization_urn = str(
+                configurable.get("organization_urn", "")
+            ).strip()
+            organization_urn = configured_organization_urn
+            if not organization_urn:
+                organization_urn = await self.resolve_organization_urn(
+                    state,
+                    config,
+                    access_token,
+                    str(configurable["linkedin_version"]).strip(),
+                )
             return organization_urn, None, organization_urn
         if post_as == "person":
             person_id, author_urn = await self.resolve_person_identity(
@@ -328,13 +334,14 @@ class LinkedInPostNode(TaskNode):
             )
             if not updated:
                 logger.warning(
-                    "Credential 'linkedin_access_token' not found in vault by name; "
-                    "the refreshed access token will not be persisted."
+                    "Credential '%s' not found in vault by name; "
+                    "the refreshed access token will not be persisted.",
+                    "linkedin_access_token",
                 )
         except Exception:
             logger.warning(
-                "Failed to update 'linkedin_access_token' in vault after "
-                "token refresh.",
+                "Failed to update '%s' in vault after token refresh.",
+                "linkedin_access_token",
                 exc_info=True,
             )
 
@@ -347,8 +354,8 @@ class LinkedInPostNode(TaskNode):
                 )
             except Exception:
                 logger.warning(
-                    "Failed to update 'linkedin_refresh_token' in vault after token "
-                    "refresh.",
+                    "Failed to update '%s' in vault after token refresh.",
+                    "linkedin_refresh_token",
                     exc_info=True,
                 )
 
@@ -363,6 +370,12 @@ class LinkedInPostNode(TaskNode):
         linkedin_version = str(configurable["linkedin_version"]).strip()
         visibility = str(configurable["visibility"]).strip().upper()
         commentary = str(configurable["commentary"]).strip()
+        if visibility not in _ALLOWED_VISIBILITY:
+            allowed_values = ", ".join(sorted(_ALLOWED_VISIBILITY))
+            raise ValueError(
+                "configurable.visibility must be one of "
+                f"{allowed_values}; received '{visibility}'."
+            )
 
         author_urn, person_id, organization_urn = await self.resolve_author_urn(
             state, config, configurable, access_token

--- a/src/orcheo/nodes/linkedin.py
+++ b/src/orcheo/nodes/linkedin.py
@@ -1,0 +1,430 @@
+"""LinkedIn node."""
+
+import base64
+import json
+import logging
+from collections.abc import Mapping
+from typing import Any
+from langchain_core.runnables import RunnableConfig
+from pydantic import Field
+from orcheo.graph.state import State
+from orcheo.nodes.base import TaskNode
+from orcheo.nodes.data import HttpRequestNode
+from orcheo.nodes.registry import NodeMetadata, registry
+from orcheo.runtime.credentials import (
+    get_active_credential_resolver,
+)
+
+
+logger = logging.getLogger(__name__)
+
+_ORG_ACLS_URL = "https://api.linkedin.com/rest/organizationAcls?q=roleAssignee"
+_POSTS_URL = "https://api.linkedin.com/rest/posts"
+_TOKEN_URL = "https://www.linkedin.com/oauth/v2/accessToken"
+_USERINFO_URL = "https://api.linkedin.com/v2/userinfo"
+
+
+class _LinkedInAuthError(Exception):
+    """Raised internally when a LinkedIn API call returns HTTP 401."""
+
+
+@registry.register(
+    NodeMetadata(
+        name="LinkedInPostNode",
+        description="Create a LinkedIn post using vault-backed access credentials.",
+        category="linkedin",
+    )
+)
+class LinkedInPostNode(TaskNode):
+    """Create a LinkedIn post using vault-backed access credentials."""
+
+    linkedin_access_token: str = Field(
+        default="[[linkedin_access_token]]",
+        description="LinkedIn access token stored in the Orcheo vault.",
+    )
+    linkedin_refresh_token: str = Field(
+        default="[[linkedin_refresh_token]]",
+        description="LinkedIn refresh token stored in the Orcheo vault.",
+    )
+    linkedin_id_token: str = Field(
+        default="[[linkedin_id_token]]",
+        description=(
+            "Optional LinkedIn OIDC id token stored in the Orcheo vault. "
+            "When present it is preferred over the userinfo endpoint for person posts."
+        ),
+    )
+    linkedin_client_id: str = Field(
+        default="[[linkedin_client_id]]",
+        description=(
+            "LinkedIn app client ID stored in the Orcheo vault. "
+            "Required to refresh an expired access token."
+        ),
+    )
+    linkedin_client_secret: str = Field(
+        default="[[linkedin_client_secret]]",
+        description=(
+            "LinkedIn app client secret stored in the Orcheo vault. "
+            "Required to refresh an expired access token."
+        ),
+    )
+    timeout: float = Field(default=30.0, ge=0.0, description="HTTP timeout in seconds.")
+
+    @staticmethod
+    def read_configurable(config: RunnableConfig) -> dict[str, Any]:
+        """Return configurable values with example defaults applied."""
+        defaults: dict[str, Any] = {
+            "commentary": "Hello from Orcheo.",
+            "linkedin_version": "202604",
+            "post_as": "person",
+            "visibility": "PUBLIC",
+        }
+        if not isinstance(config, Mapping):
+            return defaults
+        configurable = config.get("configurable", {})
+        if not isinstance(configurable, Mapping):
+            return defaults
+        return {**defaults, **dict(configurable)}
+
+    @staticmethod
+    def linkedin_headers(
+        access_token: str, linkedin_version: str, *, json_content: bool = True
+    ) -> dict[str, str]:
+        """Return LinkedIn API headers for the current request."""
+        headers = {
+            "Authorization": f"Bearer {access_token}",
+            "Linkedin-Version": linkedin_version,
+            "X-Restli-Protocol-Version": "2.0.0",
+        }
+        if json_content:
+            headers["Content-Type"] = "application/json"
+        return headers
+
+    @staticmethod
+    def create_post_payload(
+        author_urn: str, commentary: str, visibility: str
+    ) -> dict[str, Any]:
+        """Return the LinkedIn post payload."""
+        return {
+            "author": author_urn,
+            "commentary": commentary,
+            "visibility": visibility,
+            "distribution": {
+                "feedDistribution": "MAIN_FEED",
+                "targetEntities": [],
+                "thirdPartyDistributionChannels": [],
+            },
+            "lifecycleState": "PUBLISHED",
+            "isReshareDisabledByAuthor": False,
+        }
+
+    @staticmethod
+    def base64url_decode(input_str: str) -> bytes:
+        """Return decoded bytes for a base64url-encoded JWT segment."""
+        padding = "=" * (-len(input_str) % 4)
+        return base64.urlsafe_b64decode(input_str + padding)
+
+    @classmethod
+    def parse_jwt_payload(cls, jwt_token: str) -> dict[str, Any]:
+        """Return the decoded JWT payload."""
+        parts = jwt_token.split(".")
+        if len(parts) != 3:
+            raise ValueError("Invalid id_token format")
+        payload_json = cls.base64url_decode(parts[1]).decode("utf-8")
+        decoded = json.loads(payload_json)
+        if not isinstance(decoded, dict):
+            raise ValueError("Decoded id_token payload must be a JSON object")
+        return decoded
+
+    async def resolve_organization_urn(
+        self,
+        state: State,
+        config: RunnableConfig,
+        access_token: str,
+        linkedin_version: str,
+    ) -> str:
+        """Return the single approved organization URN for org posting."""
+        result = await HttpRequestNode(
+            name="resolve_organization_request",
+            method="GET",
+            url=_ORG_ACLS_URL,
+            headers=self.linkedin_headers(
+                access_token, linkedin_version, json_content=False
+            ),
+            timeout=self.timeout,
+        )(state, config)
+        payload = result["results"]["resolve_organization_request"]
+        if payload["status_code"] == 401:
+            raise _LinkedInAuthError("organizationAcls returned 401 Unauthorized")
+        if payload["status_code"] != 200:
+            raise ValueError(
+                "organizationAcls failed "
+                f"({payload['status_code']}): {payload['content']}. "
+                "Your LinkedIn app and token need the rw_organization_admin scope."
+            )
+
+        data = payload.get("json")
+        if not isinstance(data, Mapping):
+            raise ValueError("organizationAcls returned a non-JSON response")
+
+        urns: list[str] = []
+        for element in data.get("elements", []):
+            if not isinstance(element, Mapping):
+                continue
+            org = element.get("organization")
+            if isinstance(org, str) and element.get("state") == "APPROVED":
+                urns.append(org)
+
+        if not urns:
+            raise ValueError(
+                "No approved organization URNs found in organizationAcls. "
+                "Either grant the authenticated member an admin role on the "
+                "organization page or set configurable.organization_urn explicitly."
+            )
+        unique_urns = sorted(set(urns))
+        if len(unique_urns) > 1:
+            raise ValueError(
+                "Multiple approved organization URNs found: "
+                f"{', '.join(unique_urns)}. Set configurable.organization_urn to "
+                "choose one."
+            )
+        return unique_urns[0]
+
+    async def resolve_person_identity(
+        self,
+        state: State,
+        config: RunnableConfig,
+        access_token: str,
+        id_token: str = "",
+    ) -> tuple[str, str]:
+        """Return the LinkedIn person id and author URN from the OIDC userinfo API."""
+        configured_id_token = id_token.strip()
+        if configured_id_token:
+            payload = self.parse_jwt_payload(configured_id_token)
+            sub = payload.get("sub")
+            if isinstance(sub, str) and sub.strip():
+                person_id = sub.strip()
+                return person_id, f"urn:li:person:{person_id}"
+            raise ValueError("Could not resolve member id from id_token")
+
+        result = await HttpRequestNode(
+            name="resolve_person_request",
+            method="GET",
+            url=_USERINFO_URL,
+            headers={"Authorization": f"Bearer {access_token}"},
+            timeout=self.timeout,
+        )(state, config)
+        payload = result["results"]["resolve_person_request"]
+        if payload["status_code"] == 401:
+            raise _LinkedInAuthError("userinfo returned 401 Unauthorized")
+        if payload["status_code"] != 200:
+            raise ValueError(
+                "userinfo failed "
+                f"({payload['status_code']}): {payload['content']}. "
+                "To avoid calling userinfo, provide the linkedin_id_token vault "
+                "credential. Otherwise your LinkedIn app needs the "
+                "'Sign in with LinkedIn using OpenID Connect' product and the "
+                "matching OIDC scopes."
+            )
+
+        data = payload.get("json")
+        if not isinstance(data, Mapping):
+            raise ValueError("userinfo returned a non-JSON response")
+
+        sub = data.get("sub")
+        if not isinstance(sub, str) or not sub.strip():
+            raise ValueError("Could not resolve member id from OIDC userinfo")
+        person_id = sub.strip()
+        return person_id, f"urn:li:person:{person_id}"
+
+    async def resolve_author_urn(
+        self,
+        state: State,
+        config: RunnableConfig,
+        configurable: Mapping[str, Any],
+        access_token: str,
+    ) -> tuple[str, str | None, str | None]:
+        """Resolve author identity from token context."""
+        post_as = str(configurable["post_as"]).strip().lower()
+        if post_as == "organization":
+            organization_urn = await self.resolve_organization_urn(
+                state,
+                config,
+                access_token,
+                str(configurable["linkedin_version"]).strip(),
+            )
+            return organization_urn, None, organization_urn
+        if post_as == "person":
+            person_id, author_urn = await self.resolve_person_identity(
+                state,
+                config,
+                access_token,
+                self.linkedin_id_token,
+            )
+            return author_urn, person_id, None
+        raise ValueError(
+            "configurable.post_as must be either 'person' or 'organization'"
+        )
+
+    async def refresh_access_token(
+        self, state: State, config: RunnableConfig
+    ) -> tuple[str, str | None]:
+        """Exchange the refresh token for a new access token via the LinkedIn token endpoint."""  # noqa: E501
+        client_id = self.linkedin_client_id.strip()
+        client_secret = self.linkedin_client_secret.strip()
+        if not client_id or not client_secret:
+            raise ValueError(
+                "linkedin_client_id and linkedin_client_secret vault credentials are "
+                "required to refresh an expired access token. Add these credentials "
+                "or renew the access token manually."
+            )
+        result = await HttpRequestNode(
+            name="refresh_token_request",
+            method="POST",
+            url=_TOKEN_URL,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": self.linkedin_refresh_token.strip(),
+                "client_id": client_id,
+                "client_secret": client_secret,
+            },
+            timeout=self.timeout,
+        )(state, config)
+        payload = result["results"]["refresh_token_request"]
+        if payload["status_code"] != 200:
+            raise ValueError(
+                f"Token refresh failed ({payload['status_code']}): {payload['content']}"
+            )
+        data = payload.get("json")
+        if not isinstance(data, Mapping):
+            raise ValueError("Token refresh returned a non-JSON response")
+        new_access_token = data.get("access_token")
+        if not isinstance(new_access_token, str) or not new_access_token.strip():
+            raise ValueError("Token refresh response missing access_token")
+        new_refresh_token = data.get("refresh_token")
+        if not isinstance(new_refresh_token, str) or not new_refresh_token.strip():
+            new_refresh_token = None
+        return new_access_token.strip(), new_refresh_token
+
+    def _update_vault_tokens(
+        self, new_access_token: str, new_refresh_token: str | None
+    ) -> None:
+        """Write refreshed tokens back to the vault when a resolver is active."""
+        resolver = get_active_credential_resolver()
+        if resolver is None:
+            logger.warning(
+                "No active credential resolver; refreshed LinkedIn tokens will not "
+                "be persisted to the vault."
+            )
+            return
+
+        try:
+            updated = resolver.persist_refreshed_tokens(
+                "linkedin_access_token",
+                new_access_token=new_access_token,
+                new_refresh_token=new_refresh_token,
+                fallback_refresh_token=self.linkedin_refresh_token or None,
+                actor="linkedin_node",
+            )
+            if not updated:
+                logger.warning(
+                    "Credential 'linkedin_access_token' not found in vault by name; "
+                    "the refreshed access token will not be persisted."
+                )
+        except Exception:
+            logger.warning(
+                "Failed to update 'linkedin_access_token' in vault after "
+                "token refresh.",
+                exc_info=True,
+            )
+
+        if new_refresh_token:
+            try:
+                resolver.persist_refreshed_tokens(
+                    "linkedin_refresh_token",
+                    new_access_token=new_refresh_token,
+                    actor="linkedin_node",
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to update 'linkedin_refresh_token' in vault after token "
+                    "refresh.",
+                    exc_info=True,
+                )
+
+    async def _attempt_post(
+        self,
+        state: State,
+        config: RunnableConfig,
+        access_token: str,
+        configurable: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        """Resolve author and create the post; raises _LinkedInAuthError on HTTP 401."""
+        linkedin_version = str(configurable["linkedin_version"]).strip()
+        visibility = str(configurable["visibility"]).strip().upper()
+        commentary = str(configurable["commentary"]).strip()
+
+        author_urn, person_id, organization_urn = await self.resolve_author_urn(
+            state, config, configurable, access_token
+        )
+        result = await HttpRequestNode(
+            name="create_post_request",
+            method="POST",
+            url=_POSTS_URL,
+            headers=self.linkedin_headers(access_token, linkedin_version),
+            json_body=self.create_post_payload(author_urn, commentary, visibility),
+            timeout=self.timeout,
+        )(state, config)
+        response = result["results"]["create_post_request"]
+
+        if response["status_code"] == 401:
+            raise _LinkedInAuthError("Post creation returned 401 Unauthorized")
+        if response["status_code"] != 201:
+            raise ValueError(
+                f"Post creation failed ({response['status_code']}): "
+                f"{response['content']}"
+            )
+
+        return {
+            "author_urn": author_urn,
+            "organization_urn": organization_urn,
+            "person_id": person_id,
+            "post_id": response["headers"].get("x-restli-id", ""),
+            "post_as": str(configurable["post_as"]).strip().lower(),
+            "refresh_token_configured": True,
+            "status_code": response["status_code"],
+        }
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Create the LinkedIn post, refreshing the access token on 401 if needed."""
+        access_token = self.linkedin_access_token.strip()
+        refresh_token = self.linkedin_refresh_token.strip()
+        if not access_token:
+            raise ValueError("Vault credential 'linkedin_access_token' is required")
+        if not refresh_token:
+            raise ValueError("Vault credential 'linkedin_refresh_token' is required")
+
+        configurable = self.read_configurable(config)
+        commentary = str(configurable["commentary"]).strip()
+        if not commentary:
+            raise ValueError("configurable.commentary is required")
+
+        try:
+            return await self._attempt_post(state, config, access_token, configurable)
+        except _LinkedInAuthError:
+            new_access_token, new_refresh_token = await self.refresh_access_token(
+                state, config
+            )
+            self._update_vault_tokens(new_access_token, new_refresh_token)
+            try:
+                return await self._attempt_post(
+                    state, config, new_access_token, configurable
+                )
+            except _LinkedInAuthError as err:
+                raise ValueError(
+                    "LinkedIn API returned 401 Unauthorized even after token refresh. "
+                    "The credentials may have been revoked."
+                ) from err
+
+
+__all__ = ["LinkedInPostNode"]

--- a/src/orcheo/runtime/credentials/resolver.py
+++ b/src/orcheo/runtime/credentials/resolver.py
@@ -176,11 +176,17 @@ class CredentialResolver:
                 refresh_token=new_refresh_token or fallback_refresh_token,
             )
             self._vault.update_oauth_tokens(
-                credential_id=metadata.id, tokens=tokens, actor=actor
+                credential_id=metadata.id,
+                tokens=tokens,
+                actor=actor,
+                context=self._context,
             )
         else:
             self._vault.update_credential(
-                credential_id=metadata.id, actor=actor, secret=new_access_token
+                credential_id=metadata.id,
+                actor=actor,
+                secret=new_access_token,
+                context=self._context,
             )
         return True
 

--- a/src/orcheo/runtime/credentials/resolver.py
+++ b/src/orcheo/runtime/credentials/resolver.py
@@ -147,5 +147,42 @@ class CredentialResolver:
             return None
         return tokens.model_copy(deep=True)
 
+    def persist_refreshed_tokens(
+        self,
+        identifier: str,
+        *,
+        new_access_token: str,
+        new_refresh_token: str | None = None,
+        fallback_refresh_token: str | None = None,
+        actor: str = "system",
+    ) -> bool:
+        """Write refreshed OAuth tokens back to the vault.
+
+        Locates the credential by *identifier* (name or UUID) and updates it:
+        - OAUTH kind: replaces ``access_token`` and (if available) ``refresh_token``.
+        - SECRET kind: rotates the stored secret to *new_access_token*.
+
+        Returns ``True`` when the credential was found and updated, ``False`` when it
+        could not be located (e.g. custom credential name).  Other vault errors are
+        propagated to the caller.
+        """
+        try:
+            metadata = self._locate_metadata(identifier)
+        except (CredentialReferenceNotFoundError, DuplicateCredentialReferenceError):
+            return False
+        if metadata.kind is CredentialKind.OAUTH:
+            tokens = OAuthTokenSecrets(
+                access_token=new_access_token,
+                refresh_token=new_refresh_token or fallback_refresh_token,
+            )
+            self._vault.update_oauth_tokens(
+                credential_id=metadata.id, tokens=tokens, actor=actor
+            )
+        else:
+            self._vault.update_credential(
+                credential_id=metadata.id, actor=actor, secret=new_access_token
+            )
+        return True
+
 
 __all__ = ["CredentialResolver"]

--- a/tests/graph/test_ingestion_sandbox.py
+++ b/tests/graph/test_ingestion_sandbox.py
@@ -155,6 +155,16 @@ def test_create_sandbox_namespace_allows_asyncio_import() -> None:
     assert module is importlib.import_module("asyncio")
 
 
+def test_create_sandbox_namespace_allows_base64_import() -> None:
+    """Ensure restricted imports allow the base64 module."""
+    namespace = sandbox.create_sandbox_namespace()
+    restricted_import = namespace["__builtins__"]["__import__"]
+
+    module = restricted_import("base64")
+
+    assert module is importlib.import_module("base64")
+
+
 def test_create_sandbox_namespace_allows_submodule_prefix_import() -> None:
     """Ensure allow-listed prefixes include submodule imports."""
     namespace = sandbox.create_sandbox_namespace()

--- a/tests/nodes/test_linkedin.py
+++ b/tests/nodes/test_linkedin.py
@@ -389,6 +389,28 @@ async def test_resolve_author_urn_organization(node: LinkedInPostNode) -> None:
 
 
 @pytest.mark.asyncio
+async def test_resolve_author_urn_organization_uses_configurable_urn(
+    node: LinkedInPostNode,
+) -> None:
+    configurable = {
+        "post_as": "organization",
+        "linkedin_version": "202604",
+        "organization_urn": "urn:li:organization:999",
+    }
+    with patch.object(
+        LinkedInPostNode, "resolve_organization_urn", new_callable=AsyncMock
+    ) as mock_resolve:
+        author_urn, person_id, org_urn = await node.resolve_author_urn(
+            {}, None, configurable, "tok"
+        )
+
+    mock_resolve.assert_not_awaited()
+    assert author_urn == "urn:li:organization:999"
+    assert person_id is None
+    assert org_urn == "urn:li:organization:999"
+
+
+@pytest.mark.asyncio
 async def test_resolve_author_urn_invalid_post_as(node: LinkedInPostNode) -> None:
     configurable = {
         "post_as": "company",
@@ -454,6 +476,15 @@ async def test_run_missing_refresh_token_raises(node: LinkedInPostNode) -> None:
 async def test_run_empty_commentary_raises(node: LinkedInPostNode) -> None:
     config = {"configurable": {"commentary": "   "}}
     with pytest.raises(ValueError, match="commentary is required"):
+        await node.run({}, config)
+
+
+@pytest.mark.asyncio
+async def test_run_invalid_visibility_raises(node: LinkedInPostNode) -> None:
+    jwt = _make_jwt({"sub": "person1"})
+    node.linkedin_id_token = jwt
+    config = {"configurable": {"commentary": "Test", "visibility": "EVERYONE"}}
+    with pytest.raises(ValueError, match="configurable.visibility must be one of"):
         await node.run({}, config)
 
 

--- a/tests/nodes/test_linkedin.py
+++ b/tests/nodes/test_linkedin.py
@@ -1,0 +1,672 @@
+"""Tests for LinkedInPostNode."""
+
+import base64
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+import pytest
+from orcheo.nodes.linkedin import LinkedInPostNode, _LinkedInAuthError
+
+
+def _make_jwt(payload: dict[str, Any]) -> str:
+    """Return a minimal JWT string with the given payload."""
+    header = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode()
+    body = base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=").decode()
+    return f"{header}.{body}.sig"
+
+
+def _mock_http_node(return_value: dict[str, Any]) -> MagicMock:
+    """Return a mock that replaces HttpRequestNode and returns the given value."""
+    instance = AsyncMock(return_value=return_value)
+    cls = MagicMock(return_value=instance)
+    return cls
+
+
+@pytest.fixture
+def node() -> LinkedInPostNode:
+    return LinkedInPostNode(
+        name="post_linkedin",
+        linkedin_access_token="access-tok",
+        linkedin_refresh_token="refresh-tok",
+        linkedin_id_token="",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Static / class method unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_base64url_decode_no_padding() -> None:
+    raw = base64.urlsafe_b64encode(b"hello").rstrip(b"=").decode()
+    assert LinkedInPostNode.base64url_decode(raw) == b"hello"
+
+
+def test_parse_jwt_payload_valid() -> None:
+    jwt = _make_jwt({"sub": "abc123"})
+    assert LinkedInPostNode.parse_jwt_payload(jwt) == {"sub": "abc123"}
+
+
+def test_parse_jwt_payload_invalid_format() -> None:
+    with pytest.raises(ValueError, match="Invalid id_token format"):
+        LinkedInPostNode.parse_jwt_payload("only.two")
+
+
+def test_parse_jwt_payload_non_object_payload() -> None:
+    header = base64.urlsafe_b64encode(b"{}").rstrip(b"=").decode()
+    body = base64.urlsafe_b64encode(b'"string"').rstrip(b"=").decode()
+    with pytest.raises(ValueError, match="must be a JSON object"):
+        LinkedInPostNode.parse_jwt_payload(f"{header}.{body}.sig")
+
+
+def test_read_configurable_defaults_when_not_mapping() -> None:
+    result = LinkedInPostNode.read_configurable(None)  # type: ignore[arg-type]
+    assert result["post_as"] == "person"
+    assert result["visibility"] == "PUBLIC"
+
+
+def test_read_configurable_defaults_when_configurable_not_mapping() -> None:
+    result = LinkedInPostNode.read_configurable({"configurable": "not-a-mapping"})  # type: ignore[arg-type]
+    assert result["post_as"] == "person"
+    assert result["visibility"] == "PUBLIC"
+
+
+def test_read_configurable_merges_overrides() -> None:
+    config = {"configurable": {"commentary": "Custom post", "post_as": "organization"}}
+    result = LinkedInPostNode.read_configurable(config)
+    assert result["commentary"] == "Custom post"
+    assert result["post_as"] == "organization"
+    assert result["linkedin_version"] == "202604"
+
+
+def test_linkedin_headers_with_json_content() -> None:
+    h = LinkedInPostNode.linkedin_headers("tok", "202604")
+    assert h["Authorization"] == "Bearer tok"
+    assert h["Content-Type"] == "application/json"
+    assert h["Linkedin-Version"] == "202604"
+
+
+def test_linkedin_headers_without_json_content() -> None:
+    h = LinkedInPostNode.linkedin_headers("tok", "202604", json_content=False)
+    assert "Content-Type" not in h
+
+
+def test_create_post_payload_structure() -> None:
+    payload = LinkedInPostNode.create_post_payload(
+        "urn:li:person:X", "Hello!", "PUBLIC"
+    )
+    assert payload["author"] == "urn:li:person:X"
+    assert payload["commentary"] == "Hello!"
+    assert payload["visibility"] == "PUBLIC"
+    assert payload["lifecycleState"] == "PUBLISHED"
+
+
+# ---------------------------------------------------------------------------
+# resolve_person_identity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_person_identity_from_id_token(node: LinkedInPostNode) -> None:
+    jwt = _make_jwt({"sub": "person123"})
+    person_id, author_urn = await node.resolve_person_identity({}, None, "tok", jwt)
+    assert person_id == "person123"
+    assert author_urn == "urn:li:person:person123"
+
+
+@pytest.mark.asyncio
+async def test_resolve_person_identity_id_token_missing_sub(
+    node: LinkedInPostNode,
+) -> None:
+    jwt = _make_jwt({"name": "Alice"})
+    with pytest.raises(ValueError, match="Could not resolve member id from id_token"):
+        await node.resolve_person_identity({}, None, "tok", jwt)
+
+
+@pytest.mark.asyncio
+async def test_resolve_person_identity_from_userinfo(node: LinkedInPostNode) -> None:
+    http_result = {
+        "results": {
+            "resolve_person_request": {
+                "status_code": 200,
+                "json": {"sub": "person456"},
+            }
+        }
+    }
+    with patch("orcheo.nodes.linkedin.HttpRequestNode", _mock_http_node(http_result)):
+        person_id, author_urn = await node.resolve_person_identity({}, None, "tok", "")
+    assert person_id == "person456"
+    assert author_urn == "urn:li:person:person456"
+
+
+@pytest.mark.asyncio
+async def test_resolve_person_identity_userinfo_401_raises_auth_error(
+    node: LinkedInPostNode,
+) -> None:
+    http_result = {
+        "results": {
+            "resolve_person_request": {
+                "status_code": 401,
+                "content": "Unauthorized",
+            }
+        }
+    }
+    with patch("orcheo.nodes.linkedin.HttpRequestNode", _mock_http_node(http_result)):
+        with pytest.raises(_LinkedInAuthError):
+            await node.resolve_person_identity({}, None, "tok", "")
+
+
+@pytest.mark.asyncio
+async def test_resolve_person_identity_userinfo_bad_status(
+    node: LinkedInPostNode,
+) -> None:
+    http_result = {
+        "results": {
+            "resolve_person_request": {
+                "status_code": 403,
+                "content": "Forbidden",
+            }
+        }
+    }
+    with patch("orcheo.nodes.linkedin.HttpRequestNode", _mock_http_node(http_result)):
+        with pytest.raises(ValueError, match="userinfo failed"):
+            await node.resolve_person_identity({}, None, "tok", "")
+
+
+@pytest.mark.asyncio
+async def test_resolve_person_identity_userinfo_non_json(
+    node: LinkedInPostNode,
+) -> None:
+    http_result = {
+        "results": {
+            "resolve_person_request": {
+                "status_code": 200,
+                "json": None,
+            }
+        }
+    }
+    with patch("orcheo.nodes.linkedin.HttpRequestNode", _mock_http_node(http_result)):
+        with pytest.raises(ValueError, match="non-JSON response"):
+            await node.resolve_person_identity({}, None, "tok", "")
+
+
+@pytest.mark.asyncio
+async def test_resolve_person_identity_userinfo_missing_sub(
+    node: LinkedInPostNode,
+) -> None:
+    http_result = {
+        "results": {
+            "resolve_person_request": {
+                "status_code": 200,
+                "json": {"name": "Alice"},
+            }
+        }
+    }
+    with patch("orcheo.nodes.linkedin.HttpRequestNode", _mock_http_node(http_result)):
+        with pytest.raises(ValueError, match="Could not resolve member id"):
+            await node.resolve_person_identity({}, None, "tok", "")
+
+
+# ---------------------------------------------------------------------------
+# resolve_organization_urn
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_organization_urn_success(node: LinkedInPostNode) -> None:
+    http_result = {
+        "results": {
+            "resolve_organization_request": {
+                "status_code": 200,
+                "json": {
+                    "elements": [
+                        {"organization": "urn:li:organization:123", "state": "APPROVED"}
+                    ]
+                },
+            }
+        }
+    }
+    with patch("orcheo.nodes.linkedin.HttpRequestNode", _mock_http_node(http_result)):
+        urn = await node.resolve_organization_urn({}, None, "tok", "202604")
+    assert urn == "urn:li:organization:123"
+
+
+@pytest.mark.asyncio
+async def test_resolve_organization_urn_401_raises_auth_error(
+    node: LinkedInPostNode,
+) -> None:
+    http_result = {
+        "results": {
+            "resolve_organization_request": {
+                "status_code": 401,
+                "content": "Unauthorized",
+            }
+        }
+    }
+    with patch("orcheo.nodes.linkedin.HttpRequestNode", _mock_http_node(http_result)):
+        with pytest.raises(_LinkedInAuthError):
+            await node.resolve_organization_urn({}, None, "tok", "202604")
+
+
+@pytest.mark.asyncio
+async def test_resolve_organization_urn_bad_status(node: LinkedInPostNode) -> None:
+    http_result = {
+        "results": {
+            "resolve_organization_request": {
+                "status_code": 403,
+                "content": "Forbidden",
+            }
+        }
+    }
+    with patch("orcheo.nodes.linkedin.HttpRequestNode", _mock_http_node(http_result)):
+        with pytest.raises(ValueError, match="organizationAcls failed"):
+            await node.resolve_organization_urn({}, None, "tok", "202604")
+
+
+@pytest.mark.asyncio
+async def test_resolve_organization_urn_no_approved(node: LinkedInPostNode) -> None:
+    http_result = {
+        "results": {
+            "resolve_organization_request": {
+                "status_code": 200,
+                "json": {"elements": []},
+            }
+        }
+    }
+    with patch("orcheo.nodes.linkedin.HttpRequestNode", _mock_http_node(http_result)):
+        with pytest.raises(ValueError, match="No approved organization URNs"):
+            await node.resolve_organization_urn({}, None, "tok", "202604")
+
+
+@pytest.mark.asyncio
+async def test_resolve_organization_urn_multiple(node: LinkedInPostNode) -> None:
+    http_result = {
+        "results": {
+            "resolve_organization_request": {
+                "status_code": 200,
+                "json": {
+                    "elements": [
+                        {"organization": "urn:li:organization:1", "state": "APPROVED"},
+                        {"organization": "urn:li:organization:2", "state": "APPROVED"},
+                    ]
+                },
+            }
+        }
+    }
+    with patch("orcheo.nodes.linkedin.HttpRequestNode", _mock_http_node(http_result)):
+        with pytest.raises(ValueError, match="Multiple approved organization URNs"):
+            await node.resolve_organization_urn({}, None, "tok", "202604")
+
+
+@pytest.mark.asyncio
+async def test_resolve_organization_urn_non_mapping_element_skipped(
+    node: LinkedInPostNode,
+) -> None:
+    """Elements that are not Mappings should be skipped; a valid element still wins."""
+    http_result = {
+        "results": {
+            "resolve_organization_request": {
+                "status_code": 200,
+                "json": {
+                    "elements": [
+                        "not-a-mapping",
+                        {"organization": "urn:li:organization:99", "state": "APPROVED"},
+                    ]
+                },
+            }
+        }
+    }
+    with patch("orcheo.nodes.linkedin.HttpRequestNode", _mock_http_node(http_result)):
+        urn = await node.resolve_organization_urn({}, None, "tok", "202604")
+    assert urn == "urn:li:organization:99"
+
+
+@pytest.mark.asyncio
+async def test_resolve_organization_urn_element_wrong_state_skipped(
+    node: LinkedInPostNode,
+) -> None:
+    """Elements with state != 'APPROVED' should not be included in the URN list."""
+    http_result = {
+        "results": {
+            "resolve_organization_request": {
+                "status_code": 200,
+                "json": {
+                    "elements": [
+                        {"organization": "urn:li:organization:1", "state": "PENDING"},
+                        {"organization": "urn:li:organization:2", "state": "APPROVED"},
+                    ]
+                },
+            }
+        }
+    }
+    with patch("orcheo.nodes.linkedin.HttpRequestNode", _mock_http_node(http_result)):
+        urn = await node.resolve_organization_urn({}, None, "tok", "202604")
+    assert urn == "urn:li:organization:2"
+
+
+@pytest.mark.asyncio
+async def test_resolve_organization_urn_non_json(node: LinkedInPostNode) -> None:
+    http_result = {
+        "results": {
+            "resolve_organization_request": {
+                "status_code": 200,
+                "json": None,
+            }
+        }
+    }
+    with patch("orcheo.nodes.linkedin.HttpRequestNode", _mock_http_node(http_result)):
+        with pytest.raises(ValueError, match="non-JSON response"):
+            await node.resolve_organization_urn({}, None, "tok", "202604")
+
+
+# ---------------------------------------------------------------------------
+# resolve_author_urn
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_author_urn_organization(node: LinkedInPostNode) -> None:
+    http_result = {
+        "results": {
+            "resolve_organization_request": {
+                "status_code": 200,
+                "json": {
+                    "elements": [
+                        {"organization": "urn:li:organization:42", "state": "APPROVED"}
+                    ]
+                },
+            }
+        }
+    }
+    configurable = {"post_as": "organization", "linkedin_version": "202604"}
+    with patch("orcheo.nodes.linkedin.HttpRequestNode", _mock_http_node(http_result)):
+        author_urn, person_id, org_urn = await node.resolve_author_urn(
+            {}, None, configurable, "tok"
+        )
+    assert author_urn == "urn:li:organization:42"
+    assert person_id is None
+    assert org_urn == "urn:li:organization:42"
+
+
+@pytest.mark.asyncio
+async def test_resolve_author_urn_invalid_post_as(node: LinkedInPostNode) -> None:
+    configurable = {
+        "post_as": "company",
+        "linkedin_version": "202604",
+    }
+    with pytest.raises(ValueError, match="post_as must be either"):
+        await node.resolve_author_urn({}, None, configurable, "tok")
+
+
+# ---------------------------------------------------------------------------
+# run — happy paths and error paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_person_post_success(node: LinkedInPostNode) -> None:
+    jwt = _make_jwt({"sub": "person789"})
+    node.linkedin_id_token = jwt
+
+    create_result = {
+        "results": {
+            "create_post_request": {
+                "status_code": 201,
+                "headers": {"x-restli-id": "post-abc"},
+                "content": "",
+            }
+        }
+    }
+    config = {
+        "configurable": {
+            "commentary": "Hello LinkedIn!",
+            "post_as": "person",
+            "visibility": "PUBLIC",
+            "linkedin_version": "202604",
+        }
+    }
+    with patch("orcheo.nodes.linkedin.HttpRequestNode", _mock_http_node(create_result)):
+        result = await node.run({}, config)
+
+    assert result["post_id"] == "post-abc"
+    assert result["post_as"] == "person"
+    assert result["person_id"] == "person789"
+    assert result["organization_urn"] is None
+    assert result["refresh_token_configured"] is True
+    assert result["status_code"] == 201
+
+
+@pytest.mark.asyncio
+async def test_run_missing_access_token_raises(node: LinkedInPostNode) -> None:
+    node.linkedin_access_token = ""
+    with pytest.raises(ValueError, match="linkedin_access_token"):
+        await node.run({}, {})
+
+
+@pytest.mark.asyncio
+async def test_run_missing_refresh_token_raises(node: LinkedInPostNode) -> None:
+    node.linkedin_refresh_token = ""
+    with pytest.raises(ValueError, match="linkedin_refresh_token"):
+        await node.run({}, {})
+
+
+@pytest.mark.asyncio
+async def test_run_empty_commentary_raises(node: LinkedInPostNode) -> None:
+    config = {"configurable": {"commentary": "   "}}
+    with pytest.raises(ValueError, match="commentary is required"):
+        await node.run({}, config)
+
+
+@pytest.mark.asyncio
+async def test_run_post_creation_failed_raises(node: LinkedInPostNode) -> None:
+    jwt = _make_jwt({"sub": "person1"})
+    node.linkedin_id_token = jwt
+
+    create_result = {
+        "results": {
+            "create_post_request": {
+                "status_code": 422,
+                "headers": {},
+                "content": "Unprocessable Entity",
+            }
+        }
+    }
+    config = {"configurable": {"commentary": "Test post"}}
+    with patch("orcheo.nodes.linkedin.HttpRequestNode", _mock_http_node(create_result)):
+        with pytest.raises(ValueError, match="Post creation failed"):
+            await node.run({}, config)
+
+
+# ---------------------------------------------------------------------------
+# refresh_access_token
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_access_token_success(node: LinkedInPostNode) -> None:
+    node.linkedin_client_id = "client-id"
+    node.linkedin_client_secret = "client-secret"
+
+    refresh_result = {
+        "results": {
+            "refresh_token_request": {
+                "status_code": 200,
+                "json": {
+                    "access_token": "new-access-tok",
+                    "refresh_token": "new-refresh-tok",
+                },
+                "content": "",
+            }
+        }
+    }
+    with patch(
+        "orcheo.nodes.linkedin.HttpRequestNode", _mock_http_node(refresh_result)
+    ):
+        new_access, new_refresh = await node.refresh_access_token({}, None)
+    assert new_access == "new-access-tok"
+    assert new_refresh == "new-refresh-tok"
+
+
+@pytest.mark.asyncio
+async def test_refresh_access_token_no_new_refresh_token(
+    node: LinkedInPostNode,
+) -> None:
+    node.linkedin_client_id = "client-id"
+    node.linkedin_client_secret = "client-secret"
+
+    refresh_result = {
+        "results": {
+            "refresh_token_request": {
+                "status_code": 200,
+                "json": {"access_token": "new-access-tok"},
+                "content": "",
+            }
+        }
+    }
+    with patch(
+        "orcheo.nodes.linkedin.HttpRequestNode", _mock_http_node(refresh_result)
+    ):
+        new_access, new_refresh = await node.refresh_access_token({}, None)
+    assert new_access == "new-access-tok"
+    assert new_refresh is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_access_token_missing_client_credentials_raises(
+    node: LinkedInPostNode,
+) -> None:
+    node.linkedin_client_id = ""
+    node.linkedin_client_secret = ""
+    with pytest.raises(ValueError, match="linkedin_client_id"):
+        await node.refresh_access_token({}, None)
+
+
+@pytest.mark.asyncio
+async def test_refresh_access_token_bad_status_raises(node: LinkedInPostNode) -> None:
+    node.linkedin_client_id = "client-id"
+    node.linkedin_client_secret = "client-secret"
+
+    refresh_result = {
+        "results": {
+            "refresh_token_request": {
+                "status_code": 400,
+                "json": None,
+                "content": "invalid_grant",
+            }
+        }
+    }
+    with patch(
+        "orcheo.nodes.linkedin.HttpRequestNode", _mock_http_node(refresh_result)
+    ):
+        with pytest.raises(ValueError, match="Token refresh failed"):
+            await node.refresh_access_token({}, None)
+
+
+# ---------------------------------------------------------------------------
+# run — token refresh retry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_retries_after_401_on_post_creation(node: LinkedInPostNode) -> None:
+    """A 401 on post creation triggers token refresh and a successful retry."""
+    jwt = _make_jwt({"sub": "person1"})
+    node.linkedin_id_token = jwt
+    node.linkedin_client_id = "client-id"
+    node.linkedin_client_secret = "client-secret"
+
+    call_count = 0
+
+    async def _side_effect(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # First post attempt → 401
+            return {
+                "results": {
+                    "create_post_request": {
+                        "status_code": 401,
+                        "headers": {},
+                        "content": "Unauthorized",
+                    }
+                }
+            }
+        if call_count == 2:
+            # Token refresh call
+            return {
+                "results": {
+                    "refresh_token_request": {
+                        "status_code": 200,
+                        "json": {"access_token": "new-tok"},
+                        "content": "",
+                    }
+                }
+            }
+        # Second post attempt → success
+        return {
+            "results": {
+                "create_post_request": {
+                    "status_code": 201,
+                    "headers": {"x-restli-id": "post-xyz"},
+                    "content": "",
+                }
+            }
+        }
+
+    mock_instance = AsyncMock(side_effect=_side_effect)
+    mock_cls = MagicMock(return_value=mock_instance)
+
+    config = {"configurable": {"commentary": "Retry post"}}
+    with patch("orcheo.nodes.linkedin.HttpRequestNode", mock_cls):
+        with patch(
+            "orcheo.nodes.linkedin.get_active_credential_resolver", return_value=None
+        ):
+            result = await node.run({}, config)
+
+    assert result["post_id"] == "post-xyz"
+    assert result["status_code"] == 201
+
+
+@pytest.mark.asyncio
+async def test_run_raises_after_401_persists_on_retry(node: LinkedInPostNode) -> None:
+    """If the retry also returns 401 after refresh, a descriptive ValueError is raised."""  # noqa: E501
+    jwt = _make_jwt({"sub": "person1"})
+    node.linkedin_id_token = jwt
+    node.linkedin_client_id = "client-id"
+    node.linkedin_client_secret = "client-secret"
+
+    call_count = 0
+
+    async def _side_effect(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 2:
+            return {
+                "results": {
+                    "refresh_token_request": {
+                        "status_code": 200,
+                        "json": {"access_token": "new-tok"},
+                        "content": "",
+                    }
+                }
+            }
+        return {
+            "results": {
+                "create_post_request": {
+                    "status_code": 401,
+                    "headers": {},
+                    "content": "Unauthorized",
+                }
+            }
+        }
+
+    mock_instance = AsyncMock(side_effect=_side_effect)
+    mock_cls = MagicMock(return_value=mock_instance)
+
+    config = {"configurable": {"commentary": "Retry post"}}
+    with patch("orcheo.nodes.linkedin.HttpRequestNode", mock_cls):
+        with patch(
+            "orcheo.nodes.linkedin.get_active_credential_resolver", return_value=None
+        ):
+            with pytest.raises(ValueError, match="even after token refresh"):
+                await node.run({}, config)

--- a/tests/nodes/test_linkedin.py
+++ b/tests/nodes/test_linkedin.py
@@ -593,6 +593,127 @@ async def test_refresh_access_token_bad_status_raises(node: LinkedInPostNode) ->
             await node.refresh_access_token({}, None)
 
 
+@pytest.mark.asyncio
+async def test_refresh_access_token_non_json_response_raises(
+    node: LinkedInPostNode,
+) -> None:
+    node.linkedin_client_id = "client-id"
+    node.linkedin_client_secret = "client-secret"
+
+    refresh_result = {
+        "results": {
+            "refresh_token_request": {
+                "status_code": 200,
+                "json": None,
+                "content": "",
+            }
+        }
+    }
+    with patch(
+        "orcheo.nodes.linkedin.HttpRequestNode", _mock_http_node(refresh_result)
+    ):
+        with pytest.raises(ValueError, match="non-JSON response"):
+            await node.refresh_access_token({}, None)
+
+
+@pytest.mark.asyncio
+async def test_refresh_access_token_missing_access_token_raises(
+    node: LinkedInPostNode,
+) -> None:
+    node.linkedin_client_id = "client-id"
+    node.linkedin_client_secret = "client-secret"
+
+    refresh_result = {
+        "results": {
+            "refresh_token_request": {
+                "status_code": 200,
+                "json": {"refresh_token": "some-refresh"},
+                "content": "",
+            }
+        }
+    }
+    with patch(
+        "orcheo.nodes.linkedin.HttpRequestNode", _mock_http_node(refresh_result)
+    ):
+        with pytest.raises(ValueError, match="missing access_token"):
+            await node.refresh_access_token({}, None)
+
+
+# ---------------------------------------------------------------------------
+# _update_vault_tokens — active resolver paths
+# ---------------------------------------------------------------------------
+
+
+def test_update_vault_tokens_resolver_persists_access_token(
+    node: LinkedInPostNode,
+) -> None:
+    """With an active resolver, both tokens are persisted successfully."""
+    resolver = MagicMock()
+    resolver.persist_refreshed_tokens.return_value = True
+
+    with patch(
+        "orcheo.nodes.linkedin.get_active_credential_resolver", return_value=resolver
+    ):
+        node._update_vault_tokens("new-access", "new-refresh")
+
+    assert resolver.persist_refreshed_tokens.call_count == 2
+    first_call_kwargs = resolver.persist_refreshed_tokens.call_args_list[0].kwargs
+    assert first_call_kwargs["new_access_token"] == "new-access"
+    second_call_kwargs = resolver.persist_refreshed_tokens.call_args_list[1].kwargs
+    assert second_call_kwargs["new_access_token"] == "new-refresh"
+
+
+def test_update_vault_tokens_resolver_not_updated_logs_warning(
+    node: LinkedInPostNode,
+) -> None:
+    """When persist_refreshed_tokens returns False, a warning is logged."""
+    resolver = MagicMock()
+    resolver.persist_refreshed_tokens.return_value = False
+
+    with patch(
+        "orcheo.nodes.linkedin.get_active_credential_resolver", return_value=resolver
+    ):
+        with patch("orcheo.nodes.linkedin.logger") as mock_logger:
+            node._update_vault_tokens("new-access", None)
+
+    mock_logger.warning.assert_called()
+    warning_msg = mock_logger.warning.call_args_list[0].args[0]
+    assert "not found in vault" in warning_msg
+
+
+def test_update_vault_tokens_resolver_persist_raises_logs_warning(
+    node: LinkedInPostNode,
+) -> None:
+    """When persist_refreshed_tokens raises, a warning is logged and no exception propagates."""  # noqa: E501
+    resolver = MagicMock()
+    resolver.persist_refreshed_tokens.side_effect = Exception("vault error")
+
+    with patch(
+        "orcheo.nodes.linkedin.get_active_credential_resolver", return_value=resolver
+    ):
+        with patch("orcheo.nodes.linkedin.logger") as mock_logger:
+            node._update_vault_tokens("new-access", None)  # must not raise
+
+    mock_logger.warning.assert_called()
+
+
+def test_update_vault_tokens_refresh_token_persist_raises_logs_warning(
+    node: LinkedInPostNode,
+) -> None:
+    """When persisting the refresh token raises, a warning is logged."""
+    resolver = MagicMock()
+    resolver.persist_refreshed_tokens.side_effect = [True, Exception("vault error")]
+
+    with patch(
+        "orcheo.nodes.linkedin.get_active_credential_resolver", return_value=resolver
+    ):
+        with patch("orcheo.nodes.linkedin.logger") as mock_logger:
+            node._update_vault_tokens("new-access", "new-refresh")  # must not raise
+
+    assert resolver.persist_refreshed_tokens.call_count == 2
+    assert mock_logger.warning.called
+
+
 # ---------------------------------------------------------------------------
 # run — token refresh retry
 # ---------------------------------------------------------------------------

--- a/tests/plugin_fixtures/partial_register_plugin/src/orcheo_plugin_fixture_partial_register/orcheo_plugin.toml
+++ b/tests/plugin_fixtures/partial_register_plugin/src/orcheo_plugin_fixture_partial_register/orcheo_plugin.toml
@@ -1,3 +1,3 @@
-plugin_api_version = 1
-orcheo_version = ">=0.0.0"
 exports = ["nodes"]
+orcheo_version = ">=0.0.0"
+plugin_api_version = 1

--- a/tests/runtime/test_credentials_resolver_core.py
+++ b/tests/runtime/test_credentials_resolver_core.py
@@ -213,6 +213,48 @@ def test_persist_refreshed_tokens_passes_context_for_oauth(
     assert captured["context"] is context
 
 
+def test_persist_refreshed_tokens_returns_false_when_not_found() -> None:
+    """persist_refreshed_tokens returns False when the credential name does not exist."""  # noqa: E501
+    vault = InMemoryCredentialVault()
+    resolver = CredentialResolver(vault)
+    result = resolver.persist_refreshed_tokens(
+        "nonexistent_credential", new_access_token="new-token"
+    )
+    assert result is False
+
+
+def test_persist_refreshed_tokens_returns_false_for_duplicate_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """persist_refreshed_tokens returns False when the name is ambiguous (duplicate)."""
+    from uuid import uuid4
+    from orcheo.models import CredentialScope
+
+    vault = InMemoryCredentialVault()
+    metadata = vault.create_credential(
+        name="ambiguous_token",
+        provider="oauth",
+        scopes=["bot"],
+        secret="ignored",
+        actor="tester",
+        scope=CredentialScope.unrestricted(),
+    )
+    duplicate = metadata.model_copy(update={"id": uuid4()}, deep=True)
+    metadata_by_id = {metadata.id: metadata, duplicate.id: duplicate}
+    metadata_by_name = {"ambiguous_token": [metadata, duplicate]}
+
+    resolver = CredentialResolver(vault)
+    monkeypatch.setattr(
+        resolver,
+        "_load_metadata_index",
+        lambda: (metadata_by_id, metadata_by_name),
+    )
+    result = resolver.persist_refreshed_tokens(
+        "ambiguous_token", new_access_token="new-token"
+    )
+    assert result is False
+
+
 def test_persist_refreshed_tokens_passes_context_for_secret(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/runtime/test_credentials_resolver_core.py
+++ b/tests/runtime/test_credentials_resolver_core.py
@@ -3,7 +3,12 @@
 from __future__ import annotations
 from uuid import uuid4
 import pytest
-from orcheo.models import CredentialAccessContext, CredentialScope
+from orcheo.models import (
+    CredentialAccessContext,
+    CredentialKind,
+    CredentialScope,
+    OAuthTokenSecrets,
+)
 from orcheo.runtime.credentials import (
     CredentialReference,
     CredentialReferenceNotFoundError,
@@ -172,3 +177,68 @@ def test_resolver_accepts_explicit_empty_payload_path() -> None:
     with credential_resolution(resolver):
         value = resolver.resolve(CredentialReference("telegram_token", ()))
         assert value == "token"
+
+
+def test_persist_refreshed_tokens_passes_context_for_oauth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = InMemoryCredentialVault()
+    vault.create_credential(
+        name="oauth_bot",
+        provider="oauth",
+        scopes=["bot"],
+        secret="ignored",
+        actor="tester",
+        kind=CredentialKind.OAUTH,
+        scope=CredentialScope.unrestricted(),
+        oauth_tokens=OAuthTokenSecrets(access_token="old-access"),
+    )
+    context = CredentialAccessContext(workspace_id=uuid4())
+    resolver = CredentialResolver(vault, context=context)
+
+    captured: dict[str, object] = {}
+
+    def _capture_update_oauth_tokens(**kwargs: object) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(vault, "update_oauth_tokens", _capture_update_oauth_tokens)
+
+    updated = resolver.persist_refreshed_tokens(
+        "oauth_bot",
+        new_access_token="new-access",
+        new_refresh_token="new-refresh",
+    )
+
+    assert updated is True
+    assert captured["context"] is context
+
+
+def test_persist_refreshed_tokens_passes_context_for_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = InMemoryCredentialVault()
+    vault.create_credential(
+        name="secret_bot",
+        provider="telegram",
+        scopes=["bot"],
+        secret="old-secret",
+        actor="tester",
+        scope=CredentialScope.unrestricted(),
+    )
+    context = CredentialAccessContext(workflow_id=uuid4())
+    resolver = CredentialResolver(vault, context=context)
+
+    captured: dict[str, object] = {}
+
+    def _capture_update_credential(**kwargs: object) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(vault, "update_credential", _capture_update_credential)
+
+    updated = resolver.persist_refreshed_tokens(
+        "secret_bot",
+        new_access_token="new-secret",
+    )
+
+    assert updated is True
+    assert captured["context"] is context


### PR DESCRIPTION
## Summary

Adds a new `LinkedInPostNode` that can publish LinkedIn posts with vault-backed credentials, refresh expired access tokens, and persist refreshed tokens back to the credential store.

## Changes

- add `LinkedInPostNode` and export it from `orcheo.nodes`
- support resolving person and organization author URNs before posting
- refresh LinkedIn access tokens on `401 Unauthorized` and persist refreshed tokens via `CredentialResolver`
- allow `base64` imports in the ingestion sandbox for JWT payload parsing
- add LinkedIn credential setup documentation
- add unit tests for the new node, sandbox import allowlist, and plugin fixture ordering

## Testing

- added coverage in `tests/nodes/test_linkedin.py`
- added coverage in `tests/graph/test_ingestion_sandbox.py`