### PR TITLE
Fix vibe chat session handling and agent skill installation

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -19,7 +19,8 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 RUN printf '%s\n' '#!/bin/sh' 'exec uv tool run "$@"' > /usr/local/bin/uvx \
     && chmod +x /usr/local/bin/uvx
 RUN groupadd --gid 1000 orcheo \
-    && useradd --uid 1000 --gid 1000 --create-home --shell /bin/sh orcheo
+    && mkdir -p /data/home \
+    && useradd --uid 1000 --gid 1000 --home-dir /data/home --create-home --shell /bin/sh orcheo
 COPY deploy/stack/orcheo-entrypoint.sh /usr/local/bin/orcheo-entrypoint
 RUN chmod +x /usr/local/bin/orcheo-entrypoint
 
@@ -32,6 +33,9 @@ COPY apps/backend/ apps/backend/
 RUN uv sync --frozen
 RUN uv run python -m playwright install --with-deps chromium chromium-headless-shell \
     && chown -R orcheo:orcheo "$PLAYWRIGHT_BROWSERS_PATH"
+RUN HOME=/data/home UV_TOOL_DIR=/usr/local/share/uv/tools UV_TOOL_BIN_DIR=/usr/local/bin \
+    uv tool install --no-cache -U skill-mgr
+ENV PATH=/app/.venv/bin:$PATH
 
 # Copy the rest of the application
 COPY src/ src/

--- a/apps/canvas/src/features/account/pages/settings.tsx
+++ b/apps/canvas/src/features/account/pages/settings.tsx
@@ -29,7 +29,7 @@ export default function Settings() {
   } = useCredentialVault();
 
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="flex h-full min-h-0 flex-col overflow-y-auto">
       <TopNavigation
         credentials={credentials}
         isCredentialsLoading={isCredentialsLoading}

--- a/apps/canvas/src/features/vibe/components/vibe-sidebar.tsx
+++ b/apps/canvas/src/features/vibe/components/vibe-sidebar.tsx
@@ -31,7 +31,7 @@ export function VibeSidebar({ isCollapsed = false }: VibeSidebarProps) {
     contextString,
   } = useVibe();
 
-  const { getClientSecret, sessionStatus, refreshSession } =
+  const { getClientSecret, sessionStatus, hasSession, refreshSession } =
     useVibeChat(agentWorkflowId);
 
   const colorScheme = useColorScheme();
@@ -86,7 +86,7 @@ export function VibeSidebar({ isCollapsed = false }: VibeSidebarProps) {
       );
     }
 
-    if (sessionStatus === "loading") {
+    if (sessionStatus === "loading" && !hasSession) {
       return (
         <div className="flex flex-1 flex-col items-center justify-center gap-2 text-sm text-muted-foreground">
           <Loader2 className="h-5 w-5 animate-spin" />
@@ -121,7 +121,7 @@ export function VibeSidebar({ isCollapsed = false }: VibeSidebarProps) {
     }
 
     return null;
-  }, [isProvisioning, sessionStatus, refreshSession]);
+  }, [hasSession, isProvisioning, sessionStatus, refreshSession]);
 
   if (isCollapsed) {
     return (
@@ -179,9 +179,13 @@ export function VibeSidebar({ isCollapsed = false }: VibeSidebarProps) {
           </Button>
         </div>
       ) : (
-        <div className={cn("flex flex-1 flex-col overflow-hidden px-2 py-2")}>
-          {statusView}
-          {!statusView && agentWorkflowId && (
+        <div className="relative flex flex-1 flex-col overflow-hidden px-2 py-2">
+          {statusView && (
+            <div className="absolute inset-2 z-10 flex rounded-md bg-background/95">
+              {statusView}
+            </div>
+          )}
+          {agentWorkflowId && sessionStatus !== "error" && (
             <Suspense
               fallback={
                 <div className="flex h-full w-full flex-col gap-3">
@@ -193,7 +197,9 @@ export function VibeSidebar({ isCollapsed = false }: VibeSidebarProps) {
               <ChatKitSurfaceLazy
                 options={chatKitOptions}
                 className={cn(
-                  sessionStatus !== "ready" && "pointer-events-none opacity-50",
+                  (isProvisioning ||
+                    (sessionStatus === "loading" && !hasSession)) &&
+                    "pointer-events-none opacity-50",
                 )}
               />
             </Suspense>

--- a/apps/canvas/src/features/vibe/hooks/use-vibe-chat.test.ts
+++ b/apps/canvas/src/features/vibe/hooks/use-vibe-chat.test.ts
@@ -64,4 +64,55 @@ describe("useVibeChat", () => {
 
     await expect(refresh).resolves.toBe("secret-2");
   });
+
+  it("clears cached secrets before refreshing after workflow switch", async () => {
+    let resolveWorkflowTwo: (value: {
+      clientSecret: string;
+      expiresAt: number;
+    }) => void = () => undefined;
+
+    vi.mocked(requestWorkflowChatSession)
+      .mockResolvedValueOnce({
+        clientSecret: "secret-1",
+        expiresAt: Date.now() + 60_000,
+      })
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveWorkflowTwo = resolve;
+          }),
+      );
+
+    const { result, rerender } = renderHook(
+      ({ workflowId }: { workflowId: string | null }) =>
+        useVibeChat(workflowId),
+      {
+        initialProps: { workflowId: "workflow-1" },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.sessionStatus).toBe("ready");
+    });
+
+    rerender({ workflowId: "workflow-2" });
+
+    await waitFor(() => {
+      expect(result.current.sessionStatus).toBe("loading");
+    });
+    expect(result.current.hasSession).toBe(false);
+
+    resolveWorkflowTwo({
+      clientSecret: "secret-2",
+      expiresAt: Date.now() + 60_000,
+    });
+
+    await waitFor(() => {
+      expect(result.current.sessionStatus).toBe("ready");
+    });
+
+    await expect(result.current.getClientSecret(null)).resolves.toBe(
+      "secret-2",
+    );
+  });
 });

--- a/apps/canvas/src/features/vibe/hooks/use-vibe-chat.test.ts
+++ b/apps/canvas/src/features/vibe/hooks/use-vibe-chat.test.ts
@@ -1,0 +1,67 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { requestWorkflowChatSession } from "@features/chatkit/lib/workflow-session";
+import { useVibeChat } from "./use-vibe-chat";
+
+vi.mock("@features/chatkit/lib/workflow-session", () => ({
+  requestWorkflowChatSession: vi.fn(),
+}));
+
+describe("useVibeChat", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("tracks whether a usable session secret has been loaded", async () => {
+    vi.mocked(requestWorkflowChatSession).mockResolvedValue({
+      clientSecret: "secret-1",
+      expiresAt: Date.now() + 60_000,
+    });
+
+    const { result } = renderHook(() => useVibeChat("workflow-1"));
+
+    await waitFor(() => {
+      expect(result.current.sessionStatus).toBe("ready");
+    });
+
+    expect(result.current.hasSession).toBe(true);
+  });
+
+  it("keeps the existing session marked available while refreshing", async () => {
+    let resolveRefresh: (value: {
+      clientSecret: string;
+      expiresAt: number;
+    }) => void = () => undefined;
+    vi.mocked(requestWorkflowChatSession)
+      .mockResolvedValueOnce({
+        clientSecret: "secret-1",
+        expiresAt: Date.now() - 1,
+      })
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveRefresh = resolve;
+          }),
+      );
+
+    const { result } = renderHook(() => useVibeChat("workflow-1"));
+
+    await waitFor(() => {
+      expect(result.current.sessionStatus).toBe("ready");
+    });
+
+    const refresh = result.current.getClientSecret(null);
+
+    await waitFor(() => {
+      expect(result.current.sessionStatus).toBe("loading");
+    });
+    expect(result.current.hasSession).toBe(true);
+
+    resolveRefresh({
+      clientSecret: "secret-2",
+      expiresAt: Date.now() + 60_000,
+    });
+
+    await expect(refresh).resolves.toBe("secret-2");
+  });
+});

--- a/apps/canvas/src/features/vibe/hooks/use-vibe-chat.ts
+++ b/apps/canvas/src/features/vibe/hooks/use-vibe-chat.ts
@@ -82,6 +82,12 @@ export function useVibeChat(workflowId: string | null) {
       setSessionError(null);
       return;
     }
+
+    secretRef.current = null;
+    expiresAtRef.current = null;
+    setHasSession(false);
+    setSessionError(null);
+
     void refreshSession();
   }, [workflowId, refreshSession]);
 

--- a/apps/canvas/src/features/vibe/hooks/use-vibe-chat.ts
+++ b/apps/canvas/src/features/vibe/hooks/use-vibe-chat.ts
@@ -11,6 +11,7 @@ export function useVibeChat(workflowId: string | null) {
   const [sessionStatus, setSessionStatus] =
     useState<VibeChatSessionStatus>("idle");
   const [sessionError, setSessionError] = useState<string | null>(null);
+  const [hasSession, setHasSession] = useState(false);
   const secretRef = useRef<string | null>(null);
   const expiresAtRef = useRef<number | null>(null);
   const refreshingRef = useRef(false);
@@ -35,6 +36,7 @@ export function useVibeChat(workflowId: string | null) {
         const session = await requestWorkflowChatSession(workflowId);
         secretRef.current = session.clientSecret;
         expiresAtRef.current = session.expiresAt;
+        setHasSession(true);
         setSessionStatus("ready");
         refreshingRef.current = false;
         return session.clientSecret;
@@ -49,6 +51,7 @@ export function useVibeChat(workflowId: string | null) {
         : "Chat session request failed";
     secretRef.current = null;
     expiresAtRef.current = null;
+    setHasSession(false);
     setSessionStatus("error");
     setSessionError(message);
     refreshingRef.current = false;
@@ -74,6 +77,7 @@ export function useVibeChat(workflowId: string | null) {
     if (!workflowId) {
       secretRef.current = null;
       expiresAtRef.current = null;
+      setHasSession(false);
       setSessionStatus("idle");
       setSessionError(null);
       return;
@@ -81,5 +85,11 @@ export function useVibeChat(workflowId: string | null) {
     void refreshSession();
   }, [workflowId, refreshSession]);
 
-  return { getClientSecret, sessionStatus, sessionError, refreshSession };
+  return {
+    getClientSecret,
+    sessionStatus,
+    sessionError,
+    hasSession,
+    refreshSession,
+  };
 }

--- a/deploy/stack/Dockerfile.orcheo
+++ b/deploy/stack/Dockerfile.orcheo
@@ -19,8 +19,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 RUN printf '%s\n' '#!/bin/sh' 'exec uv tool run "$@"' > /usr/local/bin/uvx \
     && chmod +x /usr/local/bin/uvx
-RUN groupadd --gid 1000 orcheo \
-    && useradd --uid 1000 --gid 1000 --create-home --shell /bin/sh orcheo
+RUN mkdir -p /data/home \
+    && groupadd --gid 1000 orcheo \
+    && useradd --uid 1000 --gid 1000 --home-dir /data/home --create-home --shell /bin/sh orcheo
 COPY orcheo-entrypoint.sh /usr/local/bin/orcheo-entrypoint
 RUN chmod +x /usr/local/bin/orcheo-entrypoint
 
@@ -28,5 +29,6 @@ RUN chmod +x /usr/local/bin/orcheo-entrypoint
 RUN uv pip install --system --no-cache -U orcheo orcheo-backend orcheo-sdk
 RUN uv run python -m playwright install --with-deps chromium chromium-headless-shell \
     && chown -R orcheo:orcheo "$PLAYWRIGHT_BROWSERS_PATH"
-RUN uv tool install --no-cache -U skill-mgr
+RUN HOME=/data/home UV_TOOL_DIR=/usr/local/share/uv/tools UV_TOOL_BIN_DIR=/usr/local/bin \
+    uv tool install --no-cache -U skill-mgr
 ENTRYPOINT ["orcheo-entrypoint"]

--- a/deploy/stack/Dockerfile.orcheo.staging
+++ b/deploy/stack/Dockerfile.orcheo.staging
@@ -19,8 +19,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 RUN printf '%s\n' '#!/bin/sh' 'exec uv tool run "$@"' > /usr/local/bin/uvx \
     && chmod +x /usr/local/bin/uvx
-RUN groupadd --gid 1000 orcheo \
-    && useradd --uid 1000 --gid 1000 --create-home --shell /bin/sh orcheo
+RUN mkdir -p /data/home \
+    && groupadd --gid 1000 orcheo \
+    && useradd --uid 1000 --gid 1000 --home-dir /data/home --create-home --shell /bin/sh orcheo
 COPY deploy/stack/orcheo-entrypoint.sh /usr/local/bin/orcheo-entrypoint
 RUN chmod +x /usr/local/bin/orcheo-entrypoint
 
@@ -33,7 +34,8 @@ COPY src/ src/
 RUN uv sync --frozen
 RUN uv run python -m playwright install --with-deps chromium chromium-headless-shell \
     && chown -R orcheo:orcheo "$PLAYWRIGHT_BROWSERS_PATH"
-RUN uv tool install --no-cache -U skill-mgr
+RUN HOME=/data/home UV_TOOL_DIR=/usr/local/share/uv/tools UV_TOOL_BIN_DIR=/usr/local/bin \
+    uv tool install --no-cache -U skill-mgr
 
 ENV PATH=/app/.venv/bin:$PATH
 ENV PYTHONPATH=/app/src:/app/apps/backend/src:/app/packages/sdk/src:/app/packages/agentensor/src

--- a/deploy/stack/orcheo-entrypoint.sh
+++ b/deploy/stack/orcheo-entrypoint.sh
@@ -14,11 +14,16 @@ export HOME="$home_dir"
 
 codex_home="${CODEX_HOME:-$HOME/.codex}"
 claude_home="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+gemini_home="${GEMINI_CONFIG_DIR:-$HOME/.gemini}"
+xdg_config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
+xdg_cache_home="${XDG_CACHE_HOME:-$HOME/.cache}"
+xdg_data_home="${XDG_DATA_HOME:-$HOME/.local/share}"
 runtime_root="/data/agent-runtimes"
 cache_dir="${ORCHEO_CACHE_DIR:-/data/cache/orcheo}"
 plugin_dir="${ORCHEO_PLUGIN_DIR:-/data/plugins}"
 uv_cache_dir="${UV_CACHE_DIR:-/data/cache/uv}"
 workspace_root="/workspace/agents"
+skill_ref="${ORCHEO_AGENT_SKILL_REF:-AI-Colleagues/agent-skills/orcheo}"
 
 ensure_dir() {
   dir_path="$1"
@@ -43,11 +48,72 @@ same_path_target() {
   [ "$(stat -c '%d:%i' "$left")" = "$(stat -c '%d:%i' "$right")" ]
 }
 
+agent_skills_installed() {
+  [ -f "$HOME/.claude/skills/orcheo/SKILL.md" ] \
+    && [ -f "$HOME/.codex/skills/orcheo/SKILL.md" ] \
+    && [ -f "$HOME/.orcheo/skills/orcheo/SKILL.md" ] \
+    && [ -f "$HOME/.gemini/skills/orcheo/SKILL.md" ]
+}
+
+install_agent_skills() {
+  case "${ORCHEO_INSTALL_AGENT_SKILLS:-1}" in
+    0|false|False|FALSE|no|No|NO)
+      return
+      ;;
+  esac
+
+  if agent_skills_installed || ! command -v skill-mgr >/dev/null 2>&1; then
+    return
+  fi
+
+  if ! skill-mgr install "$skill_ref" --format json >/dev/null; then
+    echo "Warning: failed to install Orcheo agent skills with skill-mgr." >&2
+  fi
+}
+
+install_agent_skills_as_runtime_user() {
+  gosu "$runtime_user:$runtime_group" env \
+    HOME="$HOME" \
+    ORCHEO_RUNTIME_HOME="$home_dir" \
+    ORCHEO_RUNTIME_USER="$runtime_user" \
+    ORCHEO_RUNTIME_GROUP="$runtime_group" \
+    CODEX_HOME="$codex_home" \
+    CLAUDE_CONFIG_DIR="$claude_home" \
+    GEMINI_CONFIG_DIR="$gemini_home" \
+    XDG_CONFIG_HOME="$xdg_config_home" \
+    XDG_CACHE_HOME="$xdg_cache_home" \
+    XDG_DATA_HOME="$xdg_data_home" \
+    ORCHEO_AGENT_SKILL_REF="$skill_ref" \
+    ORCHEO_INSTALL_AGENT_SKILLS="${ORCHEO_INSTALL_AGENT_SKILLS:-1}" \
+    PATH="$PATH" \
+    sh -c '
+      case "${ORCHEO_INSTALL_AGENT_SKILLS:-1}" in
+        0|false|False|FALSE|no|No|NO)
+          exit 0
+          ;;
+      esac
+      if [ -f "$HOME/.claude/skills/orcheo/SKILL.md" ] \
+        && [ -f "$HOME/.codex/skills/orcheo/SKILL.md" ] \
+        && [ -f "$HOME/.orcheo/skills/orcheo/SKILL.md" ] \
+        && [ -f "$HOME/.gemini/skills/orcheo/SKILL.md" ]; then
+        exit 0
+      fi
+      if ! command -v skill-mgr >/dev/null 2>&1; then
+        exit 0
+      fi
+      if ! skill-mgr install "$ORCHEO_AGENT_SKILL_REF" --format json >/dev/null; then
+        echo "Warning: failed to install Orcheo agent skills with skill-mgr." >&2
+      fi
+    '
+}
+
 if [ "$(id -u)" -eq 0 ]; then
   ensure_dir /data
   ensure_dir "$HOME" true
   ensure_dir "$codex_home" true
   ensure_dir "$claude_home" true
+  ensure_dir "$HOME/.orcheo" true
+  ensure_dir "$gemini_home" true
   ensure_dir "$runtime_root" true
   ensure_dir "$cache_dir" true
   ensure_dir "$plugin_dir" true
@@ -64,7 +130,23 @@ if [ "$(id -u)" -eq 0 ]; then
     ensure_dir /app/.venv true
   fi
 
-  exec gosu "$runtime_user:$runtime_group" "$@"
+  install_agent_skills_as_runtime_user
+
+  exec gosu "$runtime_user:$runtime_group" env \
+    HOME="$HOME" \
+    ORCHEO_RUNTIME_HOME="$home_dir" \
+    ORCHEO_RUNTIME_USER="$runtime_user" \
+    ORCHEO_RUNTIME_GROUP="$runtime_group" \
+    CODEX_HOME="$codex_home" \
+    CLAUDE_CONFIG_DIR="$claude_home" \
+    GEMINI_CONFIG_DIR="$gemini_home" \
+    XDG_CONFIG_HOME="$xdg_config_home" \
+    XDG_CACHE_HOME="$xdg_cache_home" \
+    XDG_DATA_HOME="$xdg_data_home" \
+    PATH="$PATH" \
+    "$@"
 fi
+
+install_agent_skills
 
 exec "$@"

--- a/deploy/stack/orcheo-entrypoint.sh
+++ b/deploy/stack/orcheo-entrypoint.sh
@@ -49,10 +49,10 @@ same_path_target() {
 }
 
 agent_skills_installed() {
-  [ -f "$HOME/.claude/skills/orcheo/SKILL.md" ] \
-    && [ -f "$HOME/.codex/skills/orcheo/SKILL.md" ] \
+  [ -f "$claude_home/skills/orcheo/SKILL.md" ] \
+    && [ -f "$codex_home/skills/orcheo/SKILL.md" ] \
     && [ -f "$HOME/.orcheo/skills/orcheo/SKILL.md" ] \
-    && [ -f "$HOME/.gemini/skills/orcheo/SKILL.md" ]
+    && [ -f "$gemini_home/skills/orcheo/SKILL.md" ]
 }
 
 install_agent_skills() {
@@ -92,10 +92,10 @@ install_agent_skills_as_runtime_user() {
           exit 0
           ;;
       esac
-      if [ -f "$HOME/.claude/skills/orcheo/SKILL.md" ] \
-        && [ -f "$HOME/.codex/skills/orcheo/SKILL.md" ] \
+      if [ -f "$CLAUDE_CONFIG_DIR/skills/orcheo/SKILL.md" ] \
+        && [ -f "$CODEX_HOME/skills/orcheo/SKILL.md" ] \
         && [ -f "$HOME/.orcheo/skills/orcheo/SKILL.md" ] \
-        && [ -f "$HOME/.gemini/skills/orcheo/SKILL.md" ]; then
+        && [ -f "$GEMINI_CONFIG_DIR/skills/orcheo/SKILL.md" ]; then
         exit 0
       fi
       if ! command -v skill-mgr >/dev/null 2>&1; then

--- a/packages/sdk/src/orcheo_sdk/cli/main.py
+++ b/packages/sdk/src/orcheo_sdk/cli/main.py
@@ -226,9 +226,19 @@ def _install_agent_skills(*, console: Console, should_install: bool) -> None:
         return
     skill_mgr_bin = shutil.which("skill-mgr")
     if skill_mgr_bin:
-        cmd = [skill_mgr_bin, "install", "AI-Colleagues/agent-skills/orcheo"]
+        cmd = [
+            skill_mgr_bin,
+            "install",
+            "AI-Colleagues/agent-skills/orcheo",
+        ]
     else:
-        cmd = ["uv", "run", "skill-mgr", "install", "AI-Colleagues/agent-skills/orcheo"]
+        cmd = [
+            "uv",
+            "run",
+            "skill-mgr",
+            "install",
+            "AI-Colleagues/agent-skills/orcheo",
+        ]
     console.print(f"[cyan]$ {' '.join(cmd)}[/cyan]")
     result = subprocess.run(cmd, check=False)
     if result.returncode != 0:

--- a/tests/backend/test_chatkit_asset_proxy.py
+++ b/tests/backend/test_chatkit_asset_proxy.py
@@ -9,6 +9,7 @@ from orcheo_backend.app.chatkit_asset_proxy import (
     _RESPONSE_HEADER_ALLOWLIST,
     _inject_fetch_guard,
     _normalize_path_prefix,
+    _rewrite_chatkit_html,
     _sanitize_asset_path,
     proxy_chatkit_asset,
 )
@@ -100,6 +101,13 @@ def test_inject_fetch_guard_inserts_after_head() -> None:
     result = _inject_fetch_guard(html)
     assert "data-orcheo-fetch-guard" in result
     assert result.index("data-orcheo-fetch-guard") < result.index("<title>")
+
+
+def test_rewrite_chatkit_html_injects_fetch_guard() -> None:
+    """Proxied ChatKit HTML includes the fetch guard."""
+    html = "<html><head></head><body><div id='root'></div></body></html>"
+    result = _rewrite_chatkit_html(html, "/api/chatkit/assets/ck1/")
+    assert "data-orcheo-fetch-guard" in result
 
 
 @pytest.mark.asyncio

--- a/tests/sdk/test_cli_main.py
+++ b/tests/sdk/test_cli_main.py
@@ -796,6 +796,11 @@ def test_install_agent_skills_with_skill_mgr_found(
     monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
     main_mod._install_agent_skills(console=console, should_install=True)
     assert ran_cmds[0][0] == "/usr/bin/skill-mgr"
+    assert ran_cmds[0] == [
+        "/usr/bin/skill-mgr",
+        "install",
+        "AI-Colleagues/agent-skills/orcheo",
+    ]
 
 
 def test_install_agent_skills_without_skill_mgr_falls_back_to_uv(
@@ -816,6 +821,11 @@ def test_install_agent_skills_without_skill_mgr_falls_back_to_uv(
     monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
     main_mod._install_agent_skills(console=console, should_install=True)
     assert ran_cmds[0][:2] == ["uv", "run"]
+    assert ran_cmds[0][2:] == [
+        "skill-mgr",
+        "install",
+        "AI-Colleagues/agent-skills/orcheo",
+    ]
 
 
 def test_install_agent_skills_nonzero_exit_prints_warning(


### PR DESCRIPTION
## Summary
- Preserve an existing vibe chat session while a refresh is in flight so the sidebar stays usable instead of flashing a loading state
- Improve sidebar layout so chat content and status overlays render cleanly without blocking the page
- Install the Orcheo agent skill set in container and runtime startup paths, including shared home/config directories for Codex, Claude, Gemini, and Orcheo
- Add coverage for vibe chat session tracking, ChatKit HTML rewriting, and CLI skill installation command construction

## Testing
- Added and updated unit tests for vibe chat session behavior, ChatKit proxy rewriting, and CLI skill installation commands
- Not run (not requested)