### PR TITLE
Improve Vibe resilience and CLI setup/plugin UX

### DIFF
--- a/apps/canvas/src/features/account/components/settings/agent-settings-tab.tsx
+++ b/apps/canvas/src/features/account/components/settings/agent-settings-tab.tsx
@@ -241,8 +241,7 @@ const AgentSettingsTab = () => {
 
   useEffect(() => {
     void loadProviderStatuses();
-    void queueStatusRefresh();
-  }, [loadProviderStatuses, queueStatusRefresh]);
+  }, [loadProviderStatuses]);
 
   useEffect(() => {
     const interval = setInterval(() => {

--- a/apps/canvas/src/features/vibe/components/vibe-sidebar.tsx
+++ b/apps/canvas/src/features/vibe/components/vibe-sidebar.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useMemo } from "react";
 import { Link } from "react-router-dom";
-import { Loader2, Settings, Sparkles, X } from "lucide-react";
+import { Loader2, Settings, Sparkles, X, AlertTriangle } from "lucide-react";
 import { Button } from "@/design-system/ui/button";
 import { Skeleton } from "@/design-system/ui/skeleton";
 import { cn } from "@/lib/utils";
@@ -31,7 +31,7 @@ export function VibeSidebar({ isCollapsed = false }: VibeSidebarProps) {
     contextString,
   } = useVibe();
 
-  const { getClientSecret, sessionStatus, sessionError, refreshSession } =
+  const { getClientSecret, sessionStatus, refreshSession } =
     useVibeChat(agentWorkflowId);
 
   const colorScheme = useColorScheme();
@@ -98,22 +98,30 @@ export function VibeSidebar({ isCollapsed = false }: VibeSidebarProps) {
     if (sessionStatus === "error") {
       return (
         <div className="flex flex-1 flex-col items-center justify-center gap-3 px-4 text-center text-sm text-muted-foreground">
-          <p className="text-destructive">
-            {sessionError ?? "Failed to start chat session."}
+          <AlertTriangle className="h-5 w-5 text-destructive" />
+          <p className="font-medium text-destructive">Connection failed</p>
+          <p className="text-xs">
+            Your agent session has expired or the connection was lost. Go to
+            Settings, disconnect and reconnect your agent.
           </p>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => void refreshSession()}
-          >
-            Retry
-          </Button>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => void refreshSession()}
+            >
+              Retry
+            </Button>
+            <Button variant="outline" size="sm" asChild>
+              <Link to="/settings">Settings</Link>
+            </Button>
+          </div>
         </div>
       );
     }
 
     return null;
-  }, [isProvisioning, sessionStatus, sessionError, refreshSession]);
+  }, [isProvisioning, sessionStatus, refreshSession]);
 
   if (isCollapsed) {
     return (
@@ -121,7 +129,7 @@ export function VibeSidebar({ isCollapsed = false }: VibeSidebarProps) {
         <button
           type="button"
           onClick={toggleOpen}
-          className="absolute left-0 top-40 z-20 flex h-7 w-7 items-center justify-center rounded-full bg-muted text-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="absolute left-0 top-40 z-20 flex h-7 w-7 items-center justify-center rounded-full bg-muted/40 text-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           title="Open Orcheo Vibe"
         >
           <Sparkles

--- a/apps/canvas/src/features/vibe/hooks/use-vibe-agents.ts
+++ b/apps/canvas/src/features/vibe/hooks/use-vibe-agents.ts
@@ -2,8 +2,31 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getExternalAgents, type ExternalAgentProviderStatus } from "@/lib/api";
 import { VIBE_AGENT_POLL_INTERVAL_MS } from "@features/vibe/constants";
 
+const AGENTS_CACHE_KEY = "orcheo:vibe-agents-cache";
+const TRANSIENT_STATES = new Set(["connecting", "refreshing", "checking"]);
+
+const readCachedProviders = (): ExternalAgentProviderStatus[] => {
+  try {
+    const raw = sessionStorage.getItem(AGENTS_CACHE_KEY);
+    return raw ? (JSON.parse(raw) as ExternalAgentProviderStatus[]) : [];
+  } catch {
+    return [];
+  }
+};
+
+const writeCachedProviders = (
+  providers: ExternalAgentProviderStatus[],
+): void => {
+  try {
+    sessionStorage.setItem(AGENTS_CACHE_KEY, JSON.stringify(providers));
+  } catch {
+    // Silently ignore storage errors.
+  }
+};
+
 export function useVibeAgents() {
-  const [providers, setProviders] = useState<ExternalAgentProviderStatus[]>([]);
+  const [providers, setProviders] =
+    useState<ExternalAgentProviderStatus[]>(readCachedProviders);
   const [isLoading, setIsLoading] = useState(true);
   const mountedRef = useRef(true);
 
@@ -11,7 +34,21 @@ export function useVibeAgents() {
     try {
       const response = await getExternalAgents();
       if (mountedRef.current) {
-        setProviders(response.providers);
+        setProviders((prev) => {
+          // Keep previously-ready providers alive during transient backend states
+          // to avoid flickering "No agents connected" in the Vibe sidebar.
+          const merged = response.providers.map((next) => {
+            if (TRANSIENT_STATES.has(next.state)) {
+              const prevProvider = prev.find(
+                (p) => p.provider === next.provider,
+              );
+              return prevProvider ?? next;
+            }
+            return next;
+          });
+          writeCachedProviders(merged);
+          return merged;
+        });
       }
     } catch {
       // Silently ignore — agents may be unavailable.

--- a/apps/canvas/src/features/vibe/hooks/use-vibe-chat.ts
+++ b/apps/canvas/src/features/vibe/hooks/use-vibe-chat.ts
@@ -4,6 +4,8 @@ import { requestWorkflowChatSession } from "@features/chatkit/lib/workflow-sessi
 export type VibeChatSessionStatus = "idle" | "loading" | "ready" | "error";
 
 const SESSION_REFRESH_BUFFER_MS = 30_000;
+const MAX_REFRESH_RETRIES = 3;
+const RETRY_BASE_DELAY_MS = 2_000;
 
 export function useVibeChat(workflowId: string | null) {
   const [sessionStatus, setSessionStatus] =
@@ -22,23 +24,35 @@ export function useVibeChat(workflowId: string | null) {
     setSessionStatus("loading");
     setSessionError(null);
 
-    try {
-      const session = await requestWorkflowChatSession(workflowId);
-      secretRef.current = session.clientSecret;
-      expiresAtRef.current = session.expiresAt;
-      setSessionStatus("ready");
-      return session.clientSecret;
-    } catch (err) {
-      const message =
-        err instanceof Error ? err.message : "Chat session request failed";
-      secretRef.current = null;
-      expiresAtRef.current = null;
-      setSessionStatus("error");
-      setSessionError(message);
-      throw err;
-    } finally {
-      refreshingRef.current = false;
+    let lastErr: unknown;
+    for (let attempt = 0; attempt < MAX_REFRESH_RETRIES; attempt++) {
+      if (attempt > 0) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, RETRY_BASE_DELAY_MS * attempt),
+        );
+      }
+      try {
+        const session = await requestWorkflowChatSession(workflowId);
+        secretRef.current = session.clientSecret;
+        expiresAtRef.current = session.expiresAt;
+        setSessionStatus("ready");
+        refreshingRef.current = false;
+        return session.clientSecret;
+      } catch (err) {
+        lastErr = err;
+      }
     }
+
+    const message =
+      lastErr instanceof Error
+        ? lastErr.message
+        : "Chat session request failed";
+    secretRef.current = null;
+    expiresAtRef.current = null;
+    setSessionStatus("error");
+    setSessionError(message);
+    refreshingRef.current = false;
+    throw lastErr;
   }, [workflowId]);
 
   const getClientSecret = useCallback(

--- a/apps/canvas/src/features/vibe/hooks/use-vibe-workflow.test.ts
+++ b/apps/canvas/src/features/vibe/hooks/use-vibe-workflow.test.ts
@@ -141,4 +141,71 @@ describe("useVibeWorkflow", () => {
       },
     );
   });
+
+  it("clears a stale cached workflow id and falls back to discovering a valid managed workflow", async () => {
+    vi.mocked(listWorkflows).mockResolvedValue([EXISTING_VIBE_WORKFLOW]);
+    vi.mocked(fetchWorkflowVersions).mockResolvedValue([
+      {
+        id: "workflow-1-version-1",
+        workflow_id: "workflow-1",
+        version: 1,
+        metadata: {
+          source: "canvas-template",
+          template_id: "template-vibe-agent",
+          template: {
+            templateVersion: "1.0.1",
+          },
+        },
+        notes: "Seeded from the Orcheo Vibe template.",
+        created_by: "canvas-app",
+        created_at: "2026-04-13T09:00:00.000Z",
+        updated_at: "2026-04-13T09:00:00.000Z",
+        graph: {},
+      },
+    ]);
+    vi.mocked(request).mockImplementation(async (path, options) => {
+      if (path === "/api/workflows/workflow-1" && options?.method === "PUT") {
+        return { id: "workflow-1" };
+      }
+      throw new Error(`Unexpected request: ${path}`);
+    });
+
+    const initial = renderHook(() => useVibeWorkflow([READY_PROVIDER]));
+    await waitFor(() => {
+      expect(initial.result.current.workflowId).toBe("workflow-1");
+      expect(initial.result.current.error).toBeNull();
+    });
+    initial.unmount();
+
+    vi.mocked(listWorkflows).mockResolvedValue([
+      {
+        ...EXISTING_VIBE_WORKFLOW,
+        id: "workflow-2",
+      },
+    ]);
+    vi.mocked(fetchWorkflowVersions).mockResolvedValue([]);
+    vi.mocked(request).mockImplementation(async (path, options) => {
+      if (path === "/api/workflows/workflow-1" && options?.method === "PUT") {
+        throw new Error("Workflow not found");
+      }
+      if (path === "/api/workflows/workflow-2" && options?.method === "PUT") {
+        return { id: "workflow-2" };
+      }
+      if (
+        path === "/api/workflows/workflow-2/versions/ingest" &&
+        options?.method === "POST"
+      ) {
+        return { id: "workflow-2-version-1" };
+      }
+      throw new Error(`Unexpected request: ${path}`);
+    });
+
+    const recovered = renderHook(() => useVibeWorkflow([READY_PROVIDER]));
+
+    await waitFor(() => {
+      expect(recovered.result.current.workflowId).toBe("workflow-2");
+      expect(recovered.result.current.error).toBeNull();
+      expect(recovered.result.current.isProvisioning).toBe(false);
+    });
+  });
 });

--- a/apps/canvas/src/features/vibe/hooks/use-vibe-workflow.ts
+++ b/apps/canvas/src/features/vibe/hooks/use-vibe-workflow.ts
@@ -20,6 +20,7 @@ import { buildVibeSupportedModels } from "@features/vibe/lib/vibe-models";
 const VIBE_TEMPLATE = getWorkflowTemplateDefinition(VIBE_WORKFLOW_TEMPLATE_ID);
 const TEMPLATE_SYNC_ACTOR = "canvas-app";
 const TEMPLATE_SUMMARY = { added: 0, removed: 0, modified: 0 };
+const WORKFLOW_ID_STORAGE_KEY = "orcheo:vibe-workflow-id";
 
 interface VibeWorkflowState {
   workflowId: string | null;
@@ -27,7 +28,23 @@ interface VibeWorkflowState {
   error: string | null;
 }
 
-let cachedWorkflowId: string | null = null;
+const readCachedWorkflowId = (): string | null => {
+  try {
+    return localStorage.getItem(WORKFLOW_ID_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+};
+
+const writeCachedWorkflowId = (id: string): void => {
+  try {
+    localStorage.setItem(WORKFLOW_ID_STORAGE_KEY, id);
+  } catch {
+    // Silently ignore storage errors.
+  }
+};
+
+let cachedWorkflowId: string | null = readCachedWorkflowId();
 
 const asRecord = (value: unknown): Record<string, unknown> | null =>
   value && typeof value === "object"
@@ -59,7 +76,7 @@ export function useVibeWorkflow(
     [supportedModels],
   );
   const [state, setState] = useState<VibeWorkflowState>({
-    workflowId: supportedModels ? cachedWorkflowId : null,
+    workflowId: cachedWorkflowId,
     isProvisioning: false,
     error: null,
   });
@@ -157,8 +174,10 @@ export function useVibeWorkflow(
       if (provisioningRef.current) return;
 
       if (cachedWorkflowId) {
-        await syncManagedTemplate(cachedWorkflowId);
-        await syncSupportedModels(cachedWorkflowId, models);
+        await Promise.all([
+          syncManagedTemplate(cachedWorkflowId),
+          syncSupportedModels(cachedWorkflowId, models),
+        ]);
         setWorkflowState({
           workflowId: cachedWorkflowId,
           isProvisioning: false,
@@ -185,8 +204,11 @@ export function useVibeWorkflow(
 
         if (existing) {
           cachedWorkflowId = existing.id;
-          await syncManagedTemplate(existing.id);
-          await syncSupportedModels(existing.id, models);
+          writeCachedWorkflowId(existing.id);
+          await Promise.all([
+            syncManagedTemplate(existing.id),
+            syncSupportedModels(existing.id, models),
+          ]);
           setWorkflowState({
             workflowId: existing.id,
             isProvisioning: false,
@@ -208,6 +230,7 @@ export function useVibeWorkflow(
         }
 
         cachedWorkflowId = created.id;
+        writeCachedWorkflowId(created.id);
         await syncSupportedModels(created.id, models);
         setWorkflowState({
           workflowId: created.id,

--- a/apps/canvas/src/features/vibe/hooks/use-vibe-workflow.ts
+++ b/apps/canvas/src/features/vibe/hooks/use-vibe-workflow.ts
@@ -44,6 +44,15 @@ const writeCachedWorkflowId = (id: string): void => {
   }
 };
 
+const clearCachedWorkflowId = (): void => {
+  cachedWorkflowId = null;
+  try {
+    localStorage.removeItem(WORKFLOW_ID_STORAGE_KEY);
+  } catch {
+    // Silently ignore storage errors.
+  }
+};
+
 let cachedWorkflowId: string | null = readCachedWorkflowId();
 
 const asRecord = (value: unknown): Record<string, unknown> | null =>
@@ -174,16 +183,20 @@ export function useVibeWorkflow(
       if (provisioningRef.current) return;
 
       if (cachedWorkflowId) {
-        await Promise.all([
-          syncManagedTemplate(cachedWorkflowId),
-          syncSupportedModels(cachedWorkflowId, models),
-        ]);
-        setWorkflowState({
-          workflowId: cachedWorkflowId,
-          isProvisioning: false,
-          error: null,
-        });
-        return;
+        try {
+          await Promise.all([
+            syncManagedTemplate(cachedWorkflowId),
+            syncSupportedModels(cachedWorkflowId, models),
+          ]);
+          setWorkflowState({
+            workflowId: cachedWorkflowId,
+            isProvisioning: false,
+            error: null,
+          });
+          return;
+        } catch {
+          clearCachedWorkflowId();
+        }
       }
 
       provisioningRef.current = true;

--- a/apps/canvas/src/features/workflow/components/layouts/sidebar-layout.tsx
+++ b/apps/canvas/src/features/workflow/components/layouts/sidebar-layout.tsx
@@ -169,7 +169,7 @@ export default function SidebarLayout({
   });
 
   return (
-    <div className={cn("flex h-full min-h-0", className)}>
+    <div className={cn("flex h-full min-h-0 overflow-hidden", className)}>
       {position === "left" && (
         <>
           <aside

--- a/apps/canvas/src/features/workflow/components/trace/agent-prism/DetailsView/DetailsView.tsx
+++ b/apps/canvas/src/features/workflow/components/trace/agent-prism/DetailsView/DetailsView.tsx
@@ -133,7 +133,10 @@ export const DetailsView = ({
         />
       </div>
 
-      <div key={tab} className="min-h-0 flex-1 overflow-y-auto py-4">
+      <div
+        key={tab}
+        className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto py-4"
+      >
         {tab === "input-output" && <DetailsViewInputOutputTab data={data} />}
         {tab === "attributes" && <DetailsViewAttributesTab data={data} />}
         {tab === "raw" && <DetailsViewRawDataTab data={data} />}

--- a/packages/sdk/src/orcheo_sdk/cli/config_command.py
+++ b/packages/sdk/src/orcheo_sdk/cli/config_command.py
@@ -36,6 +36,7 @@ from orcheo_sdk.cli.state import CLIState
 config_app = typer.Typer(
     name="config",
     help="Write CLI profile settings to the Orcheo config file.",
+    invoke_without_command=True,
 )
 
 EnvFileOption = Annotated[
@@ -306,7 +307,7 @@ def _resolve_profiles_with_overrides(
     return resolved_profiles
 
 
-@config_app.callback(invoke_without_command=True)
+@config_app.callback()
 def configure(
     ctx: typer.Context,
     api_url: Annotated[
@@ -354,6 +355,9 @@ def configure(
     ] = False,
 ) -> None:
     """Write CLI profile configuration to ``cli.toml``."""
+    if ctx.invoked_subcommand is not None:
+        return
+
     state = _state(ctx)
 
     env_data = _read_env_file(env_file) if env_file else None
@@ -420,3 +424,54 @@ def configure(
     state.console.print(
         f"[green]Updated {len(profile_names)} profile(s) in {config_path}.[/green]"
     )
+
+
+def _profile_summary(data: dict[str, Any]) -> dict[str, Any]:
+    """Return a redacted summary dict for a single profile."""
+    summary: dict[str, Any] = {"api_url": data.get("api_url", "")}
+    if service_token := data.get("service_token"):
+        summary["service_token"] = _redact_value(str(service_token))
+    if auth_issuer := data.get(AUTH_ISSUER_KEY):
+        summary[AUTH_ISSUER_KEY] = str(auth_issuer)
+    if auth_client_id := data.get(AUTH_CLIENT_ID_KEY):
+        summary[AUTH_CLIENT_ID_KEY] = _redact_value(str(auth_client_id))
+    if auth_audience := data.get(AUTH_AUDIENCE_KEY):
+        summary[AUTH_AUDIENCE_KEY] = str(auth_audience)
+    return summary
+
+
+@config_app.command("list")
+def list_config_profiles(ctx: typer.Context) -> None:
+    """List all configured CLI profiles."""
+    state = _state(ctx)
+    config_path = get_config_dir() / CONFIG_FILENAME
+    try:
+        profiles = load_profiles(config_path)
+    except tomllib.TOMLDecodeError as exc:
+        raise CLIError(f"Invalid TOML in {config_path}.") from exc
+
+    if not profiles:
+        if not state.human:
+            print_json({"profiles": {}})
+        else:
+            state.console.print("[dim]No profiles configured.[/dim]")
+            state.console.print(f"[dim]Config: {config_path}[/dim]")
+        return
+
+    summaries = {name: _profile_summary(profiles[name]) for name in sorted(profiles)}
+    if not state.human:
+        print_json({"profiles": summaries})
+        return
+
+    state.console.print(f"[dim]Config: {config_path}[/dim]")
+    for name, summary in summaries.items():
+        state.console.print(f"\n[bold]{name}[/bold]")
+        state.console.print(f"  api-url: {summary.get('api_url', '(not set)')}")
+        if token := summary.get("service_token"):
+            state.console.print(f"  service-token: {token}")
+        if issuer := summary.get(AUTH_ISSUER_KEY):
+            state.console.print(f"  auth-issuer: {issuer}")
+        if client_id := summary.get(AUTH_CLIENT_ID_KEY):
+            state.console.print(f"  auth-client-id: {client_id}")
+        if audience := summary.get(AUTH_AUDIENCE_KEY):
+            state.console.print(f"  auth-audience: {audience}")

--- a/packages/sdk/src/orcheo_sdk/cli/main.py
+++ b/packages/sdk/src/orcheo_sdk/cli/main.py
@@ -218,14 +218,9 @@ def main(
         )
 
 
-def _install_agent_skills(*, console: Console, yes: bool) -> None:
-    """Prompt to install the Orcheo skill into Claude Code and Codex via skill-mgr."""
-    if yes:
-        return
-    if not typer.confirm(
-        "\nInstall Orcheo skill for Claude Code and Codex?",
-        default=True,
-    ):
+def _install_agent_skills(*, console: Console, should_install: bool) -> None:
+    """Install the Orcheo skill into Claude Code and Codex via skill-mgr."""
+    if not should_install:
         return
     skill_mgr_bin = shutil.which("skill-mgr")
     if skill_mgr_bin:
@@ -280,7 +275,7 @@ def _run_install_flow(
     )
     execute_setup(config, console=console, stack_version=stack_version)
     print_summary(config, console=console)
-    _install_agent_skills(console=console, yes=yes)
+    _install_agent_skills(console=console, should_install=config.install_agent_skills)
 
 
 def _resolve_install_console(ctx: typer.Context) -> Console:

--- a/packages/sdk/src/orcheo_sdk/cli/plugin.py
+++ b/packages/sdk/src/orcheo_sdk/cli/plugin.py
@@ -128,6 +128,26 @@ def _run_stack_subprocess(
     return result
 
 
+def _run_stack_subprocess_streaming(
+    command: list[str],
+    *,
+    expected_exit_codes: set[int] | None = None,
+) -> int:
+    """Run a stack subprocess, streaming output to the terminal in real time."""
+    if shutil.which("docker") is None:
+        raise typer.BadParameter(
+            "Docker is not installed or not in PATH. Install Docker and retry."
+        )
+    if expected_exit_codes is None:
+        expected_exit_codes = {0}
+    result = subprocess.run(command, check=False)
+    if result.returncode not in expected_exit_codes:
+        raise typer.BadParameter(
+            f"Command failed with exit code {result.returncode}: {' '.join(command)}"
+        )
+    return result.returncode
+
+
 def _running_stack_services() -> set[str]:
     compose_base_args = _stack_compose_base_args()
     result = _run_stack_subprocess(
@@ -175,16 +195,18 @@ def _stack_plugin_command(
 
 def _run_stack_plugin_passthrough(*, args: list[str], state: CLIState) -> None:
     expected_exit_codes = {0, 1} if args and args[0] == "doctor" else {0}
-    result = _run_stack_subprocess(
-        _stack_plugin_command(args=args, human=state.human),
-        expected_exit_codes=expected_exit_codes,
-    )
+    command = _stack_plugin_command(args=args, human=state.human)
+    if state.human:
+        returncode = _run_stack_subprocess_streaming(
+            command, expected_exit_codes=expected_exit_codes
+        )
+        if args and args[0] == "doctor" and returncode == 1:
+            raise typer.Exit(code=1)
+        return
+    result = _run_stack_subprocess(command, expected_exit_codes=expected_exit_codes)
     output = result.stdout.rstrip()
     if output:
-        if state.human:
-            state.console.print(output)
-        else:
-            typer.echo(output)
+        typer.echo(output)
     if args and args[0] == "doctor" and result.returncode == 1:
         raise typer.Exit(code=1)
 
@@ -528,18 +550,15 @@ def install_plugin(
         stack_ref = (
             _copy_local_plugin_ref_into_stack(ref) if _is_local_plugin_ref(ref) else ref
         )
-        _emit_plugin_progress(state, "Installing plugin inside the stack backend")
+        if state.human:
+            _emit_plugin_progress(state, "Installing plugin inside the stack backend")
+            _run_stack_plugin_passthrough(args=["install", stack_ref], state=state)
+            _restart_running_stack_services(state)
+            return
         payload = _run_stack_plugin_json(["install", stack_ref])
         if _payload_requires_restart(payload):  # pragma: no branch
             _restart_running_stack_services(state)
-        if not state.human:
-            print_json(payload)
-            return
-        render_json(state.console, payload["plugin"], title="Installed Plugin")
-        _render_impact(
-            state,
-            PluginImpactSummary(**payload["impact"]),
-        )
+        print_json(payload)
         return
     try:
         _emit_plugin_progress(state, f"Installing plugin from '{ref}'")

--- a/packages/sdk/src/orcheo_sdk/cli/setup.py
+++ b/packages/sdk/src/orcheo_sdk/cli/setup.py
@@ -70,6 +70,7 @@ class SetupConfig:
     canvas_upstream: str
     start_stack: bool
     install_docker_if_missing: bool
+    install_agent_skills: bool = False
     preserve_existing_backend_url: bool = False
     stack_project_dir: str | None = None
     stack_env_file: str | None = None
@@ -604,10 +605,11 @@ def _resolve_public_ingress_enabled(
     yes: bool,
     env_file: Path,
     env_exists: bool,
+    mode: SetupMode,
 ) -> bool:
     if public_ingress is not None:
         return public_ingress
-    if env_exists:
+    if env_exists and mode == "upgrade":
         existing = _parse_bool_value(
             _read_env_value(env_file, "ORCHEO_PUBLIC_INGRESS_ENABLED")
         )
@@ -615,9 +617,16 @@ def _resolve_public_ingress_enabled(
             return existing
     if yes:
         return False
+    existing_default = False
+    if env_exists:
+        parsed = _parse_bool_value(
+            _read_env_value(env_file, "ORCHEO_PUBLIC_INGRESS_ENABLED")
+        )
+        if parsed is not None:
+            existing_default = parsed
     return typer.confirm(
         "Enable bundled public HTTPS ingress with Caddy?",
-        default=False,
+        default=existing_default,
     )
 
 
@@ -679,12 +688,14 @@ def _resolve_public_ingress_config(
     yes: bool,
     env_file: Path,
     env_exists: bool,
+    mode: SetupMode,
 ) -> tuple[bool, str | None, bool]:
     resolved_public_ingress_enabled = _resolve_public_ingress_enabled(
         public_ingress,
         yes=yes,
         env_file=env_file,
         env_exists=env_exists,
+        mode=mode,
     )
     resolved_public_host = _resolve_public_host(
         public_host,
@@ -1357,6 +1368,7 @@ def run_setup(
         yes=yes,
         env_file=stack_env_file,
         env_exists=has_existing_stack_env,
+        mode=resolved_mode,
     )
     default_backend_url = (
         f"https://{resolved_public_host}"
@@ -1401,6 +1413,12 @@ def run_setup(
         stack_env_file,
         env_exists=has_existing_stack_env,
     )
+    resolved_install_agent_skills = _resolve_bool(
+        None,
+        yes_default=yes,
+        prompt="Install Orcheo skill for Claude Code and Codex?",
+        default=True,
+    )
     _print_setup_resolution_notes(
         console=console,
         resolved_api_key=resolved_api_key,
@@ -1426,6 +1444,7 @@ def run_setup(
         canvas_upstream=resolved_canvas_upstream,
         start_stack=resolved_start_stack,
         install_docker_if_missing=resolved_install_docker,
+        install_agent_skills=resolved_install_agent_skills,
         preserve_existing_backend_url=preserve_existing_backend_url,
     )
 
@@ -1626,11 +1645,14 @@ def print_summary(config: SetupConfig, *, console: Console) -> None:
     console.print_json(json.dumps(summary))
 
     if config.start_stack:
+        if not config.public_ingress_enabled:
+            console.print("\n[bold cyan]Canvas:[/bold cyan] http://localhost:5173")
         console.print(
             "\n[yellow]Note:[/yellow] Canvas may take 2-3 minutes on first "
             "startup while npm installs dependencies."
         )
     if config.public_ingress_enabled and config.public_host is not None:
+        console.print(f"\n[bold cyan]Canvas:[/bold cyan] https://{config.public_host}")
         console.print(
             "\n[yellow]Public ingress prerequisites:[/yellow] "
             f"point DNS for {config.public_host} at this host and allow inbound "
@@ -1646,6 +1668,8 @@ def print_summary(config: SetupConfig, *, console: Console) -> None:
         "  1. Run [cyan]orcheo auth login[/cyan] (or configure a service token)."
     )
     console.print("  2. Run [cyan]orcheo workflow list[/cyan] to verify connectivity.")
+    if config.start_stack and not config.public_ingress_enabled:
+        console.print("  3. Open [cyan]http://localhost:5173[/cyan] in your browser.")
 
 
 __all__ = [

--- a/tests/sdk/test_cli_config_command.py
+++ b/tests/sdk/test_cli_config_command.py
@@ -1006,3 +1006,65 @@ def test_config_list_does_not_run_configure_callback(
     config_dir.mkdir(parents=True, exist_ok=True)
     result = runner.invoke(app, ["--human", "config", "list"], env=env_no_token)
     assert result.exit_code == 0
+
+
+def test_config_list_invalid_toml(
+    runner: CliRunner, env: dict[str, str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """config list raises CLIError when load_profiles raises TOMLDecodeError."""
+    import tomllib as _tomllib
+    from orcheo_sdk.cli import config_command
+    from orcheo_sdk.cli.errors import CLIError
+
+    try:
+        _tomllib.loads("[[invalid")
+    except _tomllib.TOMLDecodeError as exc:
+        toml_error = exc
+
+    def raise_toml_error(path: Path) -> dict:
+        raise toml_error
+
+    monkeypatch.setattr(config_command, "load_profiles", raise_toml_error)
+    result = runner.invoke(app, ["--human", "config", "list"], env=env)
+    assert result.exit_code != 0
+    assert isinstance(result.exception, CLIError)
+    assert "Invalid TOML" in str(result.exception)
+
+
+def test_config_list_no_profiles_machine_mode(
+    runner: CliRunner, machine_env: dict[str, str]
+) -> None:
+    """config list in machine mode returns JSON with empty profiles dict."""
+    import json as _json
+
+    result = runner.invoke(app, ["config", "list"], env=machine_env)
+    assert result.exit_code == 0
+    data = _json.loads(result.output)
+    assert data == {"profiles": {}}
+
+
+def test_config_list_shows_oauth_only_profile(
+    runner: CliRunner, env: dict[str, str]
+) -> None:
+    """config list in human mode shows oauth fields and omits service_token when absent."""  # noqa: E501
+    config_path = Path(env["ORCHEO_CONFIG_DIR"]) / CONFIG_FILENAME
+    config_path.write_text(
+        "\n".join(
+            [
+                "[profiles.default]",
+                'api_url = "http://api.test"',
+                'auth_issuer = "https://issuer.example.com"',
+                'auth_client_id = "my-client"',
+                'auth_audience = "https://api.example.com"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    no_token_env = {**env, "ORCHEO_SERVICE_TOKEN": ""}
+    result = runner.invoke(app, ["--human", "config", "list"], env=no_token_env)
+    assert result.exit_code == 0
+    assert "auth-issuer" in result.output
+    assert "auth-client-id" in result.output
+    assert "auth-audience" in result.output
+    assert "service-token" not in result.output

--- a/tests/sdk/test_cli_config_command.py
+++ b/tests/sdk/test_cli_config_command.py
@@ -392,6 +392,7 @@ def test_config_command_invalid_toml(
     mock_state = MagicMock()
     mock_state.console = Console()
     mock_ctx = MagicMock(spec=Context)
+    mock_ctx.invoked_subcommand = None
     mock_ctx.ensure_object.return_value = mock_state
 
     with pytest.raises(CLIError) as exc_info:
@@ -438,6 +439,7 @@ def test_config_command_incomplete_oauth_issuer_only(
     mock_state = MagicMock()
     mock_state.console = Console()
     mock_ctx = MagicMock(spec=Context)
+    mock_ctx.invoked_subcommand = None
     mock_ctx.ensure_object.return_value = mock_state
 
     with pytest.raises(CLIError, match="auth_client_id"):
@@ -487,6 +489,7 @@ def test_config_command_incomplete_oauth_client_id_only(
     mock_state = MagicMock()
     mock_state.console = Console()
     mock_ctx = MagicMock(spec=Context)
+    mock_ctx.invoked_subcommand = None
     mock_ctx.ensure_object.return_value = mock_state
 
     with pytest.raises(CLIError, match="auth_issuer"):
@@ -536,6 +539,7 @@ def test_config_command_incomplete_oauth_missing_audience(
     mock_state = MagicMock()
     mock_state.console = Console()
     mock_ctx = MagicMock(spec=Context)
+    mock_ctx.invoked_subcommand = None
     mock_ctx.ensure_object.return_value = mock_state
 
     with pytest.raises(CLIError, match="auth_audience"):
@@ -956,3 +960,49 @@ def test_config_command_allows_setting_only_missing_oauth_field_on_existing_prof
     assert profile["auth_issuer"] == "https://auth.example.com"
     assert profile["auth_client_id"] == "my-client"
     assert profile["auth_audience"] == "https://api.example.com"
+
+
+def test_config_list_no_profiles(runner: CliRunner, env: dict[str, str]) -> None:
+    """config list shows empty message when no profiles are written yet."""
+    config_dir = Path(env["ORCHEO_CONFIG_DIR"])
+    config_dir.mkdir(parents=True, exist_ok=True)
+    result = runner.invoke(app, ["--human", "config", "list"], env=env)
+    assert result.exit_code == 0
+    assert "No profiles" in result.output
+
+
+def test_config_list_shows_profiles(runner: CliRunner, env: dict[str, str]) -> None:
+    """config list shows profile api_url and redacts the service token."""
+    runner.invoke(app, ["config"], env=env)
+    result = runner.invoke(app, ["--human", "config", "list"], env=env)
+    assert result.exit_code == 0
+    assert env["ORCHEO_API_URL"] in result.output
+    assert "..." in result.output
+
+
+def test_config_list_machine_mode_json(
+    runner: CliRunner, machine_env: dict[str, str]
+) -> None:
+    """config list in machine mode outputs valid JSON with profiles key."""
+    import json as _json
+
+    runner.invoke(app, ["config"], env=machine_env)
+    result = runner.invoke(app, ["config", "list"], env=machine_env)
+    assert result.exit_code == 0
+    payload = _json.loads(result.output)
+    assert "profiles" in payload
+    assert "default" in payload["profiles"]
+    assert payload["profiles"]["default"]["api_url"] == machine_env["ORCHEO_API_URL"]
+
+
+def test_config_list_does_not_run_configure_callback(
+    runner: CliRunner, env: dict[str, str]
+) -> None:
+    """Invoking 'config list' must not trigger the configure write callback."""
+    env_no_token = {**env}
+    env_no_token.pop("ORCHEO_SERVICE_TOKEN", None)
+    env_no_token.pop("ORCHEO_API_URL", None)
+    config_dir = Path(env["ORCHEO_CONFIG_DIR"])
+    config_dir.mkdir(parents=True, exist_ok=True)
+    result = runner.invoke(app, ["--human", "config", "list"], env=env_no_token)
+    assert result.exit_code == 0

--- a/tests/sdk/test_cli_main.py
+++ b/tests/sdk/test_cli_main.py
@@ -765,29 +765,13 @@ def test_main_skips_update_check_when_disabled(
     assert isinstance(ctx.obj, CLIState)
 
 
-def test_install_agent_skills_yes_skips_all(monkeypatch: pytest.MonkeyPatch) -> None:
-    """_install_agent_skills returns immediately when yes=True."""
+def test_install_agent_skills_skips_when_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_install_agent_skills returns immediately when should_install=False."""
     console = Console()
     monkeypatch.setattr(
         main_mod.shutil, "which", lambda name: pytest.fail("should not check")
     )
-    main_mod._install_agent_skills(console=console, yes=True)
-
-
-def test_install_agent_skills_confirm_declined(monkeypatch: pytest.MonkeyPatch) -> None:
-    """_install_agent_skills returns without running subprocess when user declines."""
-    import io
-
-    console = Console(file=io.StringIO())
-    monkeypatch.setattr(main_mod.typer, "confirm", lambda *args, **kwargs: False)
-    ran: list[object] = []
-    monkeypatch.setattr(
-        main_mod.subprocess,
-        "run",
-        lambda *a, **kw: ran.append(a) or type("R", (), {"returncode": 0})(),
-    )
-    main_mod._install_agent_skills(console=console, yes=False)
-    assert ran == []
+    main_mod._install_agent_skills(console=console, should_install=False)
 
 
 def test_install_agent_skills_with_skill_mgr_found(
@@ -797,7 +781,6 @@ def test_install_agent_skills_with_skill_mgr_found(
     import io
 
     console = Console(file=io.StringIO())
-    monkeypatch.setattr(main_mod.typer, "confirm", lambda *args, **kwargs: True)
     monkeypatch.setattr(
         main_mod.shutil,
         "which",
@@ -811,7 +794,7 @@ def test_install_agent_skills_with_skill_mgr_found(
         return type("R", (), {"returncode": 0})()
 
     monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
-    main_mod._install_agent_skills(console=console, yes=False)
+    main_mod._install_agent_skills(console=console, should_install=True)
     assert ran_cmds[0][0] == "/usr/bin/skill-mgr"
 
 
@@ -822,7 +805,6 @@ def test_install_agent_skills_without_skill_mgr_falls_back_to_uv(
     import io
 
     console = Console(file=io.StringIO())
-    monkeypatch.setattr(main_mod.typer, "confirm", lambda *args, **kwargs: True)
     monkeypatch.setattr(main_mod.shutil, "which", lambda name: None)
 
     ran_cmds: list[list[str]] = []
@@ -832,7 +814,7 @@ def test_install_agent_skills_without_skill_mgr_falls_back_to_uv(
         return type("R", (), {"returncode": 0})()
 
     monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
-    main_mod._install_agent_skills(console=console, yes=False)
+    main_mod._install_agent_skills(console=console, should_install=True)
     assert ran_cmds[0][:2] == ["uv", "run"]
 
 
@@ -844,14 +826,13 @@ def test_install_agent_skills_nonzero_exit_prints_warning(
 
     out = io.StringIO()
     console = Console(file=out, no_color=True, highlight=False)
-    monkeypatch.setattr(main_mod.typer, "confirm", lambda *args, **kwargs: True)
     monkeypatch.setattr(main_mod.shutil, "which", lambda name: None)
 
     def fake_run(cmd: list[str], **kwargs: object) -> object:
         return type("R", (), {"returncode": 1})()
 
     monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
-    main_mod._install_agent_skills(console=console, yes=False)
+    main_mod._install_agent_skills(console=console, should_install=True)
     assert (
         "Warning" in out.getvalue()
         or "warning" in out.getvalue().lower()

--- a/tests/sdk/test_cli_plugin.py
+++ b/tests/sdk/test_cli_plugin.py
@@ -63,7 +63,7 @@ def test_run_stack_subprocess_defaults_to_zero(monkeypatch: pytest.MonkeyPatch) 
     assert result.returncode == 0
 
 
-def test_run_stack_plugin_passthrough_prints_to_console(
+def test_run_stack_plugin_passthrough_streams_for_human_mode(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     state = _make_cli_state(human=True)
@@ -73,15 +73,19 @@ def test_run_stack_plugin_passthrough_prints_to_console(
         lambda *, args, human: ["dummy"],
     )
 
-    def fake_subprocess(
-        command: list[str], *, expected_exit_codes: set[int] | None = None
-    ) -> subprocess.CompletedProcess[str]:
-        del expected_exit_codes
-        return subprocess.CompletedProcess(command, 0, stdout="hello\n")
+    called_with: list[list[str]] = []
 
-    monkeypatch.setattr(plugin_module, "_run_stack_subprocess", fake_subprocess)
+    def fake_streaming(
+        command: list[str], *, expected_exit_codes: set[int] | None = None
+    ) -> int:
+        called_with.append(command)
+        return 0
+
+    monkeypatch.setattr(
+        plugin_module, "_run_stack_subprocess_streaming", fake_streaming
+    )
     plugin_module._run_stack_plugin_passthrough(args=["list"], state=state)
-    assert "hello" in state.console.export_text()
+    assert called_with == [["dummy"]]
 
 
 def test_run_stack_plugin_passthrough_uses_typer_echo(
@@ -131,6 +135,69 @@ def test_run_stack_plugin_passthrough_doctor_raises_exit(
     with pytest.raises(typer.Exit) as excinfo:
         plugin_module._run_stack_plugin_passthrough(args=["doctor"], state=state)
     assert excinfo.value.exit_code == 1
+
+
+def test_run_stack_subprocess_streaming_calls_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "orcheo_sdk.cli.plugin.shutil.which", lambda _: "/usr/bin/docker"
+    )
+
+    def fake_run(
+        command: list[str], *, check: bool
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr("orcheo_sdk.cli.plugin.subprocess.run", fake_run)
+    returncode = plugin_module._run_stack_subprocess_streaming(["docker", "ps"])
+    assert returncode == 0
+
+
+def test_run_stack_subprocess_streaming_raises_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "orcheo_sdk.cli.plugin.shutil.which", lambda _: "/usr/bin/docker"
+    )
+
+    def fake_run(
+        command: list[str], *, check: bool
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(command, 1)
+
+    monkeypatch.setattr("orcheo_sdk.cli.plugin.subprocess.run", fake_run)
+    with pytest.raises(typer.BadParameter):
+        plugin_module._run_stack_subprocess_streaming(["docker", "fail"])
+
+
+def test_install_plugin_stack_runtime_human_streams(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = MagicMock()
+    state.human = True
+    passthrough_calls: list[tuple[list[str], Any]] = []
+
+    def capture_passthrough(*, args: list[str], state: Any) -> None:
+        passthrough_calls.append((args, state))
+
+    restarts: list[Any] = []
+
+    monkeypatch.setattr(plugin_module, "_state", lambda ctx: state)
+    monkeypatch.setattr(plugin_module, "_use_stack_runtime", lambda runtime: True)
+    monkeypatch.setattr(plugin_module, "_is_local_plugin_ref", lambda ref: False)
+    monkeypatch.setattr(
+        plugin_module, "_run_stack_plugin_passthrough", capture_passthrough
+    )
+    monkeypatch.setattr(
+        plugin_module,
+        "_restart_running_stack_services",
+        lambda s: restarts.append(s),
+    )
+    plugin_module.install_plugin(None, "example-ref", runtime="auto")
+    assert len(passthrough_calls) == 1
+    assert passthrough_calls[0][0] == ["install", "example-ref"]
+    assert restarts == [state]
 
 
 def test_install_plugin_stack_runtime_restart(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/sdk/test_cli_plugin_helpers.py
+++ b/tests/sdk/test_cli_plugin_helpers.py
@@ -154,6 +154,52 @@ def test_run_stack_plugin_passthrough_doctor_error(
         )
 
 
+def test_run_stack_subprocess_streaming_requires_docker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(plugin_module.shutil, "which", lambda _: None)
+    with pytest.raises(typer.BadParameter):
+        plugin_module._run_stack_subprocess_streaming(["cmd"])
+
+
+def test_run_stack_subprocess_streaming_with_explicit_exit_codes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(plugin_module.shutil, "which", lambda _: "/usr/bin/docker")
+
+    def fake_run(
+        command: list[str], *, check: bool
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(plugin_module.subprocess, "run", fake_run)
+    returncode = plugin_module._run_stack_subprocess_streaming(
+        ["cmd"], expected_exit_codes={0, 1}
+    )
+    assert returncode == 0
+
+
+def test_run_stack_plugin_passthrough_human_doctor_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        plugin_module, "_stack_plugin_command", lambda *, args, human: ["cmd"]
+    )
+
+    def fake_streaming(
+        command: list[str], *, expected_exit_codes: set[int] | None = None
+    ) -> int:
+        return 1
+
+    monkeypatch.setattr(
+        plugin_module, "_run_stack_subprocess_streaming", fake_streaming
+    )
+    state = DummyState(human=True)
+    with pytest.raises(typer.Exit) as excinfo:
+        plugin_module._run_stack_plugin_passthrough(args=["doctor"], state=state)
+    assert excinfo.value.exit_code == 1
+
+
 def test_is_local_plugin_ref_detects_variants(tmp_path: Path) -> None:
     file_path = tmp_path / "plugin.txt"
     file_path.write_text("x", encoding="utf-8")
@@ -583,32 +629,23 @@ def test_install_command_stack_path_renders_human_output(
     monkeypatch.setattr(plugin_module, "_use_stack_runtime", lambda runtime: True)
     monkeypatch.setattr(plugin_module, "_state", lambda ctx: DummyState(human=True))
     monkeypatch.setattr(plugin_module, "_is_local_plugin_ref", lambda ref: False)
-    payload = {
-        "plugin": {"name": "pkg"},
-        "impact": {
-            "change_type": "install",
-            "affected_component_kinds": ["nodes"],
-            "affected_component_ids": ["node"],
-            "activation_mode": "silent",
-            "prompt_required": False,
-            "restart_required": True,
-        },
-    }
-    monkeypatch.setattr(plugin_module, "_run_stack_plugin_json", lambda args: payload)
+    passthrough_calls: list[list[str]] = []
+
+    def fake_passthrough(*, args: list[str], state: DummyState) -> None:
+        passthrough_calls.append(args)
+
     monkeypatch.setattr(
-        plugin_module, "_restart_running_stack_services", lambda state: None
+        plugin_module, "_run_stack_plugin_passthrough", fake_passthrough
     )
-    renders: list[dict[str, object]] = []
+    restarted: list[bool] = []
     monkeypatch.setattr(
-        plugin_module, "render_json", lambda console, data, title: renders.append(data)
-    )
-    impacts: list[PluginImpactSummary] = []
-    monkeypatch.setattr(
-        plugin_module, "_render_impact", lambda state, impact: impacts.append(impact)
+        plugin_module,
+        "_restart_running_stack_services",
+        lambda state: restarted.append(True),
     )
     runner.invoke(plugin_module.plugin_app, ["install", "pkg"], env=env)
-    assert renders
-    assert impacts
+    assert passthrough_calls == [["install", "pkg"]]
+    assert restarted
 
 
 @pytest.mark.parametrize(

--- a/tests/sdk/test_cli_setup.py
+++ b/tests/sdk/test_cli_setup.py
@@ -491,7 +491,7 @@ def test_setup_resolution_helpers_cover_env_branches(
 
     assert (
         setup._resolve_public_ingress_enabled(
-            None, yes=False, env_file=env_file, env_exists=True
+            None, yes=False, env_file=env_file, env_exists=True, mode="upgrade"
         )
         is True
     )
@@ -936,3 +936,29 @@ def test_print_summary():
     output = console.file.getvalue()
     assert "Setup complete" in output
     assert "Canvas may take" in output
+    assert "localhost:5173" in output
+
+
+def test_print_summary_public_ingress():
+    console = make_console()
+    config = setup.SetupConfig(
+        mode="install",
+        backend_url="https://orcheo.example.com",
+        auth_mode="api-key",
+        api_key="token",
+        chatkit_domain_key=None,
+        public_ingress_enabled=True,
+        public_host="orcheo.example.com",
+        publish_local_ports=False,
+        backend_upstreams="backend:8000",
+        canvas_upstream="canvas:5173",
+        start_stack=True,
+        install_docker_if_missing=False,
+    )
+    config.stack_project_dir = "/tmp/stack"
+    config.stack_env_file = "/tmp/stack/.env"
+    setup.print_summary(config, console=console)
+    output = console.file.getvalue()
+    assert "Setup complete" in output
+    assert "https://orcheo.example.com" in output
+    assert "localhost:5173" not in output

--- a/tests/sdk/test_cli_setup.py
+++ b/tests/sdk/test_cli_setup.py
@@ -962,3 +962,41 @@ def test_print_summary_public_ingress():
     assert "Setup complete" in output
     assert "https://orcheo.example.com" in output
     assert "localhost:5173" not in output
+
+
+def test_resolve_public_ingress_enabled_upgrade_mode_unparseable_existing(
+    tmp_path: Path,
+) -> None:
+    """Covers line 616->618: upgrade path with unparseable existing value falls through to yes."""  # noqa: E501
+    env_file = tmp_path / ".env"
+    env_file.write_text("ORCHEO_PUBLIC_INGRESS_ENABLED=\n", encoding="utf-8")
+    result = setup._resolve_public_ingress_enabled(
+        None, yes=True, env_file=env_file, env_exists=True, mode="upgrade"
+    )
+    assert result is False
+
+
+def test_resolve_public_ingress_enabled_env_exists_sets_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Covers lines 622-626: existing env value used as confirm default."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("ORCHEO_PUBLIC_INGRESS_ENABLED=true\n", encoding="utf-8")
+    monkeypatch.setattr(setup.typer, "confirm", lambda *args, **kwargs: True)
+    result = setup._resolve_public_ingress_enabled(
+        None, yes=False, env_file=env_file, env_exists=True, mode="install"
+    )
+    assert result is True
+
+
+def test_resolve_public_ingress_enabled_env_exists_unparseable_uses_false_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Covers line 625->627: env exists but value is unparseable, confirm defaults to False."""  # noqa: E501
+    env_file = tmp_path / ".env"
+    env_file.write_text("ORCHEO_PUBLIC_INGRESS_ENABLED=\n", encoding="utf-8")
+    monkeypatch.setattr(setup.typer, "confirm", lambda *args, **kwargs: False)
+    result = setup._resolve_public_ingress_enabled(
+        None, yes=False, env_file=env_file, env_exists=True, mode="install"
+    )
+    assert result is False


### PR DESCRIPTION
## Summary

This PR improves reliability in the Canvas Vibe experience and tightens several SDK CLI flows around config, setup, and plugin execution.

### Canvas
- Persist Vibe provider state in `sessionStorage` to avoid transient "no agents connected" flicker during backend refresh states.
- Persist the managed Vibe workflow ID in `localStorage` and reuse it across reloads.
- Retry chat session creation before surfacing an error.
- Improve the Vibe sidebar error state with clearer guidance to reconnect the agent from Settings.
- Fix a couple of overflow/layout issues in the sidebar and agent prism details view.
- Stop triggering an immediate queued status refresh on the agent settings tab mount.

### SDK / CLI
- Add `orcheo config list` to show configured profiles, with sensitive values redacted and JSON output in machine mode.
- Ensure `config list` does not accidentally trigger the config-writing callback.
- Make setup explicitly track whether agent skills should be installed, instead of tying that behavior to `--yes`.
- Refine setup/public ingress resolution so upgrade flows reuse existing ingress settings, while install prompts default more sensibly.
- Improve setup summary output to clearly show the Canvas URL for both local and public-ingress setups.
- Stream stack plugin command output directly in human mode so users can see real-time progress.
- Simplify stack-runtime plugin install behavior in human mode while preserving restart handling.

## Test Coverage
- Added and updated SDK CLI tests for:
  - `config list`
  - config callback/subcommand separation
  - agent skill install flow
  - streaming stack plugin subprocess execution
  - setup summary/public ingress behavior
