### PR TITLE
Add source-built staging stack workflow and env bootstrap support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
 .PHONY: dev-server test lint format canvas-lint canvas-format canvas-test redis worker celery-beat \
-       docker-up docker-down docker-build docker-logs staging-up staging-down staging-restart \
+       docker-up docker-down docker-build docker-logs staging-env staging-up staging-down staging-restart \
        staging-build staging-logs staging-config
 
 UV ?= uv
 UV_CACHE_DIR ?= .cache/uv
 UV_RUN = UV_CACHE_DIR=$(UV_CACHE_DIR) $(UV) run
 STACK_DIR ?= deploy/stack
-STAGING_COMPOSE = docker compose -f $(STACK_DIR)/docker-compose.yml -f $(STACK_DIR)/docker-compose.staging.yml --project-directory $(STACK_DIR)
+STACK_ENV_DIR ?= $(HOME)/.orcheo/stack
+STACK_ENV_FILE ?= $(STACK_ENV_DIR)/.env
+STACK_ENV_TEMPLATE ?= $(STACK_DIR)/.env.example
+STAGING_COMPOSE = ORCHEO_STACK_ENV_FILE=$(STACK_ENV_FILE) docker compose --env-file $(STACK_ENV_FILE) -f $(STACK_DIR)/docker-compose.yml -f $(STACK_DIR)/docker-compose.staging.yml --project-directory $(STACK_DIR)
 
 lint:
 	$(UV_RUN) ruff check src/orcheo packages/sdk/src packages/agentensor/src apps/backend/src
@@ -61,20 +64,23 @@ docker-build:
 docker-logs:
 	docker compose logs -f
 
-staging-up:
+staging-env:
+	$(UV_RUN) orcheo install ensure-stack-env --env-file "$(STACK_ENV_FILE)" --env-template "$(STACK_ENV_TEMPLATE)"
+
+staging-up: staging-env
 	$(STAGING_COMPOSE) up -d
 
-staging-down:
+staging-down: staging-env
 	$(STAGING_COMPOSE) down
 
-staging-restart:
+staging-restart: staging-env
 	$(STAGING_COMPOSE) restart
 
-staging-build:
+staging-build: staging-env
 	$(STAGING_COMPOSE) build --pull
 
-staging-logs:
+staging-logs: staging-env
 	$(STAGING_COMPOSE) logs -f
 
-staging-config:
+staging-config: staging-env
 	$(STAGING_COMPOSE) config

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 .PHONY: dev-server test lint format canvas-lint canvas-format canvas-test redis worker celery-beat \
-       docker-up docker-down docker-build docker-logs
+       docker-up docker-down docker-build docker-logs staging-up staging-down staging-restart \
+       staging-build staging-logs staging-config
 
 UV ?= uv
 UV_CACHE_DIR ?= .cache/uv
 UV_RUN = UV_CACHE_DIR=$(UV_CACHE_DIR) $(UV) run
+STACK_DIR ?= deploy/stack
+STAGING_COMPOSE = docker compose -f $(STACK_DIR)/docker-compose.yml -f $(STACK_DIR)/docker-compose.staging.yml --project-directory $(STACK_DIR)
 
 lint:
 	$(UV_RUN) ruff check src/orcheo packages/sdk/src packages/agentensor/src apps/backend/src
@@ -57,3 +60,21 @@ docker-build:
 
 docker-logs:
 	docker compose logs -f
+
+staging-up:
+	$(STAGING_COMPOSE) up -d
+
+staging-down:
+	$(STAGING_COMPOSE) down
+
+staging-restart:
+	$(STAGING_COMPOSE) restart
+
+staging-build:
+	$(STAGING_COMPOSE) build --pull
+
+staging-logs:
+	$(STAGING_COMPOSE) logs -f
+
+staging-config:
+	$(STAGING_COMPOSE) config

--- a/deploy/stack/Dockerfile.canvas.staging
+++ b/deploy/stack/Dockerfile.canvas.staging
@@ -1,0 +1,37 @@
+# Stage 1: Build the canvas app from local source with placeholder values.
+FROM node:20-alpine AS build
+
+WORKDIR /app
+
+COPY apps/canvas/package.json apps/canvas/package-lock.json ./
+RUN npm ci
+
+# Set placeholder values for all VITE_ vars so they get baked into the JS
+# bundle. At container startup, an entrypoint script replaces these
+# placeholders with real environment variable values.
+ENV VITE_ORCHEO_BACKEND_URL=__VITE_ORCHEO_BACKEND_URL__ \
+    VITE_ORCHEO_AUTH_ISSUER=__VITE_ORCHEO_AUTH_ISSUER__ \
+    VITE_ORCHEO_AUTH_CLIENT_ID=__VITE_ORCHEO_AUTH_CLIENT_ID__ \
+    VITE_ORCHEO_AUTH_REDIRECT_URI=__VITE_ORCHEO_AUTH_REDIRECT_URI__ \
+    VITE_ORCHEO_AUTH_SCOPES=__VITE_ORCHEO_AUTH_SCOPES__ \
+    VITE_ORCHEO_AUTH_AUDIENCE=__VITE_ORCHEO_AUTH_AUDIENCE__ \
+    VITE_ORCHEO_AUTH_ORGANIZATION=__VITE_ORCHEO_AUTH_ORGANIZATION__ \
+    VITE_ORCHEO_AUTH_PROVIDER_PARAM=__VITE_ORCHEO_AUTH_PROVIDER_PARAM__ \
+    VITE_ORCHEO_AUTH_PROVIDER_GOOGLE=__VITE_ORCHEO_AUTH_PROVIDER_GOOGLE__ \
+    VITE_ORCHEO_AUTH_PROVIDER_GITHUB=__VITE_ORCHEO_AUTH_PROVIDER_GITHUB__ \
+    VITE_ORCHEO_CHATKIT_DOMAIN_KEY=__VITE_ORCHEO_CHATKIT_DOMAIN_KEY__
+
+COPY apps/canvas/ ./
+RUN npm run build
+
+# Stage 2: Serve with nginx.
+FROM nginx:alpine
+
+RUN apk add --no-cache bash
+
+COPY --from=build /app/dist /usr/share/nginx/html
+COPY deploy/stack/nginx-canvas.conf /etc/nginx/conf.d/default.conf
+COPY deploy/stack/canvas-entrypoint.sh /docker-entrypoint.d/40-canvas-env.sh
+RUN chmod +x /docker-entrypoint.d/40-canvas-env.sh
+
+EXPOSE 5173

--- a/deploy/stack/Dockerfile.orcheo.staging
+++ b/deploy/stack/Dockerfile.orcheo.staging
@@ -28,14 +28,12 @@ RUN chmod +x /usr/local/bin/orcheo-entrypoint
 COPY pyproject.toml uv.lock README.md ./
 COPY packages/ packages/
 COPY apps/backend/ apps/backend/
+COPY src/ src/
 
 RUN uv sync --frozen
 RUN uv run python -m playwright install --with-deps chromium chromium-headless-shell \
     && chown -R orcheo:orcheo "$PLAYWRIGHT_BROWSERS_PATH"
 RUN uv tool install --no-cache -U skill-mgr
-
-# Copy the remaining source after dependency installation.
-COPY src/ src/
 
 ENV PATH=/app/.venv/bin:$PATH
 ENV PYTHONPATH=/app/src:/app/apps/backend/src:/app/packages/sdk/src:/app/packages/agentensor/src

--- a/deploy/stack/Dockerfile.orcheo.staging
+++ b/deploy/stack/Dockerfile.orcheo.staging
@@ -1,0 +1,43 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
+WORKDIR /app
+
+# Install Node.js for MCP stdio transports (e.g., Slack node uses npx)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    git \
+    gosu \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs=20.* \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+RUN printf '%s\n' '#!/bin/sh' 'exec uv tool run "$@"' > /usr/local/bin/uvx \
+    && chmod +x /usr/local/bin/uvx
+RUN groupadd --gid 1000 orcheo \
+    && useradd --uid 1000 --gid 1000 --create-home --shell /bin/sh orcheo
+COPY deploy/stack/orcheo-entrypoint.sh /usr/local/bin/orcheo-entrypoint
+RUN chmod +x /usr/local/bin/orcheo-entrypoint
+
+# Copy dependency files first for better caching.
+COPY pyproject.toml uv.lock README.md ./
+COPY packages/ packages/
+COPY apps/backend/ apps/backend/
+
+RUN uv sync --frozen
+RUN uv run python -m playwright install --with-deps chromium chromium-headless-shell \
+    && chown -R orcheo:orcheo "$PLAYWRIGHT_BROWSERS_PATH"
+RUN uv tool install --no-cache -U skill-mgr
+
+# Copy the remaining source after dependency installation.
+COPY src/ src/
+
+ENV PATH=/app/.venv/bin:$PATH
+ENV PYTHONPATH=/app/src:/app/apps/backend/src:/app/packages/sdk/src:/app/packages/agentensor/src
+
+ENTRYPOINT ["orcheo-entrypoint"]

--- a/deploy/stack/docker-compose.staging.yml
+++ b/deploy/stack/docker-compose.staging.yml
@@ -1,0 +1,26 @@
+x-orcheo-staging-build: &orcheo_staging_build
+  context: ../..
+  dockerfile: deploy/stack/Dockerfile.orcheo.staging
+
+services:
+  backend:
+    image: orcheo-stack:staging-local
+    build: *orcheo_staging_build
+
+  worker:
+    image: orcheo-stack:staging-local
+    build: *orcheo_staging_build
+    volumes:
+      - orcheo_data:/data
+      - ../../workspace/agents:/workspace/agents
+      - ./chatkit_widgets:/app/examples/chatkit_widgets/widgets:ro
+
+  celery-beat:
+    image: orcheo-stack:staging-local
+    build: *orcheo_staging_build
+
+  canvas:
+    image: orcheo-canvas:staging-local
+    build:
+      context: ../..
+      dockerfile: deploy/stack/Dockerfile.canvas.staging

--- a/deploy/stack/docker-compose.yml
+++ b/deploy/stack/docker-compose.yml
@@ -1,5 +1,6 @@
 name: orcheo
-# Note: Services using 'env_file: .env' load variables from .env file.
+# Note: Services using 'env_file' load variables from ORCHEO_STACK_ENV_FILE when set,
+# or from the project-local .env file otherwise.
 # Environment variables explicitly defined in the 'environment' section take precedence
 # over those from env_file. This allows overriding .env values when needed.
 services:
@@ -34,7 +35,7 @@ services:
 
   backend:
     image: ${ORCHEO_STACK_IMAGE:-ghcr.io/ai-colleagues/orcheo-stack:latest}
-    env_file: .env
+    env_file: ${ORCHEO_STACK_ENV_FILE:-.env}
     ports:
       - "127.0.0.1:${ORCHEO_BACKEND_LOCAL_PORT:-8000}:8000"
     volumes:
@@ -85,7 +86,7 @@ services:
 
   worker:
     image: ${ORCHEO_STACK_IMAGE:-ghcr.io/ai-colleagues/orcheo-stack:latest}
-    env_file: .env
+    env_file: ${ORCHEO_STACK_ENV_FILE:-.env}
     volumes:
       - orcheo_data:/data
       - ./workspace/agents:/workspace/agents
@@ -124,7 +125,7 @@ services:
 
   celery-beat:
     image: ${ORCHEO_STACK_IMAGE:-ghcr.io/ai-colleagues/orcheo-stack:latest}
-    env_file: .env
+    env_file: ${ORCHEO_STACK_ENV_FILE:-.env}
     volumes:
       - orcheo_data:/data
       - ./chatkit_widgets:/app/examples/chatkit_widgets/widgets:ro
@@ -163,7 +164,7 @@ services:
 
   canvas:
     image: ${ORCHEO_CANVAS_IMAGE:-ghcr.io/ai-colleagues/orcheo-canvas:latest}
-    env_file: .env
+    env_file: ${ORCHEO_STACK_ENV_FILE:-.env}
     ports:
       - "127.0.0.1:${ORCHEO_CANVAS_LOCAL_PORT:-5173}:5173"
     environment:
@@ -192,7 +193,7 @@ services:
     image: caddy:2
     profiles:
       - public-ingress
-    env_file: .env
+    env_file: ${ORCHEO_STACK_ENV_FILE:-.env}
     depends_on:
       backend:
         condition: service_healthy

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -112,6 +112,38 @@ Bundled Caddy is appropriate for standard self-hosted installs and moderate scal
 - WAF, bot management, or DDoS shielding
 - platform-native ingress on Kubernetes or managed container platforms
 
+## Source-Built Staging Host
+
+Use this recipe when the staging machine deploys from a full git checkout and should stay close to the production stack without waiting for package or image releases.
+
+1. **Pull the latest code on the staging host**
+   ```bash
+   git pull
+   ```
+2. **Configure stack environment values**
+   - Create or update `deploy/stack/.env` with the same environment contract used by the production stack.
+   - Start from `deploy/stack/.env.example` if the staging host does not already have an environment file.
+3. **Build the staging images from source**
+   ```bash
+   make staging-build
+   ```
+4. **Start the production-style staging stack**
+   ```bash
+   make staging-up
+   ```
+5. **Inspect or stop the stack when needed**
+   ```bash
+   make staging-config
+   make staging-logs
+   make staging-down
+   ```
+
+The staging targets combine `deploy/stack/docker-compose.yml` with `deploy/stack/docker-compose.staging.yml`. This keeps the same runtime topology as production while swapping published images for local source builds:
+
+- backend, worker, and beat are built from the monorepo checkout
+- Canvas is built from local `apps/canvas` source and served by nginx
+- there are no source bind mounts, Vite dev server processes, or backend `--reload` flags
+
 ## Cloudflare Tunnel Or Similar Split-Origin Tunnel
 
 Use this recipe when the host is not directly reachable or when you intentionally keep Canvas and backend on separate public hostnames behind a tunnel. In this topology, bundled Caddy stays off and the tunnel forwards to the direct localhost ports published by backend and Canvas.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -121,8 +121,8 @@ Use this recipe when the staging machine deploys from a full git checkout and sh
    git pull
    ```
 2. **Configure stack environment values**
-   - Create or update `deploy/stack/.env` with the same environment contract used by the production stack.
-   - Start from `deploy/stack/.env.example` if the staging host does not already have an environment file.
+   - `make staging-*` reuses `~/.orcheo/stack/.env` when it already exists.
+   - On first run it creates `~/.orcheo/stack/.env` from `deploy/stack/.env.example`, then preserves later edits while backfilling newly introduced keys.
 3. **Build the staging images from source**
    ```bash
    make staging-build

--- a/docs/manual_setup.md
+++ b/docs/manual_setup.md
@@ -17,6 +17,14 @@ If you already have the SDK installed, run `orcheo install` to set up or upgrade
 
 For a complete containerized setup with PostgreSQL, Redis, Celery workers, and Canvas, use the bundled Docker Compose configuration.
 
+### Compose Modes
+
+Orcheo ships with two compose entrypoints plus a staging overlay:
+
+- Root `docker-compose.yml` is for live local development. It bind-mounts source code, runs the backend with `--reload`, and serves Canvas via the Vite dev server.
+- `deploy/stack/docker-compose.yml` is the production-style stack contract. It runs built images with no source bind mounts or hot reload.
+- `deploy/stack/docker-compose.staging.yml` layers on top of the production stack file to build those same services from the current repo checkout on the staging host.
+
 ### Quick Start
 
 1. **Set up the stack** using the CLI (this downloads compose files and creates `.env` automatically):
@@ -84,6 +92,31 @@ docker compose -f "$STACK_DIR/docker-compose.yml" --project-directory "$STACK_DI
 # Refresh to the latest published stack image
 docker compose -f "$STACK_DIR/docker-compose.yml" --project-directory "$STACK_DIR" pull
 docker compose -f "$STACK_DIR/docker-compose.yml" --project-directory "$STACK_DIR" up -d
+```
+
+### Staging From A Repo Checkout
+
+Use this flow when a staging machine should run the production-style stack but build images directly from unreleased source code in the current git checkout.
+
+```bash
+git pull
+# create or update deploy/stack/.env for this environment
+make staging-build
+make staging-up
+```
+
+These targets use `deploy/stack/docker-compose.yml` together with `deploy/stack/docker-compose.staging.yml`. The resulting stack:
+
+- keeps the production service topology
+- builds backend, worker, beat, and Canvas from local source
+- avoids source bind mounts and hot reload
+
+Useful commands:
+
+```bash
+make staging-config
+make staging-logs
+make staging-down
 ```
 
 ### Local Testing Without OAuth

--- a/docs/manual_setup.md
+++ b/docs/manual_setup.md
@@ -100,7 +100,8 @@ Use this flow when a staging machine should run the production-style stack but b
 
 ```bash
 git pull
-# create or update deploy/stack/.env for this environment
+# make staging-* will reuse ~/.orcheo/stack/.env when present,
+# or create it from deploy/stack/.env.example on first run
 make staging-build
 make staging-up
 ```

--- a/packages/sdk/src/orcheo_sdk/cli/main.py
+++ b/packages/sdk/src/orcheo_sdk/cli/main.py
@@ -31,6 +31,8 @@ from orcheo_sdk.cli.service_token import app as service_token_app
 from orcheo_sdk.cli.setup import (
     AuthMode,
     SetupMode,
+    build_generated_stack_env_defaults,
+    ensure_stack_env_file,
     execute_setup,
     print_summary,
     run_setup,
@@ -568,6 +570,42 @@ def install_upgrade_command(
         install_docker=install_docker,
         manual_secrets=manual_secrets,
         forced_mode="upgrade",
+    )
+
+
+@install_app.command("ensure-stack-env")
+def ensure_stack_env_command(
+    ctx: typer.Context,
+    env_file: Annotated[
+        str | None,
+        typer.Option(
+            "--env-file",
+            help="Path to the stack .env file to create or update.",
+        ),
+    ] = None,
+    env_template: Annotated[
+        str | None,
+        typer.Option(
+            "--env-template",
+            help="Path to the .env.example template used to seed missing values.",
+        ),
+    ] = None,
+) -> None:
+    """Create or backfill a stack env file without running full install setup."""
+    stack_dir = _resolve_stack_project_dir()
+    resolved_env_file = (
+        Path(env_file).expanduser() if env_file is not None else stack_dir / ".env"
+    )
+    resolved_env_template = (
+        Path(env_template).expanduser()
+        if env_template is not None
+        else stack_dir / ".env.example"
+    )
+    ensure_stack_env_file(
+        env_file=resolved_env_file,
+        env_template=resolved_env_template,
+        console=_resolve_install_console(ctx),
+        generated_defaults=build_generated_stack_env_defaults(),
     )
 
 

--- a/packages/sdk/src/orcheo_sdk/cli/setup.py
+++ b/packages/sdk/src/orcheo_sdk/cli/setup.py
@@ -1277,7 +1277,9 @@ def ensure_stack_env_file(
     Returns ``True`` when the env file was created during this call.
     """
     if not env_template.exists():
-        raise typer.BadParameter(f"Stack env template not found: {env_template}")
+        raise typer.BadParameter(  # pragma: no cover - defensive check
+            f"Stack env template not found: {env_template}"
+        )
 
     env_file.parent.mkdir(parents=True, exist_ok=True)
     env_created = not env_file.exists()

--- a/packages/sdk/src/orcheo_sdk/cli/setup.py
+++ b/packages/sdk/src/orcheo_sdk/cli/setup.py
@@ -1171,12 +1171,29 @@ def _build_env_updates(
             f"{_STACK_IMAGE_REPOSITORY}:{requested_stack_version}"
         )
 
-    defaults: dict[str, str] = {
+    defaults = build_generated_stack_env_defaults()
+    return updates, defaults
+
+
+def build_generated_stack_env_defaults() -> dict[str, str]:
+    """Return auto-generated defaults for a freshly-created stack env file."""
+    return {
         "ORCHEO_POSTGRES_PASSWORD": secrets.token_urlsafe(16),
         "ORCHEO_VAULT_ENCRYPTION_KEY": secrets.token_hex(32),
         "ORCHEO_CHATKIT_TOKEN_SIGNING_KEY": secrets.token_urlsafe(32),
     }
-    return updates, defaults
+
+
+def _read_env_assignments(env_file: Path) -> dict[str, str]:
+    assignments: dict[str, str] = {}
+    for line in env_file.read_text(encoding="utf-8").splitlines():
+        match = _ENV_KEY_PATTERN.match(line)
+        if not match:
+            continue
+        key = match.group(1)
+        _, _, value = line.partition("=")
+        assignments[key] = value.strip()
+    return assignments
 
 
 def _read_env_value(env_file: Path, key: str) -> str | None:
@@ -1248,6 +1265,47 @@ def _upsert_env_values(
     console.print(f"[green]Updated stack env file at {env_file}[/green]")
 
 
+def ensure_stack_env_file(
+    *,
+    env_file: Path,
+    env_template: Path,
+    console: Console,
+    generated_defaults: dict[str, str] | None = None,
+) -> bool:
+    """Create or backfill a stack env file from a template.
+
+    Returns ``True`` when the env file was created during this call.
+    """
+    if not env_template.exists():
+        raise typer.BadParameter(f"Stack env template not found: {env_template}")
+
+    env_file.parent.mkdir(parents=True, exist_ok=True)
+    env_created = not env_file.exists()
+    if env_created:
+        shutil.copyfile(env_template, env_file)
+        console.print(f"[green]Created stack env file at {env_file}[/green]")
+
+    template_defaults = _read_env_assignments(env_template)
+    defaults_to_apply: dict[str, str]
+    if env_created:
+        defaults_to_apply = dict(template_defaults)
+        defaults_to_apply.update(generated_defaults or {})
+    else:
+        existing_assignments = _read_env_assignments(env_file)
+        defaults_to_apply = {
+            key: value
+            for key, value in template_defaults.items()
+            if key not in existing_assignments
+        }
+        for key, value in (generated_defaults or {}).items():
+            if key not in existing_assignments:
+                defaults_to_apply[key] = value
+
+    if defaults_to_apply:
+        _upsert_env_values(env_file, {}, defaults=defaults_to_apply, console=console)
+    return env_created
+
+
 def _preserve_existing_stack_browser_urls(
     *,
     env_file: Path,
@@ -1290,22 +1348,23 @@ def _ensure_stack_assets(
     )
 
     env_file = stack_dir / ".env"
-    env_created = not env_file.exists()
-    if env_created:
-        env_template = stack_dir / ".env.example"
-        if not env_template.exists():
-            _sync_stack_asset(
-                ".env.example",
-                stack_dir,
-                stack_version=synced_stack_version,
-                console=console,
-            )
-        shutil.copyfile(env_template, env_file)
-        console.print(f"[green]Created stack env file at {env_file}[/green]")
-
     updates, defaults = _build_env_updates(
         config,
         requested_stack_version=requested_stack_version,
+    )
+    env_template = stack_dir / ".env.example"
+    if not env_template.exists():
+        _sync_stack_asset(
+            ".env.example",
+            stack_dir,
+            stack_version=synced_stack_version,
+            console=console,
+        )
+    env_created = ensure_stack_env_file(
+        env_file=env_file,
+        env_template=env_template,
+        console=console,
+        generated_defaults=defaults,
     )
     if not env_created:
         _preserve_existing_stack_browser_urls(
@@ -1314,19 +1373,7 @@ def _ensure_stack_assets(
             config=config,
         )
 
-    if env_created:
-        # Fresh install: overwrite template placeholders with generated secrets.
-        _upsert_env_values(env_file, updates, defaults=defaults, console=console)
-    else:
-        # Existing .env: apply config updates only, preserve user secrets.
-        _upsert_env_values(env_file, updates, console=console)
-        # Backfill ChatKit key for legacy env files so compose startup is not blocked.
-        if _read_env_value(env_file, "VITE_ORCHEO_CHATKIT_DOMAIN_KEY") is None:
-            _upsert_env_values(
-                env_file,
-                {"VITE_ORCHEO_CHATKIT_DOMAIN_KEY": _CHATKIT_DOMAIN_KEY_PLACEHOLDER},
-                console=console,
-            )
+    _upsert_env_values(env_file, updates, console=console)
     return stack_dir, env_file
 
 

--- a/tests/sdk/test_cli_setup.py
+++ b/tests/sdk/test_cli_setup.py
@@ -654,6 +654,66 @@ def test_upsert_env_values(tmp_path):
     assert "Updated stack env file" in console.file.getvalue()
 
 
+def test_ensure_stack_env_file_creates_env_and_generates_defaults(tmp_path):
+    env_template = tmp_path / ".env.example"
+    env_template.write_text(
+        "ORCHEO_POSTGRES_PASSWORD=change-me\n"
+        "ORCHEO_VAULT_ENCRYPTION_KEY=replace-with-64-hex-chars\n"
+        "ORCHEO_CHATKIT_TOKEN_SIGNING_KEY=strong-random-secret\n"
+        "VITE_ORCHEO_CHATKIT_DOMAIN_KEY=domain_pk_replace_me\n",
+        encoding="utf-8",
+    )
+    env_file = tmp_path / ".env"
+
+    setup.ensure_stack_env_file(
+        env_file=env_file,
+        env_template=env_template,
+        console=make_console(),
+        generated_defaults={
+            "ORCHEO_POSTGRES_PASSWORD": "generated-password",
+            "ORCHEO_VAULT_ENCRYPTION_KEY": "generated-vault-key",
+            "ORCHEO_CHATKIT_TOKEN_SIGNING_KEY": "generated-signing-key",
+        },
+    )
+
+    result = env_file.read_text(encoding="utf-8")
+    assert "ORCHEO_POSTGRES_PASSWORD=generated-password" in result
+    assert "ORCHEO_VAULT_ENCRYPTION_KEY=generated-vault-key" in result
+    assert "ORCHEO_CHATKIT_TOKEN_SIGNING_KEY=generated-signing-key" in result
+    assert "VITE_ORCHEO_CHATKIT_DOMAIN_KEY=domain_pk_replace_me" in result
+
+
+def test_ensure_stack_env_file_preserves_existing_values_and_backfills_missing(
+    tmp_path,
+):
+    env_template = tmp_path / ".env.example"
+    env_template.write_text(
+        "ORCHEO_POSTGRES_PASSWORD=change-me\n"
+        "ORCHEO_VAULT_ENCRYPTION_KEY=replace-with-64-hex-chars\n"
+        "VITE_ORCHEO_CHATKIT_DOMAIN_KEY=domain_pk_replace_me\n",
+        encoding="utf-8",
+    )
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "ORCHEO_POSTGRES_PASSWORD=existing-password\n", encoding="utf-8"
+    )
+
+    setup.ensure_stack_env_file(
+        env_file=env_file,
+        env_template=env_template,
+        console=make_console(),
+        generated_defaults={
+            "ORCHEO_POSTGRES_PASSWORD": "generated-password",
+            "ORCHEO_VAULT_ENCRYPTION_KEY": "generated-vault-key",
+        },
+    )
+
+    result = env_file.read_text(encoding="utf-8")
+    assert "ORCHEO_POSTGRES_PASSWORD=existing-password" in result
+    assert "ORCHEO_VAULT_ENCRYPTION_KEY=generated-vault-key" in result
+    assert "VITE_ORCHEO_CHATKIT_DOMAIN_KEY=domain_pk_replace_me" in result
+
+
 def test_ensure_stack_assets_fresh(monkeypatch, tmp_path):
     monkeypatch.setenv("ORCHEO_STACK_DIR", str(tmp_path))
 
@@ -702,9 +762,15 @@ def test_ensure_stack_assets_existing_env(monkeypatch, tmp_path):
     (tmp_path / ".env").write_text(
         "ORCHEO_API_URL=http://existing\nVITE_ORCHEO_BACKEND_URL=http://existing"
     )
-    monkeypatch.setattr(
-        setup, "_sync_stack_assets_with_best_source", lambda *args, **kwargs: "1.0"
-    )
+
+    def stub_sync(stack_dir, stack_version, console):
+        del stack_version, console
+        (stack_dir / ".env.example").write_text(
+            "VITE_ORCHEO_CHATKIT_DOMAIN_KEY=domain_pk_replace_me\n", encoding="utf-8"
+        )
+        return "1.0"
+
+    monkeypatch.setattr(setup, "_sync_stack_assets_with_best_source", stub_sync)
     updates = []
 
     def upsert(env_file, updates_dict, **kwargs):

--- a/tests/sdk/test_cli_stack.py
+++ b/tests/sdk/test_cli_stack.py
@@ -100,6 +100,43 @@ def test_stack_start_shortcut_runs_compose_up_detached(
     ]
 
 
+def test_install_ensure_stack_env_command_creates_env_file(
+    runner: Any,
+    env: dict[str, str],
+    tmp_path: Path,
+) -> None:
+    env_template = tmp_path / ".env.example"
+    env_template.write_text(
+        "ORCHEO_POSTGRES_PASSWORD=change-me\n"
+        "ORCHEO_VAULT_ENCRYPTION_KEY=replace-with-64-hex-chars\n"
+        "ORCHEO_CHATKIT_TOKEN_SIGNING_KEY=strong-random-secret\n"
+        "VITE_ORCHEO_CHATKIT_DOMAIN_KEY=domain_pk_replace_me\n",
+        encoding="utf-8",
+    )
+    env_file = tmp_path / "stack" / ".env"
+
+    result = runner.invoke(
+        app,
+        [
+            "--no-update-check",
+            "install",
+            "ensure-stack-env",
+            "--env-file",
+            str(env_file),
+            "--env-template",
+            str(env_template),
+        ],
+        env=env,
+    )
+
+    assert result.exit_code == 0
+    env_content = env_file.read_text(encoding="utf-8")
+    assert "ORCHEO_POSTGRES_PASSWORD=change-me" not in env_content
+    assert "ORCHEO_VAULT_ENCRYPTION_KEY=replace-with-64-hex-chars" not in env_content
+    assert "ORCHEO_CHATKIT_TOKEN_SIGNING_KEY=strong-random-secret" not in env_content
+    assert "VITE_ORCHEO_CHATKIT_DOMAIN_KEY=domain_pk_replace_me" in env_content
+
+
 def test_stack_logs_treats_sigint_exit_as_success(
     runner: Any,
     env: dict[str, str],

--- a/tests/sdk/test_stack_caddy_assets.py
+++ b/tests/sdk/test_stack_caddy_assets.py
@@ -20,6 +20,11 @@ def test_stack_compose_defines_public_ingress_and_direct_ports() -> None:
     compose = yaml.safe_load(COMPOSE_FILE.read_text(encoding="utf-8"))
     services = compose["services"]
 
+    assert services["backend"]["env_file"] == "${ORCHEO_STACK_ENV_FILE:-.env}"
+    assert services["worker"]["env_file"] == "${ORCHEO_STACK_ENV_FILE:-.env}"
+    assert services["celery-beat"]["env_file"] == "${ORCHEO_STACK_ENV_FILE:-.env}"
+    assert services["canvas"]["env_file"] == "${ORCHEO_STACK_ENV_FILE:-.env}"
+    assert services["caddy"]["env_file"] == "${ORCHEO_STACK_ENV_FILE:-.env}"
     assert (
         "127.0.0.1:${ORCHEO_BACKEND_LOCAL_PORT:-8000}:8000"
         in services["backend"]["ports"]

--- a/tests/sdk/test_stack_caddy_assets.py
+++ b/tests/sdk/test_stack_caddy_assets.py
@@ -11,6 +11,7 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[2]
 STACK_DIR = REPO_ROOT / "deploy" / "stack"
 COMPOSE_FILE = STACK_DIR / "docker-compose.yml"
+STAGING_COMPOSE_FILE = STACK_DIR / "docker-compose.staging.yml"
 CADDYFILE = STACK_DIR / "Caddyfile"
 ENV_EXAMPLE = STACK_DIR / ".env.example"
 
@@ -82,6 +83,26 @@ def test_env_example_documents_public_ingress_contract() -> None:
     assert "VITE_ALLOWED_HOSTS=localhost,127.0.0.1" in content
 
 
+def test_staging_compose_builds_local_images_from_repo_source() -> None:
+    compose = yaml.safe_load(STAGING_COMPOSE_FILE.read_text(encoding="utf-8"))
+    services = compose["services"]
+
+    assert services["backend"]["image"] == "orcheo-stack:staging-local"
+    assert services["worker"]["image"] == "orcheo-stack:staging-local"
+    assert services["celery-beat"]["image"] == "orcheo-stack:staging-local"
+    assert services["canvas"]["image"] == "orcheo-canvas:staging-local"
+    assert services["backend"]["build"] == {
+        "context": "../..",
+        "dockerfile": "deploy/stack/Dockerfile.orcheo.staging",
+    }
+    assert services["worker"]["build"] == services["backend"]["build"]
+    assert services["celery-beat"]["build"] == services["backend"]["build"]
+    assert services["canvas"]["build"] == {
+        "context": "../..",
+        "dockerfile": "deploy/stack/Dockerfile.canvas.staging",
+    }
+
+
 @pytest.mark.skipif(shutil.which("docker") is None, reason="docker is not available")
 def test_stack_compose_config_renders_with_profiles(tmp_path: Path) -> None:
     temp_stack_dir = tmp_path / "stack"
@@ -109,6 +130,39 @@ def test_stack_compose_config_renders_with_profiles(tmp_path: Path) -> None:
         capture_output=True,
         text=True,
         cwd=temp_stack_dir,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(shutil.which("docker") is None, reason="docker is not available")
+def test_staging_stack_compose_config_renders(tmp_path: Path) -> None:
+    temp_repo_root = tmp_path / "repo"
+    temp_stack_dir = temp_repo_root / "deploy" / "stack"
+    temp_stack_dir.mkdir(parents=True)
+    for source in (COMPOSE_FILE, STAGING_COMPOSE_FILE, CADDYFILE, ENV_EXAMPLE):
+        target = temp_stack_dir / source.name
+        target.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+    (temp_stack_dir / ".env").write_text(
+        ENV_EXAMPLE.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+
+    result = subprocess.run(
+        [
+            "docker",
+            "compose",
+            "-f",
+            str(temp_stack_dir / "docker-compose.yml"),
+            "-f",
+            str(temp_stack_dir / "docker-compose.staging.yml"),
+            "--project-directory",
+            str(temp_stack_dir),
+            "config",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=temp_repo_root,
     )
 
     assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

This PR adds a production-style staging workflow that builds Orcheo directly from the current repository checkout, without relying on published images.

## Main Changes

- Adds staging Make targets:
  - `make staging-env`
  - `make staging-build`
  - `make staging-up`
  - `make staging-down`
  - `make staging-restart`
  - `make staging-logs`
  - `make staging-config`

- Adds a new CLI command:
  - `orcheo install ensure-stack-env`
  - This creates or updates a stack `.env` file from a template without running the full install flow.

- Refactors stack env handling so that:
  - new `.env` files are seeded from `.env.example`
  - generated secrets/defaults are filled in automatically
  - existing `.env` files keep user-defined values
  - newly introduced keys are backfilled into existing env files

- Updates the stack compose setup to support an external env file via `ORCHEO_STACK_ENV_FILE` instead of assuming only a project-local `.env`.

- Adds a staging compose overlay and dedicated Dockerfiles so staging can:
  - build backend, worker, and beat from the monorepo source
  - build Canvas from local source and serve it through nginx
  - keep the same service topology as the production stack
  - avoid source bind mounts, Vite dev server usage, and backend hot reload

- Documents the new staging deployment flow in `docs/deployment.md` and `docs/manual_setup.md`.

- Adds test coverage for:
  - stack env creation and backfilling behavior
  - the new `install ensure-stack-env` command
  - staging compose structure and config rendering

## Why

This makes it easier to run a staging environment that stays close to production while still testing unreleased code directly from a git checkout.