### PR TITLE
Add workflow frontmatter parsing for Python LangGraph scripts

### DIFF
--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -81,7 +81,7 @@ This installs completion for your current shell (bash, zsh, fish, or PowerShell)
 | `orcheo workflow run <workflow> [--inputs <json> \| --inputs-file <path>] [--config <json> \| --config-file <path>] [--verbose] [--stream/--no-stream]` | Trigger a workflow execution. Streaming is enabled by default. |
 | `orcheo workflow evaluate <workflow> [--inputs <json> \| --inputs-file <path>] [--config <json> \| --config-file <path>] [--evaluation <json> \| --evaluation-file <path>] [--verbose] [--stream/--no-stream]` | Trigger a workflow evaluation run (requires streaming mode). |
 | `orcheo workflow update <workflow> [--name <name>] [--description <text>] [--handle <handle>] [--chatkit-prompts <json> \| --chatkit-prompts-file <path> \| --clear-chatkit-prompts]` | Update workflow metadata, including per-workflow public ChatKit starter prompts. |
-| `orcheo workflow upload <file> [--name <name>] [--config <json> \| --config-file <path>]` | Upload a workflow from a Python LangGraph script (`.py`). |
+| `orcheo workflow upload <file> [--id <ref>] [--name <name>] [--entrypoint <name>] [--config <json> \| --config-file <path>]` | Upload a workflow from a Python LangGraph script (`.py`). The script may declare an optional `# /// orcheo ... # ///` frontmatter block whose values are used as defaults (CLI flags override). |
 | `orcheo workflow save-config <workflow> [--version <num>] (--config <json> \| --config-file <path> \| --clear)` | Save version `runnable_config` without creating a new version. |
 | `orcheo workflow download <workflow> [-o <file>] [--config-out <file>] [--version <num>]` | Download workflow source as Python only. Use `--config-out` to write stored runnable config JSON when present, and `--version` to download a specific version. |
 | `orcheo workflow delete <workflow> [--force]` | Delete a workflow with confirmation safeguards. |
@@ -254,6 +254,33 @@ orcheo workflow unpublish my-workflow
 ### Workflow Configuration
 
 Upload-time defaults can be stored on a workflow version with `orcheo workflow upload ... --config` or `--config-file`. You can update config later without creating a version via `orcheo workflow save-config ...`. Stored config is merged with per-run overrides (run config wins). `orcheo workflow download --config-out <file>` writes that stored runnable config as companion JSON when present. Avoid putting secrets in runnable config; use environment variables or credential vaults instead.
+
+### Workflow Frontmatter
+
+Workflow `.py` files may include an optional PEP 723-style metadata block. When present, the `orcheo workflow upload` command reads it as the source of truth for the workflow's name, target id/handle, companion config file, and entrypoint. Any explicit CLI flag overrides the matching frontmatter field.
+
+```python
+# /// orcheo
+# name = "My Workflow"
+# id = "wf-abc123"
+# config = "./my-workflow.config.json"
+# entrypoint = "build_graph"
+# ///
+
+from langgraph.graph import StateGraph
+
+def build_graph():
+    return StateGraph(dict)
+```
+
+Supported fields (all optional):
+
+- `name` – display name used when creating or renaming the workflow.
+- `id` (or `handle`) – workflow reference; when set, the upload updates this existing workflow instead of creating a new one.
+- `config` – path to a companion JSON runnable config file. Relative paths resolve against the workflow file's directory.
+- `entrypoint` – LangGraph entrypoint function/variable name.
+
+The block is parsed as TOML; only the fields above are accepted. CLI flags (`--name`, `--id`, `--config-file`, `--entrypoint`) always win over the frontmatter values.
 
 ## Offline Mode
 

--- a/packages/sdk/src/orcheo_sdk/cli/workflow/__init__.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflow/__init__.py
@@ -31,6 +31,12 @@ from .commands.running import evaluate_workflow, run_workflow
 from .commands.scheduling import schedule_workflow, unschedule_workflow
 from .commands.showing import show_workflow
 from .formatting import _format_workflow_as_python
+from .frontmatter import (
+    WorkflowFrontmatter,
+    load_workflow_frontmatter,
+    parse_workflow_frontmatter,
+    resolve_frontmatter_config,
+)
 from .ingest import (
     _generate_slug,
     _load_workflow_from_python,
@@ -105,6 +111,10 @@ __all__ = [
     "_strip_main_block",
     "_load_workflow_from_python",
     "_format_workflow_as_python",
+    "WorkflowFrontmatter",
+    "parse_workflow_frontmatter",
+    "load_workflow_frontmatter",
+    "resolve_frontmatter_config",
     "render_json",
     "render_table",
     "list_workflows",

--- a/packages/sdk/src/orcheo_sdk/cli/workflow/frontmatter.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflow/frontmatter.py
@@ -1,0 +1,150 @@
+"""Parse optional metadata frontmatter from workflow Python files.
+
+The frontmatter follows the PEP 723-inspired comment block convention:
+
+    # /// orcheo
+    # name = "My Workflow"
+    # id = "wf-abc123"
+    # config = "./my-workflow.config.json"
+    # entrypoint = "build_graph"
+    # ///
+
+The block content is parsed as TOML.  All fields are optional; CLI flags
+always take precedence over values declared in the frontmatter.
+"""
+
+from __future__ import annotations
+import json
+import re
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from orcheo_sdk.cli.errors import CLIError
+
+
+_BLOCK_TYPE = "orcheo"
+_FRONTMATTER_RE = re.compile(
+    r"(?m)^# /// (?P<type>[a-zA-Z0-9_-]+)[ \t]*$\n"
+    r"(?P<content>(?:^#(?:[ \t].*)?\n)+?)"
+    r"^# ///[ \t]*$"
+)
+_ALLOWED_FIELDS = frozenset({"name", "id", "handle", "config", "entrypoint"})
+
+
+@dataclass(frozen=True)
+class WorkflowFrontmatter:
+    """Optional metadata embedded in a workflow source file."""
+
+    name: str | None = None
+    workflow_id: str | None = None
+    config_path: str | None = None
+    entrypoint: str | None = None
+
+    @property
+    def is_empty(self) -> bool:
+        """Return True when no frontmatter values were declared."""
+        return not any((self.name, self.workflow_id, self.config_path, self.entrypoint))
+
+
+def parse_workflow_frontmatter(source: str) -> WorkflowFrontmatter:
+    """Parse the optional ``orcheo`` frontmatter block from Python source."""
+    matches = [
+        match
+        for match in _FRONTMATTER_RE.finditer(source)
+        if match.group("type") == _BLOCK_TYPE
+    ]
+    if not matches:
+        return WorkflowFrontmatter()
+    if len(matches) > 1:
+        raise CLIError(
+            f"Multiple '{_BLOCK_TYPE}' frontmatter blocks found in workflow file."
+        )
+
+    content_lines = matches[0].group("content").splitlines()
+    toml_lines: list[str] = []
+    for line in content_lines:
+        stripped = line[1:]  # drop leading '#'
+        if stripped.startswith(" "):
+            stripped = stripped[1:]
+        toml_lines.append(stripped)
+    toml_text = "\n".join(toml_lines)
+
+    try:
+        data = tomllib.loads(toml_text)
+    except tomllib.TOMLDecodeError as exc:
+        raise CLIError(f"Invalid TOML in 'orcheo' frontmatter: {exc}") from exc
+
+    unknown = set(data) - _ALLOWED_FIELDS
+    if unknown:
+        keys = ", ".join(sorted(unknown))
+        raise CLIError(f"Unknown 'orcheo' frontmatter field(s): {keys}.")
+
+    if "id" in data and "handle" in data:
+        raise CLIError("'orcheo' frontmatter must not specify both 'id' and 'handle'.")
+
+    return WorkflowFrontmatter(
+        name=_string_field(data, "name"),
+        workflow_id=_string_field(data, "id") or _string_field(data, "handle"),
+        config_path=_string_field(data, "config"),
+        entrypoint=_string_field(data, "entrypoint"),
+    )
+
+
+def _string_field(data: dict[str, Any], key: str) -> str | None:
+    """Return a normalized string field, or None when absent."""
+    if key not in data:
+        return None
+    value = data[key]
+    if not isinstance(value, str):
+        raise CLIError(f"'orcheo' frontmatter field '{key}' must be a string.")
+    stripped = value.strip()
+    if not stripped:
+        raise CLIError(f"'orcheo' frontmatter field '{key}' must not be empty.")
+    return stripped
+
+
+def load_workflow_frontmatter(path: Path) -> WorkflowFrontmatter:
+    """Read ``path`` and return its parsed workflow frontmatter."""
+    try:
+        source = path.read_text(encoding="utf-8")
+    except OSError as exc:  # pragma: no cover - filesystem errors
+        raise CLIError(f"Failed to read workflow file '{path}': {exc}") from exc
+    return parse_workflow_frontmatter(source)
+
+
+def resolve_frontmatter_config(workflow_path: Path, config_path: str) -> dict[str, Any]:
+    """Load a companion runnable config referenced by frontmatter.
+
+    Relative paths resolve against the workflow file's parent directory.
+    """
+    candidate = Path(config_path).expanduser()
+    if not candidate.is_absolute():
+        candidate = workflow_path.parent / candidate
+    resolved = candidate.resolve()
+    if not resolved.exists():
+        raise CLIError(
+            f"Frontmatter config file '{config_path}' does not exist "
+            f"(resolved to '{resolved}')."
+        )
+    if not resolved.is_file():
+        raise CLIError(f"Frontmatter config path '{config_path}' is not a file.")
+    try:
+        data = json.loads(resolved.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise CLIError(
+            f"Invalid JSON in frontmatter config file '{config_path}': {exc}"
+        ) from exc
+    if not isinstance(data, dict):
+        raise CLIError(
+            f"Frontmatter config file '{config_path}' must contain a JSON object."
+        )
+    return data
+
+
+__all__ = [
+    "WorkflowFrontmatter",
+    "parse_workflow_frontmatter",
+    "load_workflow_frontmatter",
+    "resolve_frontmatter_config",
+]

--- a/packages/sdk/src/orcheo_sdk/cli/workflow/frontmatter.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflow/frontmatter.py
@@ -25,11 +25,47 @@ from orcheo_sdk.cli.errors import CLIError
 
 _BLOCK_TYPE = "orcheo"
 _FRONTMATTER_RE = re.compile(
-    r"(?m)^# /// (?P<type>[a-zA-Z0-9_-]+)[ \t]*$\n"
-    r"(?P<content>(?:^#(?:[ \t].*)?\n)+?)"
-    r"^# ///[ \t]*$"
+    r"(?m)^# /// (?P<type>[a-zA-Z0-9_-]+)[ \t]*$"
+    r"(?P<content>(?:\r?\n^#(?:[ \t].*)?)*?)"
+    r"\r?\n^# ///[ \t]*$"
 )
 _ALLOWED_FIELDS = frozenset({"name", "id", "handle", "config", "entrypoint"})
+_ENCODING_RE = re.compile(r"coding[=:]\s*([-\w.]+)")
+
+
+def _detect_file_encoding(path: Path) -> str:
+    """Detect the encoding of a Python source file following PEP 263.
+    
+    Returns the encoding name, defaulting to 'utf-8' if none is declared.
+    """
+    try:
+        with path.open("rb") as f:
+            # Read the first two lines as bytes to check for encoding declarations
+            first_line = f.readline()
+            second_line = f.readline()
+    except OSError:
+        # If we can't read the file, default to utf-8
+        return "utf-8"
+    
+    # Check the first line for encoding declaration
+    try:
+        first_str = first_line.decode("ascii", errors="ignore")
+        match = _ENCODING_RE.search(first_str)
+        if match:
+            return match.group(1)
+    except UnicodeDecodeError:
+        pass
+    
+    # Check the second line for encoding declaration
+    try:
+        second_str = second_line.decode("ascii", errors="ignore")
+        match = _ENCODING_RE.search(second_str)
+        if match:
+            return match.group(1)
+    except UnicodeDecodeError:
+        pass
+    
+    return "utf-8"
 
 
 @dataclass(frozen=True)
@@ -107,9 +143,12 @@ def _string_field(data: dict[str, Any], key: str) -> str | None:
 def load_workflow_frontmatter(path: Path) -> WorkflowFrontmatter:
     """Read ``path`` and return its parsed workflow frontmatter."""
     try:
-        source = path.read_text(encoding="utf-8")
+        encoding = _detect_file_encoding(path)
+        source = path.read_text(encoding=encoding)
     except OSError as exc:  # pragma: no cover - filesystem errors
         raise CLIError(f"Failed to read workflow file '{path}': {exc}") from exc
+    except UnicodeDecodeError as exc:  # pragma: no cover - encoding errors
+        raise CLIError(f"Failed to decode workflow file '{path}': {exc}") from exc
     return parse_workflow_frontmatter(source)
 
 

--- a/packages/sdk/src/orcheo_sdk/cli/workflow/frontmatter.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflow/frontmatter.py
@@ -100,6 +100,8 @@ def parse_workflow_frontmatter(source: str) -> WorkflowFrontmatter:
     content_lines = matches[0].group("content").splitlines()
     toml_lines: list[str] = []
     for line in content_lines:
+        if not line or not line.startswith("#"):
+            continue  # Skip malformed lines
         stripped = line[1:]  # drop leading '#'
         if stripped.startswith(" "):
             stripped = stripped[1:]
@@ -186,4 +188,5 @@ __all__ = [
     "parse_workflow_frontmatter",
     "load_workflow_frontmatter",
     "resolve_frontmatter_config",
+    "_detect_file_encoding",  # Export for testing
 ]

--- a/packages/sdk/src/orcheo_sdk/services/workflows/upload.py
+++ b/packages/sdk/src/orcheo_sdk/services/workflows/upload.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from orcheo_sdk.cli.errors import CLIError
 from orcheo_sdk.cli.http import ApiClient
+
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from orcheo_sdk.cli.workflow.frontmatter import WorkflowFrontmatter
 
 
 def _load_workflow_config_from_path(
@@ -54,6 +58,49 @@ def _upload_langgraph_workflow(
         raise CLIError("Failed to upload LangGraph workflow script via API.") from exc
 
 
+def _apply_frontmatter_defaults(
+    *,
+    path_obj: Path,
+    frontmatter: WorkflowFrontmatter,
+    workflow_id: str | None,
+    workflow_name: str | None,
+    entrypoint: str | None,
+    runnable_config: dict[str, Any] | None,
+    console: Any | None,
+) -> tuple[str | None, str | None, str | None, dict[str, Any] | None]:
+    """Fill missing values from the workflow file's frontmatter.
+
+    CLI-provided arguments always take precedence; frontmatter only fills
+    in fields that were omitted by the caller.
+    """
+    from orcheo_sdk.cli.workflow.frontmatter import resolve_frontmatter_config
+
+    if frontmatter.is_empty:
+        return workflow_id, workflow_name, entrypoint, runnable_config
+
+    used: list[str] = []
+    if workflow_id is None and frontmatter.workflow_id is not None:
+        workflow_id = frontmatter.workflow_id
+        used.append("id")
+    if workflow_name is None and frontmatter.name is not None:
+        workflow_name = frontmatter.name
+        used.append("name")
+    if entrypoint is None and frontmatter.entrypoint is not None:
+        entrypoint = frontmatter.entrypoint
+        used.append("entrypoint")
+    if runnable_config is None and frontmatter.config_path is not None:
+        runnable_config = resolve_frontmatter_config(path_obj, frontmatter.config_path)
+        used.append(f"config ({frontmatter.config_path})")
+
+    if used and console is not None:
+        try:
+            console.print(f"[dim]Loaded workflow frontmatter: {', '.join(used)}.[/dim]")
+        except Exception:  # noqa: BLE001  # pragma: no cover - defensive
+            pass
+
+    return workflow_id, workflow_name, entrypoint, runnable_config
+
+
 def upload_workflow_data(
     client: ApiClient,
     file_path: str | Path,
@@ -70,6 +117,7 @@ def upload_workflow_data(
         _upload_langgraph_script,
         _validate_local_path,
     )
+    from orcheo_sdk.cli.workflow.frontmatter import load_workflow_frontmatter
 
     class MinimalState:
         def __init__(self, client_obj: Any, console_obj: Any | None) -> None:
@@ -81,8 +129,25 @@ def upload_workflow_data(
             pass
 
     state = MinimalState(client, console)
-    requested_name = _normalize_workflow_name(workflow_name)
     path_obj = _validate_local_path(file_path, description="workflow")
+
+    frontmatter = load_workflow_frontmatter(path_obj)
+    (
+        workflow_id,
+        workflow_name,
+        entrypoint,
+        runnable_config,
+    ) = _apply_frontmatter_defaults(
+        path_obj=path_obj,
+        frontmatter=frontmatter,
+        workflow_id=workflow_id,
+        workflow_name=workflow_name,
+        entrypoint=entrypoint,
+        runnable_config=runnable_config,
+        console=console,
+    )
+
+    requested_name = _normalize_workflow_name(workflow_name)
 
     workflow_config = _load_workflow_config_from_path(
         path_obj,

--- a/tests/sdk/test_cli_workflow_frontmatter.py
+++ b/tests/sdk/test_cli_workflow_frontmatter.py
@@ -1,0 +1,341 @@
+"""Tests for workflow Python file frontmatter parsing and integration."""
+
+from __future__ import annotations
+import json
+from pathlib import Path
+import httpx
+import pytest
+import respx
+from typer.testing import CliRunner
+from orcheo_sdk.cli.errors import CLIError
+from orcheo_sdk.cli.main import app
+from orcheo_sdk.cli.workflow.frontmatter import (
+    WorkflowFrontmatter,
+    load_workflow_frontmatter,
+    parse_workflow_frontmatter,
+    resolve_frontmatter_config,
+)
+
+
+def test_parse_returns_empty_when_no_block() -> None:
+    source = "# regular comment\nprint('hello')\n"
+    fm = parse_workflow_frontmatter(source)
+    assert fm == WorkflowFrontmatter()
+    assert fm.is_empty
+
+
+def test_parse_extracts_all_fields() -> None:
+    source = (
+        "# /// orcheo\n"
+        '# name = "My Workflow"\n'
+        '# id = "wf-abc123"\n'
+        '# config = "./wf.config.json"\n'
+        '# entrypoint = "build_graph"\n'
+        "# ///\n"
+        "print('hello')\n"
+    )
+    fm = parse_workflow_frontmatter(source)
+    assert fm.name == "My Workflow"
+    assert fm.workflow_id == "wf-abc123"
+    assert fm.config_path == "./wf.config.json"
+    assert fm.entrypoint == "build_graph"
+    assert not fm.is_empty
+
+
+def test_parse_accepts_handle_alias() -> None:
+    source = '# /// orcheo\n# handle = "wf-handle"\n# ///\n'
+    fm = parse_workflow_frontmatter(source)
+    assert fm.workflow_id == "wf-handle"
+
+
+def test_parse_rejects_id_and_handle_together() -> None:
+    source = '# /// orcheo\n# id = "x"\n# handle = "y"\n# ///\n'
+    with pytest.raises(CLIError, match="must not specify both 'id' and 'handle'"):
+        parse_workflow_frontmatter(source)
+
+
+def test_parse_rejects_unknown_field() -> None:
+    source = '# /// orcheo\n# bogus = "x"\n# ///\n'
+    with pytest.raises(CLIError, match="Unknown 'orcheo' frontmatter field"):
+        parse_workflow_frontmatter(source)
+
+
+def test_parse_rejects_non_string_field() -> None:
+    source = "# /// orcheo\n# name = 123\n# ///\n"
+    with pytest.raises(CLIError, match="must be a string"):
+        parse_workflow_frontmatter(source)
+
+
+def test_parse_rejects_empty_string_field() -> None:
+    source = '# /// orcheo\n# name = "   "\n# ///\n'
+    with pytest.raises(CLIError, match="must not be empty"):
+        parse_workflow_frontmatter(source)
+
+
+def test_parse_rejects_invalid_toml() -> None:
+    source = '# /// orcheo\n# name = "unterminated\n# ///\n'
+    with pytest.raises(CLIError, match="Invalid TOML"):
+        parse_workflow_frontmatter(source)
+
+
+def test_parse_rejects_multiple_blocks() -> None:
+    source = (
+        "# /// orcheo\n"
+        '# name = "first"\n'
+        "# ///\n"
+        "\n"
+        "# /// orcheo\n"
+        '# name = "second"\n'
+        "# ///\n"
+    )
+    with pytest.raises(CLIError, match="Multiple 'orcheo' frontmatter blocks"):
+        parse_workflow_frontmatter(source)
+
+
+def test_parse_ignores_other_block_types() -> None:
+    """A non-orcheo PEP 723 block (e.g., 'script') is left alone."""
+    source = (
+        "# /// script\n"
+        '# requires-python = ">=3.12"\n'
+        "# ///\n"
+        "\n"
+        "# /// orcheo\n"
+        '# name = "Real Workflow"\n'
+        "# ///\n"
+    )
+    fm = parse_workflow_frontmatter(source)
+    assert fm.name == "Real Workflow"
+
+
+def test_load_from_file_reads_source(tmp_path: Path) -> None:
+    py_file = tmp_path / "wf.py"
+    py_file.write_text(
+        '# /// orcheo\n# name = "From File"\n# ///\n',
+        encoding="utf-8",
+    )
+    fm = load_workflow_frontmatter(py_file)
+    assert fm.name == "From File"
+
+
+def test_resolve_config_relative_to_workflow(tmp_path: Path) -> None:
+    workflow = tmp_path / "wf.py"
+    workflow.write_text("# noop", encoding="utf-8")
+    config = tmp_path / "wf.config.json"
+    config.write_text(json.dumps({"tags": ["alpha"]}), encoding="utf-8")
+
+    data = resolve_frontmatter_config(workflow, "wf.config.json")
+    assert data == {"tags": ["alpha"]}
+
+
+def test_resolve_config_missing_file_raises(tmp_path: Path) -> None:
+    workflow = tmp_path / "wf.py"
+    workflow.write_text("# noop", encoding="utf-8")
+
+    with pytest.raises(CLIError, match="does not exist"):
+        resolve_frontmatter_config(workflow, "missing.config.json")
+
+
+def test_resolve_config_rejects_directory(tmp_path: Path) -> None:
+    workflow = tmp_path / "wf.py"
+    workflow.write_text("# noop", encoding="utf-8")
+    (tmp_path / "configdir").mkdir()
+
+    with pytest.raises(CLIError, match="is not a file"):
+        resolve_frontmatter_config(workflow, "configdir")
+
+
+def test_resolve_config_rejects_invalid_json(tmp_path: Path) -> None:
+    workflow = tmp_path / "wf.py"
+    workflow.write_text("# noop", encoding="utf-8")
+    bad = tmp_path / "bad.json"
+    bad.write_text("{ not json", encoding="utf-8")
+
+    with pytest.raises(CLIError, match="Invalid JSON"):
+        resolve_frontmatter_config(workflow, "bad.json")
+
+
+def test_resolve_config_rejects_non_object(tmp_path: Path) -> None:
+    workflow = tmp_path / "wf.py"
+    workflow.write_text("# noop", encoding="utf-8")
+    arr = tmp_path / "arr.json"
+    arr.write_text("[1, 2, 3]", encoding="utf-8")
+
+    with pytest.raises(CLIError, match="must contain a JSON object"):
+        resolve_frontmatter_config(workflow, "arr.json")
+
+
+def _langgraph_script_with_frontmatter(
+    *,
+    workflow_id: str | None = None,
+    name: str | None = None,
+    config_path: str | None = None,
+    entrypoint: str | None = None,
+) -> str:
+    lines = ["# /// orcheo"]
+    if name is not None:
+        lines.append(f'# name = "{name}"')
+    if workflow_id is not None:
+        lines.append(f'# id = "{workflow_id}"')
+    if config_path is not None:
+        lines.append(f'# config = "{config_path}"')
+    if entrypoint is not None:
+        lines.append(f'# entrypoint = "{entrypoint}"')
+    lines.append("# ///")
+    lines.append("")
+    lines.append("from langgraph.graph import StateGraph")
+    lines.append("")
+    lines.append("def build_graph():")
+    lines.append("    return StateGraph(dict)")
+    return "\n".join(lines) + "\n"
+
+
+def test_upload_uses_frontmatter_id_for_existing_workflow(
+    runner: CliRunner, env: dict[str, str], tmp_path: Path
+) -> None:
+    """Frontmatter id triggers the update path without needing --id."""
+    py_file = tmp_path / "wf.py"
+    py_file.write_text(
+        _langgraph_script_with_frontmatter(workflow_id="wf-known"),
+        encoding="utf-8",
+    )
+
+    existing_workflow = {"id": "wf-known", "name": "existing"}
+    created_version = {"id": "v-2", "version": 2, "workflow_id": "wf-known"}
+    with respx.mock(assert_all_called=True) as router:
+        router.get("http://api.test/api/workflows/wf-known").mock(
+            return_value=httpx.Response(200, json=existing_workflow)
+        )
+        router.post("http://api.test/api/workflows/wf-known/versions/ingest").mock(
+            return_value=httpx.Response(201, json=created_version)
+        )
+        result = runner.invoke(
+            app,
+            ["workflow", "upload", str(py_file)],
+            env=env,
+        )
+
+    assert result.exit_code == 0, result.stdout
+    assert "Ingested LangGraph script as version 2" in result.stdout
+
+
+def test_upload_uses_frontmatter_name_when_creating(
+    runner: CliRunner, env: dict[str, str], tmp_path: Path
+) -> None:
+    """Frontmatter name overrides the filename-derived default."""
+    py_file = tmp_path / "wf.py"
+    py_file.write_text(
+        _langgraph_script_with_frontmatter(name="Frontmatter Workflow"),
+        encoding="utf-8",
+    )
+
+    created_workflow = {"id": "wf-new", "name": "Frontmatter Workflow"}
+    created_version = {"id": "v-1", "version": 1, "workflow_id": "wf-new"}
+    with respx.mock(assert_all_called=True) as router:
+        create_route = router.post("http://api.test/api/workflows").mock(
+            return_value=httpx.Response(201, json=created_workflow)
+        )
+        router.post("http://api.test/api/workflows/wf-new/versions/ingest").mock(
+            return_value=httpx.Response(201, json=created_version)
+        )
+        result = runner.invoke(
+            app,
+            ["workflow", "upload", str(py_file)],
+            env=env,
+        )
+
+    assert result.exit_code == 0, result.stdout
+    body = json.loads(create_route.calls[0].request.content)
+    assert body["name"] == "Frontmatter Workflow"
+    assert body["slug"] == "frontmatter-workflow"
+
+
+def test_upload_loads_companion_config_from_frontmatter(
+    runner: CliRunner, env: dict[str, str], tmp_path: Path
+) -> None:
+    """Frontmatter config path loads the companion JSON file."""
+    py_file = tmp_path / "wf.py"
+    py_file.write_text(
+        _langgraph_script_with_frontmatter(config_path="wf.config.json"),
+        encoding="utf-8",
+    )
+    config_file = tmp_path / "wf.config.json"
+    config_file.write_text('{"tags": ["from-frontmatter"]}', encoding="utf-8")
+
+    created_workflow = {"id": "wf-new", "name": "wf"}
+    created_version = {"id": "v-1", "version": 1, "workflow_id": "wf-new"}
+    with respx.mock(assert_all_called=True) as router:
+        router.post("http://api.test/api/workflows").mock(
+            return_value=httpx.Response(201, json=created_workflow)
+        )
+        ingest_route = router.post(
+            "http://api.test/api/workflows/wf-new/versions/ingest"
+        ).mock(return_value=httpx.Response(201, json=created_version))
+        result = runner.invoke(
+            app,
+            ["workflow", "upload", str(py_file)],
+            env=env,
+        )
+
+    assert result.exit_code == 0, result.stdout
+    request_body = json.loads(ingest_route.calls[0].request.content)
+    assert request_body["runnable_config"] == {"tags": ["from-frontmatter"]}
+
+
+def test_upload_cli_flag_overrides_frontmatter(
+    runner: CliRunner, env: dict[str, str], tmp_path: Path
+) -> None:
+    """An explicit --name on the CLI wins over the frontmatter name."""
+    py_file = tmp_path / "wf.py"
+    py_file.write_text(
+        _langgraph_script_with_frontmatter(name="From Frontmatter"),
+        encoding="utf-8",
+    )
+
+    created_workflow = {"id": "wf-new", "name": "CLI Wins"}
+    created_version = {"id": "v-1", "version": 1, "workflow_id": "wf-new"}
+    with respx.mock(assert_all_called=True) as router:
+        create_route = router.post("http://api.test/api/workflows").mock(
+            return_value=httpx.Response(201, json=created_workflow)
+        )
+        router.post("http://api.test/api/workflows/wf-new/versions/ingest").mock(
+            return_value=httpx.Response(201, json=created_version)
+        )
+        result = runner.invoke(
+            app,
+            ["workflow", "upload", str(py_file), "--name", "CLI Wins"],
+            env=env,
+        )
+
+    assert result.exit_code == 0, result.stdout
+    body = json.loads(create_route.calls[0].request.content)
+    assert body["name"] == "CLI Wins"
+
+
+def test_upload_uses_frontmatter_entrypoint(
+    runner: CliRunner, env: dict[str, str], tmp_path: Path
+) -> None:
+    """Frontmatter entrypoint is forwarded to ingest."""
+    py_file = tmp_path / "wf.py"
+    py_file.write_text(
+        _langgraph_script_with_frontmatter(entrypoint="build_graph"),
+        encoding="utf-8",
+    )
+
+    created_workflow = {"id": "wf-new", "name": "wf"}
+    created_version = {"id": "v-1", "version": 1, "workflow_id": "wf-new"}
+    with respx.mock(assert_all_called=True) as router:
+        router.post("http://api.test/api/workflows").mock(
+            return_value=httpx.Response(201, json=created_workflow)
+        )
+        ingest_route = router.post(
+            "http://api.test/api/workflows/wf-new/versions/ingest"
+        ).mock(return_value=httpx.Response(201, json=created_version))
+        result = runner.invoke(
+            app,
+            ["workflow", "upload", str(py_file)],
+            env=env,
+        )
+
+    assert result.exit_code == 0, result.stdout
+    request_body = json.loads(ingest_route.calls[0].request.content)
+    assert request_body["entrypoint"] == "build_graph"

--- a/tests/sdk/test_cli_workflow_frontmatter.py
+++ b/tests/sdk/test_cli_workflow_frontmatter.py
@@ -14,6 +14,7 @@ from orcheo_sdk.cli.workflow.frontmatter import (
     load_workflow_frontmatter,
     parse_workflow_frontmatter,
     resolve_frontmatter_config,
+    _detect_file_encoding,
 )
 
 
@@ -416,3 +417,112 @@ def test_upload_uses_frontmatter_entrypoint(
     assert result.exit_code == 0, result.stdout
     request_body = json.loads(ingest_route.calls[0].request.content)
     assert request_body["entrypoint"] == "build_graph"
+
+
+def test_parse_handles_empty_comment_lines() -> None:
+    """Frontmatter parsing skips empty lines and malformed comment lines."""
+    source = (
+        "# /// orcheo\n"
+        "#\n"  # Empty comment line
+        '# name = "Robust Parsing"\n'
+        "\n"   # Empty line (shouldn't happen but should be handled)
+        "# ///\n"
+    )
+    fm = parse_workflow_frontmatter(source)
+    assert fm.name == "Robust Parsing"
+
+
+def test_parse_handles_comment_only_lines() -> None:
+    """Frontmatter parsing handles lines with only '#' character."""
+    source = (
+        "# /// orcheo\n"
+        "#\n" 
+        '# name = "Comment Only Test"\n'
+        "#\n"
+        "# ///\n"
+    )
+    fm = parse_workflow_frontmatter(source)
+    assert fm.name == "Comment Only Test"
+
+
+def test_parse_handles_tabs_in_comment() -> None:
+    """Frontmatter parsing handles tabs after # character."""
+    source = (
+        "# /// orcheo\n"
+        "#\tname = \"Tab Test\"\n"  # Tab instead of space
+        "# ///\n"
+    )
+    fm = parse_workflow_frontmatter(source)
+    assert fm.name == "Tab Test"
+
+
+def test_load_from_file_with_file_not_found_error(tmp_path: Path) -> None:
+    """load_workflow_frontmatter raises CLIError for missing files."""
+    missing_file = tmp_path / "does_not_exist.py"
+    with pytest.raises(CLIError, match="Failed to read workflow file"):
+        load_workflow_frontmatter(missing_file)
+
+
+def test_load_from_file_with_permission_error(tmp_path: Path) -> None:
+    """load_workflow_frontmatter handles permission errors gracefully."""
+    import os
+    import stat
+    
+    py_file = tmp_path / "restricted.py"
+    py_file.write_text("# /// orcheo\n# name = \"test\"\n# ///\n")
+    
+    # Remove read permissions (if on Unix-like system)
+    if hasattr(os, 'chmod'):
+        try:
+            os.chmod(py_file, stat.S_IWRITE)  # Write only
+            with pytest.raises(CLIError, match="Failed to read workflow file"):
+                load_workflow_frontmatter(py_file)
+        finally:
+            # Restore permissions for cleanup
+            os.chmod(py_file, stat.S_IREAD | stat.S_IWRITE)
+
+
+def test_load_from_file_with_invalid_encoding(tmp_path: Path) -> None:
+    """load_workflow_frontmatter handles encoding errors gracefully."""
+    py_file = tmp_path / "bad_encoding.py"
+    
+    # Write a file with declared latin-1 encoding but invalid UTF-8 bytes
+    with py_file.open("wb") as f:
+        f.write(b"# -*- coding: utf-8 -*-\n")
+        f.write(b"# /// orcheo\n")
+        f.write(b"# name = \"\xff\xfe\"  # Invalid UTF-8 bytes\n")  
+        f.write(b"# ///\n")
+    
+    with pytest.raises(CLIError, match="Failed to decode workflow file"):
+        load_workflow_frontmatter(py_file)
+
+
+def test_detect_file_encoding_with_no_file(tmp_path: Path) -> None:
+    """_detect_file_encoding returns utf-8 for non-existent files."""
+    missing_file = tmp_path / "missing.py"
+    assert _detect_file_encoding(missing_file) == "utf-8"
+
+
+def test_detect_file_encoding_with_invalid_first_line(tmp_path: Path) -> None:
+    """_detect_file_encoding handles files that can't be decoded as ASCII."""
+    
+    py_file = tmp_path / "binary_start.py"
+    with py_file.open("wb") as f:
+        f.write(b"\xff\xfe\x00\x00")  # Invalid ASCII/UTF-8 bytes
+        f.write(b"\n# coding: latin-1\n")
+    
+    # Should default to utf-8 when first line can't be decoded
+    assert _detect_file_encoding(py_file) == "utf-8"
+
+
+def test_resolve_config_with_unicode_error_in_json(tmp_path: Path) -> None:
+    """resolve_frontmatter_config handles JSON files that can't be decoded."""
+    workflow = tmp_path / "wf.py"
+    workflow.write_text("# noop", encoding="utf-8")
+    
+    config_file = tmp_path / "bad_unicode.json"
+    with config_file.open("wb") as f:
+        f.write(b'{"name": "\xff\xfe"}')  # Invalid UTF-8 in JSON
+    
+    with pytest.raises(CLIError, match="Invalid JSON"):
+        resolve_frontmatter_config(workflow, "bad_unicode.json")

--- a/tests/sdk/test_cli_workflow_frontmatter.py
+++ b/tests/sdk/test_cli_workflow_frontmatter.py
@@ -107,6 +107,34 @@ def test_parse_ignores_other_block_types() -> None:
     assert fm.name == "Real Workflow"
 
 
+def test_parse_handles_crlf_line_endings() -> None:
+    """Frontmatter blocks work with Windows CRLF line endings."""
+    source = (
+        "# /// orcheo\r\n"
+        '# name = "CRLF Workflow"\r\n'
+        '# id = "wf-crlf"\r\n'
+        "# ///\r\n"
+        "print('hello')\r\n"
+    )
+    fm = parse_workflow_frontmatter(source)
+    assert fm.name == "CRLF Workflow"
+    assert fm.workflow_id == "wf-crlf"
+
+
+def test_parse_handles_mixed_line_endings() -> None:
+    """Frontmatter blocks work with mixed LF/CRLF line endings."""
+    source = (
+        "# /// orcheo\n"
+        '# name = "Mixed Endings"\r\n'
+        '# id = "wf-mixed"\n'
+        "# ///\r\n"
+        "print('hello')\n"
+    )
+    fm = parse_workflow_frontmatter(source)
+    assert fm.name == "Mixed Endings"
+    assert fm.workflow_id == "wf-mixed"
+
+
 def test_load_from_file_reads_source(tmp_path: Path) -> None:
     py_file = tmp_path / "wf.py"
     py_file.write_text(
@@ -115,6 +143,55 @@ def test_load_from_file_reads_source(tmp_path: Path) -> None:
     )
     fm = load_workflow_frontmatter(py_file)
     assert fm.name == "From File"
+
+
+def test_load_from_file_with_pep263_encoding(tmp_path: Path) -> None:
+    """Load workflow frontmatter from file with PEP 263 encoding declaration."""
+    py_file = tmp_path / "wf_latin1.py"
+    content = (
+        "# -*- coding: latin-1 -*-\n"
+        "# /// orcheo\n"
+        '# name = "Encoded Workflow"\n'
+        "# ///\n"
+        "# This file uses latin-1 encoding\n"
+        "print('café')\n"  # This will be encoded as latin-1
+    )
+    py_file.write_text(content, encoding="latin-1")
+    
+    fm = load_workflow_frontmatter(py_file)
+    assert fm.name == "Encoded Workflow"
+
+
+def test_load_from_file_with_encoding_on_second_line(tmp_path: Path) -> None:
+    """PEP 263 allows encoding declaration on the second line."""
+    py_file = tmp_path / "wf_second_line.py"
+    content = (
+        "#!/usr/bin/env python3\n"
+        "# coding=utf-16\n"
+        "# /// orcheo\n"
+        '# name = "Second Line Encoding"\n'
+        "# ///\n"
+        "print('hello')\n"
+    )
+    py_file.write_text(content, encoding="utf-16")
+    
+    fm = load_workflow_frontmatter(py_file)
+    assert fm.name == "Second Line Encoding"
+
+
+def test_load_from_file_defaults_to_utf8(tmp_path: Path) -> None:
+    """Files without encoding declaration default to UTF-8."""
+    py_file = tmp_path / "wf_no_encoding.py"
+    content = (
+        "# /// orcheo\n"
+        '# name = "No Encoding Declared"\n'
+        "# ///\n"
+        "print('hello')\n"
+    )
+    py_file.write_text(content, encoding="utf-8")
+    
+    fm = load_workflow_frontmatter(py_file)
+    assert fm.name == "No Encoding Declared"
 
 
 def test_resolve_config_relative_to_workflow(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
This PR adds support for optional PEP 723-inspired frontmatter blocks in Python workflow files, allowing developers to declare workflow metadata (name, ID, config path, entrypoint) directly in their scripts. CLI flags continue to take precedence over frontmatter values.

## Key Changes

- **New frontmatter module** (`orcheo_sdk/cli/workflow/frontmatter.py`):
  - `WorkflowFrontmatter` dataclass to represent parsed metadata
  - `parse_workflow_frontmatter()` to extract and validate `# /// orcheo ... # ///` blocks from Python source
  - `load_workflow_frontmatter()` to read and parse workflow files
  - `resolve_frontmatter_config()` to load companion JSON config files referenced in frontmatter
  - Comprehensive validation: rejects unknown fields, non-string values, empty strings, invalid TOML, and multiple blocks
  - Supports both `id` and `handle` aliases for workflow ID

- **Integration with upload workflow** (`orcheo_sdk/services/workflows/upload.py`):
  - New `_apply_frontmatter_defaults()` function that fills missing CLI arguments from frontmatter
  - Frontmatter values only used when CLI arguments are not provided
  - Loads companion config files automatically when `config` path is specified in frontmatter
  - Logs which frontmatter fields were applied

- **Updated CLI documentation** (`docs/cli_reference.md`):
  - Documents the new `--id` and `--entrypoint` flags for `workflow upload`
  - Explains the frontmatter block syntax and precedence rules

- **Comprehensive test coverage** (`tests/sdk/test_cli_workflow_frontmatter.py`):
  - 341 lines of tests covering parsing, validation, file loading, config resolution, and end-to-end upload scenarios
  - Tests verify CLI flags override frontmatter values
  - Tests confirm companion config files are loaded and applied correctly

## Implementation Details

- Frontmatter blocks follow PEP 723 comment convention with TOML content
- Supported fields: `name`, `id`/`handle`, `config`, `entrypoint`
- Relative config paths resolve against the workflow file's parent directory
- All validation errors raise `CLIError` with descriptive messages
- Frontmatter module is properly exported from the workflow package `__init__.py`

https://claude.ai/code/session_019XCDXumAK31EMBXjfDRe49