### PR TITLE
Add workflow isolation and auto-title generation for chat threads

### DIFF
--- a/apps/backend/src/orcheo_backend/app/chatkit/in_memory_store.py
+++ b/apps/backend/src/orcheo_backend/app/chatkit/in_memory_store.py
@@ -9,6 +9,22 @@ from chatkit.types import Thread, ThreadItem, ThreadMetadata
 from orcheo_backend.app.chatkit.context import ChatKitRequestContext
 
 
+def _extract_title_from_request(context: ChatKitRequestContext | None) -> str | None:
+    """Return first 20 chars of the first user text content in the request."""
+    if not context:
+        return None
+    request = context.get("chatkit_request")
+    if request is None:
+        return None
+    params = getattr(request, "params", None)
+    user_input = getattr(params, "input", None)
+    for item in getattr(user_input, "content", []):
+        text = getattr(item, "text", None)
+        if text:
+            return text[:20].strip() or None
+    return None
+
+
 @dataclass
 class _ThreadState:
     """Internal storage for thread metadata and items."""
@@ -70,6 +86,8 @@ class InMemoryChatKitStore(Store[ChatKitRequestContext]):
         self, thread: ThreadMetadata, context: ChatKitRequestContext
     ) -> None:
         """Persist metadata for ``thread`` while merging incoming context metadata."""
+        if not thread.title:
+            thread.title = _extract_title_from_request(context)
         async with self._lock:
             self._merge_metadata_from_context(thread, context)
             existing = self._threads.get(thread.id)
@@ -86,13 +104,20 @@ class InMemoryChatKitStore(Store[ChatKitRequestContext]):
         order: str,
         context: ChatKitRequestContext,
     ) -> Page[ThreadMetadata]:
-        """Return a page of stored thread metadata ordered by creation."""
+        """Return a page of stored thread metadata scoped to the workflow in context."""
+        workflow_id: str | None = context.get("workflow_id") if context else None
         async with self._lock:
+            all_threads = (
+                self._clone_metadata(state.thread) for state in self._threads.values()
+            )
+            if workflow_id:
+                all_threads = (
+                    t
+                    for t in all_threads
+                    if t.metadata.get("workflow_id") == workflow_id
+                )
             threads = sorted(
-                (
-                    self._clone_metadata(state.thread)
-                    for state in self._threads.values()
-                ),
+                all_threads,
                 key=lambda t: t.created_at or datetime.min,
                 reverse=(order == "desc"),
             )

--- a/apps/backend/src/orcheo_backend/app/chatkit_store_postgres/threads.py
+++ b/apps/backend/src/orcheo_backend/app/chatkit_store_postgres/threads.py
@@ -18,6 +18,22 @@ from orcheo_backend.app.chatkit_store_postgres.utils import (
 )
 
 
+def _extract_title_from_request(context: ChatKitRequestContext | None) -> str | None:
+    """Return first 20 chars of the first user text content in the request."""
+    if not context:
+        return None
+    request = context.get("chatkit_request")
+    if request is None:
+        return None
+    params = getattr(request, "params", None)
+    user_input = getattr(params, "input", None)
+    for item in getattr(user_input, "content", []):
+        text = getattr(item, "text", None)
+        if text:
+            return text[:20].strip() or None
+    return None
+
+
 class ThreadStoreMixin(BasePostgresStore):
     """CRUD helpers for thread metadata."""
 
@@ -45,6 +61,8 @@ class ThreadStoreMixin(BasePostgresStore):
     ) -> None:
         """Insert or update metadata for ``thread``."""
         await self._ensure_initialized()
+        if not thread.title:
+            thread.title = _extract_title_from_request(context)
         async with self._lock:
             async with self._connection() as conn:
                 metadata_payload = self._merge_metadata_from_context(thread, context)
@@ -85,13 +103,18 @@ class ThreadStoreMixin(BasePostgresStore):
         order: str,
         context: ChatKitRequestContext,
     ) -> Page[ThreadMetadata]:
-        """Return a paginated collection of threads."""
+        """Return a paginated collection of threads scoped to the workflow."""
         await self._ensure_initialized()
+        workflow_id: str | None = context.get("workflow_id") if context else None
         limit = max(limit, 1)
         ordering = "asc" if order.lower() == "asc" else "desc"
         comparator = ">" if ordering == "asc" else "<"
         params: list[Any] = []
-        where_clause = ""
+        conditions: list[str] = []
+
+        if workflow_id:
+            conditions.append("workflow_id = %s")
+            params.append(workflow_id)
 
         async with self._connection() as conn:
             if after:  # pragma: no branch
@@ -102,15 +125,15 @@ class ThreadStoreMixin(BasePostgresStore):
                 marker = await cursor.fetchone()
                 if marker is not None:
                     created_at = marker["created_at"]
-                    where_clause = f" WHERE (created_at, id) {comparator} (%s, %s)"
+                    conditions.append(f"((created_at, id) {comparator} (%s, %s))")
                     params.extend([created_at, marker["id"]])
 
             query = (
                 "SELECT id, title, status_json, metadata_json, created_at "
                 "FROM chat_threads"
             )
-            if where_clause:
-                query += where_clause
+            if conditions:
+                query += " WHERE " + " AND ".join(conditions)
             query += f" ORDER BY created_at {ordering.upper()}, id {ordering.upper()}"
             query += " LIMIT %s"
             params.append(limit + 1)

--- a/apps/backend/src/orcheo_backend/app/chatkit_store_postgres/threads.py
+++ b/apps/backend/src/orcheo_backend/app/chatkit_store_postgres/threads.py
@@ -118,10 +118,15 @@ class ThreadStoreMixin(BasePostgresStore):
 
         async with self._connection() as conn:
             if after:  # pragma: no branch
-                cursor = await conn.execute(
-                    "SELECT created_at, id FROM chat_threads WHERE id = %s",
-                    (after,),
-                )
+                # Cursor lookup must be scoped to the same workflow to prevent
+                # information leakage and ensure consistent pagination
+                cursor_query = "SELECT created_at, id FROM chat_threads WHERE id = %s"
+                cursor_params = [after]
+                if workflow_id:
+                    cursor_query += " AND workflow_id = %s"
+                    cursor_params.append(workflow_id)
+                
+                cursor = await conn.execute(cursor_query, tuple(cursor_params))
                 marker = await cursor.fetchone()
                 if marker is not None:
                     created_at = marker["created_at"]

--- a/apps/backend/src/orcheo_backend/app/chatkit_store_sqlite/threads.py
+++ b/apps/backend/src/orcheo_backend/app/chatkit_store_sqlite/threads.py
@@ -119,10 +119,15 @@ class ThreadStoreMixin(BaseSqliteStore):
                 params.append(workflow_id)
 
             if after:
-                cursor = await conn.execute(
-                    "SELECT created_at, id FROM chat_threads WHERE id = ?",
-                    (after,),
-                )
+                # Cursor lookup must be scoped to the same workflow to prevent
+                # information leakage and ensure consistent pagination
+                cursor_query = "SELECT created_at, id FROM chat_threads WHERE id = ?"
+                cursor_params = [after]
+                if workflow_id:
+                    cursor_query += " AND workflow_id = ?"
+                    cursor_params.append(workflow_id)
+                
+                cursor = await conn.execute(cursor_query, tuple(cursor_params))
                 marker = await cursor.fetchone()
                 if marker is not None:
                     created_at = marker["created_at"]

--- a/apps/backend/src/orcheo_backend/app/chatkit_store_sqlite/threads.py
+++ b/apps/backend/src/orcheo_backend/app/chatkit_store_sqlite/threads.py
@@ -17,6 +17,22 @@ from orcheo_backend.app.chatkit_store_sqlite.utils import (
 )
 
 
+def _extract_title_from_request(context: ChatKitRequestContext | None) -> str | None:
+    """Return first 20 chars of the first user text content in the request."""
+    if not context:
+        return None
+    request = context.get("chatkit_request")
+    if request is None:
+        return None
+    params = getattr(request, "params", None)
+    user_input = getattr(params, "input", None)
+    for item in getattr(user_input, "content", []):
+        text = getattr(item, "text", None)
+        if text:
+            return text[:20].strip() or None
+    return None
+
+
 class ThreadStoreMixin(BaseSqliteStore):
     """CRUD helpers for thread metadata."""
 
@@ -44,6 +60,8 @@ class ThreadStoreMixin(BaseSqliteStore):
     ) -> None:
         """Insert or update metadata for ``thread``."""
         await self._ensure_initialized()
+        if not thread.title:
+            thread.title = _extract_title_from_request(context)
         async with self._lock:
             async with self._connection() as conn:
                 metadata_payload = self._merge_metadata_from_context(thread, context)
@@ -86,14 +104,20 @@ class ThreadStoreMixin(BaseSqliteStore):
         order: str,
         context: ChatKitRequestContext,
     ) -> Page[ThreadMetadata]:
-        """Return a paginated collection of threads."""
+        """Return a paginated collection of threads scoped to the workflow."""
         await self._ensure_initialized()
+        workflow_id: str | None = context.get("workflow_id") if context else None
         limit = max(limit, 1)
         ordering = "asc" if order.lower() == "asc" else "desc"
         comparator = ">" if ordering == "asc" else "<"
         async with self._connection() as conn:
             params: list[Any] = []
-            where_clause = ""
+            conditions: list[str] = []
+
+            if workflow_id:
+                conditions.append("workflow_id = ?")
+                params.append(workflow_id)
+
             if after:
                 cursor = await conn.execute(
                     "SELECT created_at, id FROM chat_threads WHERE id = ?",
@@ -102,9 +126,9 @@ class ThreadStoreMixin(BaseSqliteStore):
                 marker = await cursor.fetchone()
                 if marker is not None:
                     created_at = marker["created_at"]
-                    where_clause = (
-                        f" WHERE (created_at {comparator} ?)"
-                        f" OR (created_at = ? AND id {comparator} ?)"
+                    conditions.append(
+                        f"((created_at {comparator} ?)"
+                        f" OR (created_at = ? AND id {comparator} ?))"
                     )
                     params.extend([created_at, created_at, marker["id"]])
 
@@ -112,8 +136,8 @@ class ThreadStoreMixin(BaseSqliteStore):
                 "SELECT id, title, status_json, metadata_json, created_at "
                 "FROM chat_threads"
             )
-            if where_clause:
-                query += where_clause
+            if conditions:
+                query += " WHERE " + " AND ".join(conditions)
             query += f" ORDER BY created_at {ordering.upper()}, id {ordering.upper()}"
             query += " LIMIT ?"
             params.append(limit + 1)

--- a/apps/backend/src/orcheo_backend/app/factory.py
+++ b/apps/backend/src/orcheo_backend/app/factory.py
@@ -197,15 +197,15 @@ def create_app(
     if credential_service is not None:
         set_credential_service(credential_service)
         set_vault(getattr(credential_service, "_vault", None))
-        application.dependency_overrides[get_credential_service] = (
-            lambda: credential_service
+        application.dependency_overrides[get_credential_service] = lambda: (
+            credential_service
         )
     elif repository is not None:
         inferred_service = getattr(repository, "_credential_service", None)
         if inferred_service is not None:
             set_credential_service(inferred_service)
-            application.dependency_overrides[get_credential_service] = (
-                lambda: inferred_service
+            application.dependency_overrides[get_credential_service] = lambda: (
+                inferred_service
             )
 
     application.include_router(api_router)

--- a/apps/backend/src/orcheo_backend/worker/external_agents.py
+++ b/apps/backend/src/orcheo_backend/worker/external_agents.py
@@ -1378,10 +1378,12 @@ async def start_external_agent_login_async(  # noqa: C901, PLR0915
                 on_output=on_output,
                 consume_input=manage_login_input,
                 auto_input=auto_login_input,
-                is_authenticated=lambda: provider.probe_auth(
-                    runtime,
-                    environ=manager.environment_for_provider(provider_name),
-                ).authenticated,
+                is_authenticated=lambda: (
+                    provider.probe_auth(
+                        runtime,
+                        environ=manager.environment_for_provider(provider_name),
+                    ).authenticated
+                ),
                 on_tick=heartbeat_session,
             )
             if (

--- a/src/orcheo/listeners/registry.py
+++ b/src/orcheo/listeners/registry.py
@@ -218,13 +218,12 @@ def register_builtin_listeners() -> None:
                 ),
             ),
             compiler=default_listener_compiler,
-            adapter_factory=lambda *,
-            repository,
-            subscription,
-            runtime_id: TelegramPollingAdapter(
-                repository=repository,
-                subscription=subscription,
-                runtime_id=runtime_id,
+            adapter_factory=lambda *, repository, subscription, runtime_id: (
+                TelegramPollingAdapter(
+                    repository=repository,
+                    subscription=subscription,
+                    runtime_id=runtime_id,
+                )
             ),
         )
     if listener_registry.resolve(ListenerPlatform.DISCORD) is None:
@@ -237,13 +236,12 @@ def register_builtin_listeners() -> None:
                 description="Receive Discord bot messages through the Gateway.",
             ),
             compiler=default_listener_compiler,
-            adapter_factory=lambda *,
-            repository,
-            subscription,
-            runtime_id: DiscordGatewayAdapter(
-                repository=repository,
-                subscription=subscription,
-                runtime_id=runtime_id,
+            adapter_factory=lambda *, repository, subscription, runtime_id: (
+                DiscordGatewayAdapter(
+                    repository=repository,
+                    subscription=subscription,
+                    runtime_id=runtime_id,
+                )
             ),
         )
     if listener_registry.resolve(ListenerPlatform.QQ) is None:
@@ -256,13 +254,12 @@ def register_builtin_listeners() -> None:
                 description="Receive QQ bot messages through the managed Gateway.",
             ),
             compiler=default_listener_compiler,
-            adapter_factory=lambda *,
-            repository,
-            subscription,
-            runtime_id: QQGatewayAdapter(
-                repository=repository,
-                subscription=subscription,
-                runtime_id=runtime_id,
+            adapter_factory=lambda *, repository, subscription, runtime_id: (
+                QQGatewayAdapter(
+                    repository=repository,
+                    subscription=subscription,
+                    runtime_id=runtime_id,
+                )
             ),
         )
 

--- a/tests/backend/api/test_backend_credentials_workflows.py
+++ b/tests/backend/api/test_backend_credentials_workflows.py
@@ -32,8 +32,8 @@ async def test_credential_health_get_without_service(
     workflow_id = workflow_response.json()["id"]
 
     monkeypatch.setitem(backend_app._credential_service_ref, "service", None)
-    api_client.app.dependency_overrides[backend_app.get_credential_service] = (
-        lambda: None
+    api_client.app.dependency_overrides[backend_app.get_credential_service] = lambda: (
+        None
     )
 
     response = api_client.get(f"/api/workflows/{workflow_id}/credentials/health")
@@ -53,8 +53,8 @@ async def test_credential_health_validate_without_service(
     workflow_id = workflow_response.json()["id"]
 
     monkeypatch.setitem(backend_app._credential_service_ref, "service", None)
-    api_client.app.dependency_overrides[backend_app.get_credential_service] = (
-        lambda: None
+    api_client.app.dependency_overrides[backend_app.get_credential_service] = lambda: (
+        None
     )
 
     response = api_client.post(

--- a/tests/backend/api/test_issue_templates.py
+++ b/tests/backend/api/test_issue_templates.py
@@ -27,11 +27,11 @@ def test_issue_template_without_service_returns_503(api_client: TestClient) -> N
     )
     template_id = create_response.json()["id"]
 
-    api_client.app.dependency_overrides[backend_app.get_vault] = (
-        lambda: api_client.app.state.vault
+    api_client.app.dependency_overrides[backend_app.get_vault] = lambda: (
+        api_client.app.state.vault
     )
-    api_client.app.dependency_overrides[backend_app.get_credential_service] = (
-        lambda: None
+    api_client.app.dependency_overrides[backend_app.get_credential_service] = lambda: (
+        None
     )
 
     response = api_client.post(
@@ -59,11 +59,11 @@ def test_issue_template_value_error_returns_400(api_client: TestClient) -> None:
         def issue_from_template(self, **_: Any) -> None:
             raise ValueError("invalid")
 
-    api_client.app.dependency_overrides[backend_app.get_vault] = (
-        lambda: api_client.app.state.vault
+    api_client.app.dependency_overrides[backend_app.get_vault] = lambda: (
+        api_client.app.state.vault
     )
-    api_client.app.dependency_overrides[backend_app.get_credential_service] = (
-        lambda: RaisingService()
+    api_client.app.dependency_overrides[backend_app.get_credential_service] = lambda: (
+        RaisingService()
     )
 
     response = api_client.post(
@@ -80,11 +80,11 @@ def test_issue_template_not_found_returns_404(api_client: TestClient) -> None:
         def issue_from_template(self, **_: Any) -> None:
             raise CredentialTemplateNotFoundError("missing")
 
-    api_client.app.dependency_overrides[backend_app.get_vault] = (
-        lambda: api_client.app.state.vault
+    api_client.app.dependency_overrides[backend_app.get_vault] = lambda: (
+        api_client.app.state.vault
     )
-    api_client.app.dependency_overrides[backend_app.get_credential_service] = (
-        lambda: MissingTemplateService()
+    api_client.app.dependency_overrides[backend_app.get_credential_service] = lambda: (
+        MissingTemplateService()
     )
 
     response = api_client.post(
@@ -115,11 +115,11 @@ def test_issue_template_scope_violation_returns_403(api_client: TestClient) -> N
         def issue_from_template(self, **_: Any) -> None:
             raise WorkflowScopeError("denied")
 
-    api_client.app.dependency_overrides[backend_app.get_vault] = (
-        lambda: api_client.app.state.vault
+    api_client.app.dependency_overrides[backend_app.get_vault] = lambda: (
+        api_client.app.state.vault
     )
-    api_client.app.dependency_overrides[backend_app.get_credential_service] = (
-        lambda: ScopeDeniedService()
+    api_client.app.dependency_overrides[backend_app.get_credential_service] = lambda: (
+        ScopeDeniedService()
     )
 
     response = api_client.post(

--- a/tests/backend/test_chatkit_store_sqlite_core.py
+++ b/tests/backend/test_chatkit_store_sqlite_core.py
@@ -13,6 +13,7 @@ from chatkit.types import (
     FileAttachment,
     InferenceOptions,
     ThreadMetadata,
+    UserMessageInput,
     UserMessageItem,
     UserMessageTextContent,
 )
@@ -208,3 +209,110 @@ async def test_sqlite_store_concurrent_initialization(tmp_path: Path) -> None:
     assert thread1.id == "thr_concurrent_1"
     assert thread2.id == "thr_concurrent_2"
     assert thread3.id == "thr_concurrent_3"
+
+
+@pytest.mark.asyncio
+async def test_sqlite_store_load_threads_isolated_by_workflow(
+    tmp_path: Path,
+) -> None:
+    """load_threads should only return threads belonging to the requested workflow."""
+    db_path = tmp_path / "store.sqlite"
+    store = SqliteChatKitStore(db_path)
+
+    ctx_a: dict[str, object] = {"workflow_id": "wf-aaa"}
+    ctx_b: dict[str, object] = {"workflow_id": "wf-bbb"}
+
+    thr_a = ThreadMetadata(
+        id="thr_iso_a",
+        created_at=_timestamp(),
+        metadata={"workflow_id": "wf-aaa"},
+    )
+    thr_b = ThreadMetadata(
+        id="thr_iso_b",
+        created_at=_timestamp(),
+        metadata={"workflow_id": "wf-bbb"},
+    )
+
+    await store.save_thread(thr_a, ctx_a)
+    await store.save_thread(thr_b, ctx_b)
+
+    page_a = await store.load_threads(limit=10, after=None, order="asc", context=ctx_a)
+    assert [t.id for t in page_a.data] == ["thr_iso_a"]
+
+    page_b = await store.load_threads(limit=10, after=None, order="asc", context=ctx_b)
+    assert [t.id for t in page_b.data] == ["thr_iso_b"]
+
+
+@pytest.mark.asyncio
+async def test_sqlite_store_load_threads_no_workflow_returns_all(
+    tmp_path: Path,
+) -> None:
+    """load_threads without workflow_id in context should return all threads."""
+    db_path = tmp_path / "store.sqlite"
+    store = SqliteChatKitStore(db_path)
+    context: dict[str, object] = {}
+
+    for i in range(3):
+        thr = ThreadMetadata(id=f"thr_nofilter_{i}", created_at=_timestamp())
+        await store.save_thread(thr, context)
+
+    page = await store.load_threads(limit=10, after=None, order="asc", context=context)
+    assert len(page.data) == 3
+
+
+@pytest.mark.asyncio
+async def test_sqlite_store_save_thread_sets_title_from_first_user_message(
+    tmp_path: Path,
+) -> None:
+    """save_thread should derive title from the first user text when unset."""
+    db_path = tmp_path / "store.sqlite"
+    store = SqliteChatKitStore(db_path)
+
+    class FakeParams:
+        input = UserMessageInput(
+            content=[UserMessageTextContent(text="Hello, world! This is long")],
+            attachments=[],
+            inference_options=InferenceOptions(),
+        )
+
+    class FakeRequest:
+        metadata: dict = {}
+        params = FakeParams()
+
+    context: dict[str, object] = {"chatkit_request": FakeRequest()}
+
+    thread = ThreadMetadata(id="thr_autotitle", created_at=_timestamp())
+    await store.save_thread(thread, context)
+
+    loaded = await store.load_thread("thr_autotitle", context)
+    assert loaded.title == "Hello, world! This i"
+
+
+@pytest.mark.asyncio
+async def test_sqlite_store_save_thread_preserves_existing_title(
+    tmp_path: Path,
+) -> None:
+    """save_thread should not overwrite a title that is already set."""
+    db_path = tmp_path / "store.sqlite"
+    store = SqliteChatKitStore(db_path)
+
+    class FakeParams:
+        input = UserMessageInput(
+            content=[UserMessageTextContent(text="New message content")],
+            attachments=[],
+            inference_options=InferenceOptions(),
+        )
+
+    class FakeRequest:
+        metadata: dict = {}
+        params = FakeParams()
+
+    context: dict[str, object] = {"chatkit_request": FakeRequest()}
+
+    thread = ThreadMetadata(
+        id="thr_keeptitle", created_at=_timestamp(), title="Existing Title"
+    )
+    await store.save_thread(thread, context)
+
+    loaded = await store.load_thread("thr_keeptitle", context)
+    assert loaded.title == "Existing Title"

--- a/tests/backend/test_chatkit_store_threads.py
+++ b/tests/backend/test_chatkit_store_threads.py
@@ -3,7 +3,12 @@
 from __future__ import annotations
 from datetime import UTC, datetime
 import pytest
-from chatkit.types import ThreadMetadata
+from chatkit.types import (
+    InferenceOptions,
+    ThreadMetadata,
+    UserMessageInput,
+    UserMessageTextContent,
+)
 from orcheo_backend.app.chatkit import (
     ChatKitRequestContext,
     InMemoryChatKitStore,
@@ -126,3 +131,107 @@ async def test_in_memory_store_merge_metadata_without_request() -> None:
 
     loaded = await store.load_thread("thr_no_request", context)
     assert loaded.metadata["existing"] == "value"
+
+
+@pytest.mark.asyncio
+async def test_in_memory_store_load_threads_isolated_by_workflow() -> None:
+    """load_threads should only return threads belonging to the requested workflow."""
+    store = InMemoryChatKitStore()
+
+    class FakeRequest:
+        def __init__(self, wf_id: str) -> None:
+            self.metadata = {"workflow_id": wf_id}
+
+    ctx_a: ChatKitRequestContext = {
+        "chatkit_request": FakeRequest("wf_aaa"),  # type: ignore[typeddict-item]
+        "workflow_id": "wf_aaa",
+    }
+    ctx_b: ChatKitRequestContext = {
+        "chatkit_request": FakeRequest("wf_bbb"),  # type: ignore[typeddict-item]
+        "workflow_id": "wf_bbb",
+    }
+
+    thr_a = ThreadMetadata(id="thr_a", created_at=datetime.now(UTC))
+    thr_b = ThreadMetadata(id="thr_b", created_at=datetime.now(UTC))
+
+    await store.save_thread(thr_a, ctx_a)
+    await store.save_thread(thr_b, ctx_b)
+
+    page_a = await store.load_threads(limit=10, after=None, order="asc", context=ctx_a)
+    assert [t.id for t in page_a.data] == ["thr_a"]
+
+    page_b = await store.load_threads(limit=10, after=None, order="asc", context=ctx_b)
+    assert [t.id for t in page_b.data] == ["thr_b"]
+
+
+@pytest.mark.asyncio
+async def test_in_memory_store_load_threads_no_workflow_returns_all() -> None:
+    """load_threads without workflow_id in context should return all threads."""
+    store = InMemoryChatKitStore()
+    context: ChatKitRequestContext = {}
+
+    for i in range(3):
+        thr = ThreadMetadata(
+            id=f"thr_all_{i}",
+            created_at=datetime(2024, 1, i + 1, tzinfo=UTC),
+        )
+        await store.save_thread(thr, context)
+
+    page = await store.load_threads(limit=10, after=None, order="asc", context=context)
+    assert len(page.data) == 3
+
+
+@pytest.mark.asyncio
+async def test_in_memory_store_save_thread_sets_title_from_first_user_message() -> None:
+    """save_thread should derive title from the first user message when unset."""
+    store = InMemoryChatKitStore()
+
+    class FakeParams:
+        input = UserMessageInput(
+            content=[UserMessageTextContent(text="Hello, world! This is long")],
+            attachments=[],
+            inference_options=InferenceOptions(),
+        )
+
+    class FakeRequest:
+        metadata: dict = {}
+        params = FakeParams()
+
+    context: ChatKitRequestContext = {
+        "chatkit_request": FakeRequest(),  # type: ignore[typeddict-item]
+    }
+
+    thread = ThreadMetadata(id="thr_title", created_at=datetime.now(UTC))
+    await store.save_thread(thread, context)
+
+    loaded = await store.load_thread("thr_title", context)
+    assert loaded.title == "Hello, world! This i"
+
+
+@pytest.mark.asyncio
+async def test_in_memory_store_save_thread_preserves_existing_title() -> None:
+    """save_thread should not overwrite a title that is already set."""
+    store = InMemoryChatKitStore()
+
+    class FakeParams:
+        input = UserMessageInput(
+            content=[UserMessageTextContent(text="New message content")],
+            attachments=[],
+            inference_options=InferenceOptions(),
+        )
+
+    class FakeRequest:
+        metadata: dict = {}
+        params = FakeParams()
+
+    context: ChatKitRequestContext = {
+        "chatkit_request": FakeRequest(),  # type: ignore[typeddict-item]
+    }
+
+    thread = ThreadMetadata(
+        id="thr_existing_title", created_at=datetime.now(UTC), title="Existing Title"
+    )
+    await store.save_thread(thread, context)
+
+    loaded = await store.load_thread("thr_existing_title", context)
+    assert loaded.title == "Existing Title"

--- a/tests/backend/test_chatkit_workflow_executor.py
+++ b/tests/backend/test_chatkit_workflow_executor.py
@@ -469,14 +469,12 @@ async def test_run_builds_step_callback_when_progress_callback_is_provided(
     monkeypatch.setattr(
         WorkflowExecutor,
         "_build_step_callback",
-        lambda self,
-        *,
-        history_store,
-        execution_id,
-        progress_callback: build_step_callback_calls.append(
-            (history_store, execution_id, progress_callback)
-        )
-        or step_callback,
+        lambda self, *, history_store, execution_id, progress_callback: (
+            build_step_callback_calls.append(
+                (history_store, execution_id, progress_callback)
+            )
+            or step_callback
+        ),
     )
 
     async def fake_execute_graph(self, **kwargs):

--- a/tests/nodes/test_browser_nodes.py
+++ b/tests/nodes/test_browser_nodes.py
@@ -547,8 +547,9 @@ def test_configure_playwright_browser_path_keeps_valid_existing_setting(
     monkeypatch.setattr(
         browser_nodes,
         "_contains_playwright_browser_installation",
-        lambda root, browser_type: root == configured_root
-        and browser_type == "chromium",
+        lambda root, browser_type: (
+            root == configured_root and browser_type == "chromium"
+        ),
     )
 
     browser_nodes._configure_playwright_browser_path("chromium")

--- a/tests/sdk/test_cli_plugin.py
+++ b/tests/sdk/test_cli_plugin.py
@@ -328,21 +328,23 @@ def test_plugin_install_human_mode_emits_progress(
         plugin_module,
         "install_plugin_data",
         lambda ref, *, progress=None: (
-            progress("Creating isolated plugin environment")
-            if progress is not None
-            else None
-        )
-        or {
-            "plugin": {"name": "example"},
-            "impact": PluginImpactSummary(
-                change_type="install",
-                affected_component_kinds=[],
-                affected_component_ids=[],
-                activation_mode="silent_hot_reload",
-                prompt_required=False,
-                restart_required=False,
-            ),
-        },
+            (
+                progress("Creating isolated plugin environment")
+                if progress is not None
+                else None
+            )
+            or {
+                "plugin": {"name": "example"},
+                "impact": PluginImpactSummary(
+                    change_type="install",
+                    affected_component_kinds=[],
+                    affected_component_ids=[],
+                    activation_mode="silent_hot_reload",
+                    prompt_required=False,
+                    restart_required=False,
+                ),
+            }
+        ),
     )
 
     plugin_module.install_plugin(None, "example-ref", runtime="auto")


### PR DESCRIPTION
## Summary
This PR adds two key features to the ChatKit thread storage layer:
1. **Workflow isolation**: Thread listing now respects workflow boundaries, returning only threads belonging to the requested workflow
2. **Auto-title generation**: Thread titles are automatically derived from the first user message when not explicitly set

## Key Changes

### Thread Storage Implementations
- **In-memory store** (`in_memory_store.py`): Added workflow filtering in `load_threads()` and auto-title extraction in `save_thread()`
- **SQLite store** (`chatkit_store_sqlite/threads.py`): Implemented workflow-scoped queries and title auto-generation
- **PostgreSQL store** (`chatkit_store_postgres/threads.py`): Added matching workflow isolation and auto-title logic

### Helper Function
- Added `_extract_title_from_request()` utility function (duplicated across stores) that:
  - Extracts the first user text content from the ChatKit request
  - Returns the first 20 characters (stripped)
  - Returns `None` if no text content is found

### Workflow Isolation Logic
- `load_threads()` now checks for `workflow_id` in the request context
- When present, filters threads to only those with matching `workflow_id` in metadata
- When absent, returns all threads (backward compatible)

### Auto-Title Generation
- `save_thread()` checks if thread title is unset before saving
- If unset, extracts title from the first user message in the request
- Preserves existing titles (does not overwrite)

### Test Coverage
Added comprehensive tests for both in-memory and SQLite stores:
- `test_*_load_threads_isolated_by_workflow`: Verifies workflow isolation
- `test_*_load_threads_no_workflow_returns_all`: Verifies backward compatibility
- `test_*_save_thread_sets_title_from_first_user_message`: Verifies auto-title generation
- `test_*_save_thread_preserves_existing_title`: Verifies title preservation

### Code Formatting
- Fixed lambda formatting in multiple files to improve readability (wrapping multi-line lambdas with parentheses)
- Updated files: `registry.py`, `test_issue_templates.py`, `test_cli_plugin.py`, `test_chatkit_workflow_executor.py`, `external_agents.py`, `factory.py`, `test_backend_credentials_workflows.py`, `test_browser_nodes.py`

## Implementation Details
- The `_extract_title_from_request()` function uses `getattr()` for safe attribute access to handle various request object structures
- Workflow filtering uses SQL `AND` conditions to combine with existing pagination logic
- Title extraction is limited to 20 characters and stripped of whitespace to ensure clean, concise titles

https://claude.ai/code/session_01QyU5dJU3RAgFEfWBdGwbnw