### PR TITLE
Add in-node status streaming API for intermediate progress updates

### DIFF
--- a/apps/backend/src/orcheo_backend/app/chatkit/server.py
+++ b/apps/backend/src/orcheo_backend/app/chatkit/server.py
@@ -247,7 +247,21 @@ def _format_node_event_update(node: str, event: str, payload: Any) -> str:
         if error_message:
             return f"! {node} error: {error_message}"
         return f"! {node} error"
+    if normalized_event == "node_status":
+        return _format_node_status_update(node, payload)
     return f"[{event}] {node}"
+
+
+def _format_node_status_update(node: str, payload: Any) -> str:
+    """Render an in-node ``emit_node_status`` payload as progress text."""
+    if isinstance(payload, Mapping):
+        for key in ("message", "text", "status"):
+            value = payload.get(key)
+            if isinstance(value, str) and value.strip():
+                return f"{node}: {value.strip()}"
+    if isinstance(payload, str) and payload.strip():
+        return f"{node}: {payload.strip()}"
+    return f"{node}: status update"
 
 
 def _progress_texts_for_step(step: Mapping[str, Any]) -> list[str]:

--- a/apps/backend/src/orcheo_backend/app/factory.py
+++ b/apps/backend/src/orcheo_backend/app/factory.py
@@ -197,15 +197,15 @@ def create_app(
     if credential_service is not None:
         set_credential_service(credential_service)
         set_vault(getattr(credential_service, "_vault", None))
-        application.dependency_overrides[get_credential_service] = (
-            lambda: credential_service
+        application.dependency_overrides[get_credential_service] = lambda: (
+            credential_service
         )
     elif repository is not None:
         inferred_service = getattr(repository, "_credential_service", None)
         if inferred_service is not None:
             set_credential_service(inferred_service)
-            application.dependency_overrides[get_credential_service] = (
-                lambda: inferred_service
+            application.dependency_overrides[get_credential_service] = lambda: (
+                inferred_service
             )
 
     application.include_router(api_router)

--- a/apps/backend/src/orcheo_backend/app/workflow_execution.py
+++ b/apps/backend/src/orcheo_backend/app/workflow_execution.py
@@ -17,6 +17,7 @@ from orcheo.agentensor.training import TrainingRequest
 from orcheo.config import get_settings
 from orcheo.external_agents import scoped_external_agent_environment
 from orcheo.graph.state import State
+from orcheo.nodes.agent_tools.context import tool_progress_context
 from orcheo.nodes.agentensor import AgentensorNode
 from orcheo.nodes.browser import close_browser_sessions_for_scope
 from orcheo.runtime.credentials import CredentialResolver, credential_resolution
@@ -174,6 +175,26 @@ async def _emit_trace_update(
         await _safe_send_json(websocket, update.model_dump(mode="json"))
 
 
+async def _forward_node_step(
+    payload: Mapping[str, Any],
+    *,
+    history_store: RunHistoryStore,
+    execution_id: str,
+    websocket: WebSocket,
+    tracer: Tracer,
+) -> None:
+    """Persist and stream a single step payload to the connected client."""
+    record_workflow_step(tracer, payload)
+    history_step = await history_store.append_step(execution_id, payload)
+    await _safe_send_json(websocket, _sanitize_public_step_payload(payload))
+    await _emit_trace_update(
+        history_store,
+        websocket,
+        execution_id,
+        step=history_step,
+    )
+
+
 async def _stream_workflow_updates(
     compiled_graph: Any,
     state: Any,
@@ -184,26 +205,42 @@ async def _stream_workflow_updates(
     tracer: Tracer,
 ) -> None:
     """Stream workflow updates to the client while recording history."""
-    async for step in compiled_graph.astream(
-        state,
-        config=config,  # type: ignore[arg-type]
-        stream_mode="updates",
-    ):  # pragma: no cover
-        _log_step_debug(step)
-        record_workflow_step(tracer, step)
-        history_step = await history_store.append_step(execution_id, step)
-        try:
-            await _safe_send_json(websocket, _sanitize_public_step_payload(step))
-        except Exception as exc:  # pragma: no cover
-            logger.error("Error processing messages: %s", exc)
-            raise
 
-        await _emit_trace_update(
-            history_store,
-            websocket,
-            execution_id,
-            step=history_step,
+    async def in_node_status_callback(payload: Mapping[str, Any]) -> None:
+        if not isinstance(payload, Mapping):
+            return  # pragma: no cover - defensive
+        if payload.get("event") != "node_status":
+            # Sub-graph (tool) updates are surfaced through their own paths.
+            return
+        await _forward_node_step(
+            payload,
+            history_store=history_store,
+            execution_id=execution_id,
+            websocket=websocket,
+            tracer=tracer,
         )
+
+    with tool_progress_context(in_node_status_callback):
+        async for step in compiled_graph.astream(
+            state,
+            config=config,  # type: ignore[arg-type]
+            stream_mode="updates",
+        ):  # pragma: no cover
+            _log_step_debug(step)
+            record_workflow_step(tracer, step)
+            history_step = await history_store.append_step(execution_id, step)
+            try:
+                await _safe_send_json(websocket, _sanitize_public_step_payload(step))
+            except Exception as exc:  # pragma: no cover
+                logger.error("Error processing messages: %s", exc)
+                raise
+
+            await _emit_trace_update(
+                history_store,
+                websocket,
+                execution_id,
+                step=history_step,
+            )
 
     final_state = await compiled_graph.aget_state(cast(RunnableConfig, config))
     _log_final_state_debug(final_state.values)

--- a/apps/backend/src/orcheo_backend/worker/external_agents.py
+++ b/apps/backend/src/orcheo_backend/worker/external_agents.py
@@ -1378,10 +1378,12 @@ async def start_external_agent_login_async(  # noqa: C901, PLR0915
                 on_output=on_output,
                 consume_input=manage_login_input,
                 auto_input=auto_login_input,
-                is_authenticated=lambda: provider.probe_auth(
-                    runtime,
-                    environ=manager.environment_for_provider(provider_name),
-                ).authenticated,
+                is_authenticated=lambda: (
+                    provider.probe_auth(
+                        runtime,
+                        environ=manager.environment_for_provider(provider_name),
+                    ).authenticated
+                ),
                 on_tick=heartbeat_session,
             )
             if (

--- a/src/orcheo/listeners/registry.py
+++ b/src/orcheo/listeners/registry.py
@@ -218,13 +218,12 @@ def register_builtin_listeners() -> None:
                 ),
             ),
             compiler=default_listener_compiler,
-            adapter_factory=lambda *,
-            repository,
-            subscription,
-            runtime_id: TelegramPollingAdapter(
-                repository=repository,
-                subscription=subscription,
-                runtime_id=runtime_id,
+            adapter_factory=lambda *, repository, subscription, runtime_id: (
+                TelegramPollingAdapter(
+                    repository=repository,
+                    subscription=subscription,
+                    runtime_id=runtime_id,
+                )
             ),
         )
     if listener_registry.resolve(ListenerPlatform.DISCORD) is None:
@@ -237,13 +236,12 @@ def register_builtin_listeners() -> None:
                 description="Receive Discord bot messages through the Gateway.",
             ),
             compiler=default_listener_compiler,
-            adapter_factory=lambda *,
-            repository,
-            subscription,
-            runtime_id: DiscordGatewayAdapter(
-                repository=repository,
-                subscription=subscription,
-                runtime_id=runtime_id,
+            adapter_factory=lambda *, repository, subscription, runtime_id: (
+                DiscordGatewayAdapter(
+                    repository=repository,
+                    subscription=subscription,
+                    runtime_id=runtime_id,
+                )
             ),
         )
     if listener_registry.resolve(ListenerPlatform.QQ) is None:
@@ -256,13 +254,12 @@ def register_builtin_listeners() -> None:
                 description="Receive QQ bot messages through the managed Gateway.",
             ),
             compiler=default_listener_compiler,
-            adapter_factory=lambda *,
-            repository,
-            subscription,
-            runtime_id: QQGatewayAdapter(
-                repository=repository,
-                subscription=subscription,
-                runtime_id=runtime_id,
+            adapter_factory=lambda *, repository, subscription, runtime_id: (
+                QQGatewayAdapter(
+                    repository=repository,
+                    subscription=subscription,
+                    runtime_id=runtime_id,
+                )
             ),
         )
 

--- a/src/orcheo/nodes/agent_tools/context.py
+++ b/src/orcheo/nodes/agent_tools/context.py
@@ -9,12 +9,16 @@ from langchain_core.runnables import RunnableConfig
 
 
 ToolProgressCallback = Callable[[Mapping[str, Any]], Awaitable[None]]
+NodeStatusEmitter = Callable[[Mapping[str, Any]], Awaitable[None]]
 
 _ACTIVE_TOOL_CONFIG: ContextVar[RunnableConfig | None] = ContextVar(
     "orcheo_active_tool_config", default=None
 )
 _ACTIVE_TOOL_PROGRESS_CALLBACK: ContextVar[ToolProgressCallback | None] = ContextVar(
     "orcheo_active_tool_progress_callback", default=None
+)
+_ACTIVE_NODE_STATUS_EMITTER: ContextVar[NodeStatusEmitter | None] = ContextVar(
+    "orcheo_active_node_status_emitter", default=None
 )
 
 
@@ -38,6 +42,21 @@ def tool_progress_context(callback: ToolProgressCallback | None) -> Any:
         _ACTIVE_TOOL_PROGRESS_CALLBACK.reset(token)
 
 
+@contextmanager
+def node_status_context(emitter: NodeStatusEmitter | None) -> Any:
+    """Bind an in-node status emitter for the current node execution.
+
+    Node base classes call this around each ``run()`` invocation so developer
+    code can publish optional intermediate status updates via
+    :func:`emit_node_status` without depending on streaming wiring directly.
+    """
+    token = _ACTIVE_NODE_STATUS_EMITTER.set(emitter)
+    try:
+        yield emitter
+    finally:
+        _ACTIVE_NODE_STATUS_EMITTER.reset(token)
+
+
 def get_active_tool_config() -> RunnableConfig | None:
     """Return the currently bound tool execution config, if any."""
     return _ACTIVE_TOOL_CONFIG.get()
@@ -48,10 +67,51 @@ def get_active_tool_progress_callback() -> ToolProgressCallback | None:
     return _ACTIVE_TOOL_PROGRESS_CALLBACK.get()
 
 
+def get_active_node_status_emitter() -> NodeStatusEmitter | None:
+    """Return the in-node status emitter for the running node, if any."""
+    return _ACTIVE_NODE_STATUS_EMITTER.get()
+
+
+async def emit_node_status(
+    status: Any = None,
+    *,
+    payload: Mapping[str, Any] | None = None,
+    **details: Any,
+) -> None:
+    """Stream an optional in-node status update from inside ``run()``.
+
+    The call is a no-op when no status emitter is bound (e.g. when the node
+    runs outside a streaming workflow execution), so node implementations can
+    call this unconditionally.
+
+    Args:
+        status: Optional short status label (e.g. ``"fetching"``). Stored under
+            the ``"status"`` key when supplied and not already present.
+        payload: Optional mapping of additional fields to merge into the
+            emitted body.
+        **details: Convenience keyword fields merged into the emitted body.
+    """
+    emitter = get_active_node_status_emitter()
+    if emitter is None:
+        return
+    body: dict[str, Any] = {}
+    if payload is not None:
+        body.update(dict(payload))
+    if details:
+        body.update(details)
+    if status is not None:
+        body.setdefault("status", status)
+    await emitter(body)
+
+
 __all__ = [
+    "NodeStatusEmitter",
     "ToolProgressCallback",
+    "emit_node_status",
+    "get_active_node_status_emitter",
     "get_active_tool_config",
     "get_active_tool_progress_callback",
+    "node_status_context",
     "tool_execution_context",
     "tool_progress_context",
 ]

--- a/src/orcheo/nodes/base.py
+++ b/src/orcheo/nodes/base.py
@@ -4,7 +4,7 @@ import logging
 import re
 from abc import abstractmethod
 from collections.abc import Mapping, Sequence
-from typing import Any, ClassVar, Self, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Self, cast
 from langchain_core.runnables import RunnableConfig
 from pydantic import BaseModel
 from orcheo.graph.state import State
@@ -20,6 +20,10 @@ from orcheo.tracing.model_metadata import (
     build_ai_trace_metadata,
     infer_chat_result_model_name,
 )
+
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only import
+    from orcheo.nodes.agent_tools.context import NodeStatusEmitter
 
 
 logger = logging.getLogger(__name__)
@@ -345,6 +349,37 @@ class BaseNode(BaseRunnable):
             metadata["ai"] = ai_trace
         return metadata
 
+    def _build_node_status_emitter(self) -> "NodeStatusEmitter | None":
+        """Return an emitter that streams in-node status to the active sink.
+
+        The emitter wraps the currently bound tool progress callback (if any)
+        so developer ``run()`` code can publish optional intermediate updates
+        via :func:`orcheo.nodes.agent_tools.context.emit_node_status`. Each
+        emitted body is wrapped in an envelope ``{"node": self.name,
+        "event": "node_status", "payload": ...}`` so existing streaming
+        consumers (ChatKit, websocket clients) can recognise it.
+        """
+        from orcheo.nodes.agent_tools.context import (
+            get_active_tool_progress_callback,
+        )
+
+        callback = get_active_tool_progress_callback()
+        if callback is None:
+            return None
+
+        node_name = self.name
+
+        async def _emit(body: Mapping[str, Any]) -> None:
+            await callback(
+                {
+                    "node": node_name,
+                    "event": "node_status",
+                    "payload": dict(body),
+                }
+            )
+
+        return _emit
+
     def _attach_trace_metadata(self, result: Any) -> Any:
         """Attach trace metadata to the emitted node payload."""
         if not isinstance(result, Mapping):
@@ -392,10 +427,14 @@ class AINode(BaseNode):
 
     async def __call__(self, state: State, config: RunnableConfig) -> dict[str, Any]:
         """Execute the node and wrap the result in a messages key."""
+        from orcheo.nodes.agent_tools.context import node_status_context
+
         runnable = self.resolved_for_run(state, config=config)
         runnable._clear_trace_metadata_for_run()
+        emitter = runnable._build_node_status_emitter()
         try:
-            result = await runnable.run(state, config)
+            with node_status_context(emitter):
+                result = await runnable.run(state, config)
         except Exception:
             runnable._clear_trace_metadata_for_run()
             raise
@@ -413,10 +452,14 @@ class TaskNode(BaseNode):
 
     async def __call__(self, state: State, config: RunnableConfig) -> dict[str, Any]:
         """Execute the node and wrap the result in a outputs key."""
+        from orcheo.nodes.agent_tools.context import node_status_context
+
         runnable = self.resolved_for_run(state, config=config)
         runnable._clear_trace_metadata_for_run()
+        emitter = runnable._build_node_status_emitter()
         try:
-            result = await runnable.run(state, config)
+            with node_status_context(emitter):
+                result = await runnable.run(state, config)
         except Exception:
             runnable._clear_trace_metadata_for_run()
             raise

--- a/tests/backend/api/test_backend_credentials_workflows.py
+++ b/tests/backend/api/test_backend_credentials_workflows.py
@@ -32,8 +32,8 @@ async def test_credential_health_get_without_service(
     workflow_id = workflow_response.json()["id"]
 
     monkeypatch.setitem(backend_app._credential_service_ref, "service", None)
-    api_client.app.dependency_overrides[backend_app.get_credential_service] = (
-        lambda: None
+    api_client.app.dependency_overrides[backend_app.get_credential_service] = lambda: (
+        None
     )
 
     response = api_client.get(f"/api/workflows/{workflow_id}/credentials/health")
@@ -53,8 +53,8 @@ async def test_credential_health_validate_without_service(
     workflow_id = workflow_response.json()["id"]
 
     monkeypatch.setitem(backend_app._credential_service_ref, "service", None)
-    api_client.app.dependency_overrides[backend_app.get_credential_service] = (
-        lambda: None
+    api_client.app.dependency_overrides[backend_app.get_credential_service] = lambda: (
+        None
     )
 
     response = api_client.post(

--- a/tests/backend/api/test_issue_templates.py
+++ b/tests/backend/api/test_issue_templates.py
@@ -27,11 +27,11 @@ def test_issue_template_without_service_returns_503(api_client: TestClient) -> N
     )
     template_id = create_response.json()["id"]
 
-    api_client.app.dependency_overrides[backend_app.get_vault] = (
-        lambda: api_client.app.state.vault
+    api_client.app.dependency_overrides[backend_app.get_vault] = lambda: (
+        api_client.app.state.vault
     )
-    api_client.app.dependency_overrides[backend_app.get_credential_service] = (
-        lambda: None
+    api_client.app.dependency_overrides[backend_app.get_credential_service] = lambda: (
+        None
     )
 
     response = api_client.post(
@@ -59,11 +59,11 @@ def test_issue_template_value_error_returns_400(api_client: TestClient) -> None:
         def issue_from_template(self, **_: Any) -> None:
             raise ValueError("invalid")
 
-    api_client.app.dependency_overrides[backend_app.get_vault] = (
-        lambda: api_client.app.state.vault
+    api_client.app.dependency_overrides[backend_app.get_vault] = lambda: (
+        api_client.app.state.vault
     )
-    api_client.app.dependency_overrides[backend_app.get_credential_service] = (
-        lambda: RaisingService()
+    api_client.app.dependency_overrides[backend_app.get_credential_service] = lambda: (
+        RaisingService()
     )
 
     response = api_client.post(
@@ -80,11 +80,11 @@ def test_issue_template_not_found_returns_404(api_client: TestClient) -> None:
         def issue_from_template(self, **_: Any) -> None:
             raise CredentialTemplateNotFoundError("missing")
 
-    api_client.app.dependency_overrides[backend_app.get_vault] = (
-        lambda: api_client.app.state.vault
+    api_client.app.dependency_overrides[backend_app.get_vault] = lambda: (
+        api_client.app.state.vault
     )
-    api_client.app.dependency_overrides[backend_app.get_credential_service] = (
-        lambda: MissingTemplateService()
+    api_client.app.dependency_overrides[backend_app.get_credential_service] = lambda: (
+        MissingTemplateService()
     )
 
     response = api_client.post(
@@ -115,11 +115,11 @@ def test_issue_template_scope_violation_returns_403(api_client: TestClient) -> N
         def issue_from_template(self, **_: Any) -> None:
             raise WorkflowScopeError("denied")
 
-    api_client.app.dependency_overrides[backend_app.get_vault] = (
-        lambda: api_client.app.state.vault
+    api_client.app.dependency_overrides[backend_app.get_vault] = lambda: (
+        api_client.app.state.vault
     )
-    api_client.app.dependency_overrides[backend_app.get_credential_service] = (
-        lambda: ScopeDeniedService()
+    api_client.app.dependency_overrides[backend_app.get_credential_service] = lambda: (
+        ScopeDeniedService()
     )
 
     response = api_client.post(

--- a/tests/backend/test_chatkit_server_response.py
+++ b/tests/backend/test_chatkit_server_response.py
@@ -354,6 +354,49 @@ def test_format_node_event_update_unknown_event() -> None:
     assert result == "[on_tool_start] indexer"
 
 
+def test_format_node_event_update_node_status_with_message() -> None:
+    from orcheo_backend.app.chatkit.server import _format_node_event_update
+
+    result = _format_node_event_update(
+        "indexer",
+        "node_status",
+        {"message": "fetching documents"},
+    )
+    assert result == "indexer: fetching documents"
+
+
+def test_format_node_event_update_node_status_with_text_field() -> None:
+    from orcheo_backend.app.chatkit.server import _format_node_event_update
+
+    result = _format_node_event_update(
+        "indexer",
+        "node_status",
+        {"text": "loading"},
+    )
+    assert result == "indexer: loading"
+
+
+def test_format_node_event_update_node_status_with_status_field() -> None:
+    from orcheo_backend.app.chatkit.server import _format_node_event_update
+
+    result = _format_node_event_update("indexer", "node_status", {"status": "ready"})
+    assert result == "indexer: ready"
+
+
+def test_format_node_event_update_node_status_string_payload() -> None:
+    from orcheo_backend.app.chatkit.server import _format_node_event_update
+
+    result = _format_node_event_update("indexer", "node_status", "in flight")
+    assert result == "indexer: in flight"
+
+
+def test_format_node_event_update_node_status_default_label() -> None:
+    from orcheo_backend.app.chatkit.server import _format_node_event_update
+
+    result = _format_node_event_update("indexer", "node_status", {})
+    assert result == "indexer: status update"
+
+
 def test_progress_texts_for_step_skips_none_key() -> None:
     from orcheo_backend.app.chatkit.server import _progress_texts_for_step
 

--- a/tests/backend/test_chatkit_workflow_executor.py
+++ b/tests/backend/test_chatkit_workflow_executor.py
@@ -469,14 +469,12 @@ async def test_run_builds_step_callback_when_progress_callback_is_provided(
     monkeypatch.setattr(
         WorkflowExecutor,
         "_build_step_callback",
-        lambda self,
-        *,
-        history_store,
-        execution_id,
-        progress_callback: build_step_callback_calls.append(
-            (history_store, execution_id, progress_callback)
-        )
-        or step_callback,
+        lambda self, *, history_store, execution_id, progress_callback: (
+            build_step_callback_calls.append(
+                (history_store, execution_id, progress_callback)
+            )
+            or step_callback
+        ),
     )
 
     async def fake_execute_graph(self, **kwargs):

--- a/tests/backend/test_workflow_execution_unit.py
+++ b/tests/backend/test_workflow_execution_unit.py
@@ -596,6 +596,71 @@ async def test_stream_workflow_updates_logs_final_state(
 
 
 @pytest.mark.asyncio
+async def test_stream_workflow_updates_forwards_in_node_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In-node status emissions should be persisted and streamed to clients."""
+
+    safe_send = AsyncMock(return_value=True)
+    emit_update = AsyncMock()
+    history_store = AsyncMock()
+    history_step = SimpleNamespace()
+    history_store.append_step = AsyncMock(return_value=history_step)
+    captured_callback: dict[str, Any] = {}
+
+    from orcheo.nodes.agent_tools.context import get_active_tool_progress_callback
+
+    class CompiledGraph:
+        async def astream(self, state: object, *, config: object, stream_mode: str):
+            captured_callback["callback"] = get_active_tool_progress_callback()
+            assert captured_callback["callback"] is not None
+            await captured_callback["callback"](
+                {
+                    "node": "indexer",
+                    "event": "node_status",
+                    "payload": {"status": "loading"},
+                }
+            )
+            # Sub-graph progress without an event key must not be forwarded.
+            await captured_callback["callback"]({"sub_node": {"value": 1}})
+            yield {"indexer": {"value": "done"}}
+
+        async def aget_state(self, config: object) -> object:
+            return SimpleNamespace(values={"reply": "done"})
+
+    monkeypatch.setattr(workflow_execution, "_safe_send_json", safe_send)
+    monkeypatch.setattr(workflow_execution, "_emit_trace_update", emit_update)
+    monkeypatch.setattr(
+        workflow_execution, "record_workflow_step", lambda tracer, payload: None
+    )
+    monkeypatch.setattr(
+        workflow_execution, "_log_final_state_debug", lambda values: None
+    )
+
+    await workflow_execution._stream_workflow_updates(
+        CompiledGraph(),
+        {"inputs": {}},
+        {"configurable": {"thread_id": "exec"}},
+        history_store,
+        "exec",
+        AsyncMock(),
+        object(),
+    )
+
+    appended = [call.args[1] for call in history_store.append_step.await_args_list]
+    assert {
+        "node": "indexer",
+        "event": "node_status",
+        "payload": {"status": "loading"},
+    } in appended
+    assert {"indexer": {"value": "done"}} in appended
+    # Sub-graph payload without an event key must be filtered out.
+    assert {"sub_node": {"value": 1}} not in appended
+    # Callback must be unbound after the loop completes.
+    assert get_active_tool_progress_callback() is None
+
+
+@pytest.mark.asyncio
 async def test_run_workflow_stream_handles_cancellation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/nodes/test_browser_nodes.py
+++ b/tests/nodes/test_browser_nodes.py
@@ -547,8 +547,9 @@ def test_configure_playwright_browser_path_keeps_valid_existing_setting(
     monkeypatch.setattr(
         browser_nodes,
         "_contains_playwright_browser_installation",
-        lambda root, browser_type: root == configured_root
-        and browser_type == "chromium",
+        lambda root, browser_type: (
+            root == configured_root and browser_type == "chromium"
+        ),
     )
 
     browser_nodes._configure_playwright_browser_path("chromium")

--- a/tests/nodes/test_node_status_streaming.py
+++ b/tests/nodes/test_node_status_streaming.py
@@ -1,0 +1,167 @@
+"""Tests for the in-node status streaming API."""
+
+from __future__ import annotations
+from collections.abc import Mapping
+from typing import Any
+import pytest
+from langchain_core.runnables import RunnableConfig
+from orcheo.graph.state import State
+from orcheo.nodes.agent_tools.context import (
+    emit_node_status,
+    get_active_node_status_emitter,
+    node_status_context,
+    tool_progress_context,
+)
+from orcheo.nodes.base import AINode, TaskNode
+
+
+class _StatusReportingTaskNode(TaskNode):
+    """Task node that streams optional status updates from ``run``."""
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        del state, config
+        await emit_node_status("starting")
+        await emit_node_status(
+            "progress",
+            payload={"completed": 1, "total": 3},
+        )
+        await emit_node_status(message="finalising", percent=100)
+        return {"value": "done"}
+
+
+class _StatusReportingAINode(AINode):
+    """AI node that streams optional status updates from ``run``."""
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        del state, config
+        await emit_node_status("thinking")
+        return {"messages": []}
+
+
+@pytest.mark.asyncio
+async def test_emit_node_status_is_noop_when_no_emitter_bound() -> None:
+    assert get_active_node_status_emitter() is None
+    # Should not raise even without a configured emitter.
+    await emit_node_status("ignored", payload={"x": 1})
+
+
+@pytest.mark.asyncio
+async def test_node_status_context_binds_and_resets_emitter() -> None:
+    received: list[Mapping[str, Any]] = []
+
+    async def emitter(body: Mapping[str, Any]) -> None:
+        received.append(dict(body))
+
+    with node_status_context(emitter):
+        assert get_active_node_status_emitter() is emitter
+        await emit_node_status("running", payload={"step": "load"}, batch=4)
+
+    assert get_active_node_status_emitter() is None
+    assert received == [{"status": "running", "step": "load", "batch": 4}]
+
+
+@pytest.mark.asyncio
+async def test_emit_node_status_with_no_arguments() -> None:
+    received: list[Mapping[str, Any]] = []
+
+    async def emitter(body: Mapping[str, Any]) -> None:
+        received.append(dict(body))
+
+    with node_status_context(emitter):
+        await emit_node_status()
+
+    assert received == [{}]
+
+
+@pytest.mark.asyncio
+async def test_emit_node_status_preserves_existing_status_key() -> None:
+    received: list[Mapping[str, Any]] = []
+
+    async def emitter(body: Mapping[str, Any]) -> None:
+        received.append(dict(body))
+
+    with node_status_context(emitter):
+        await emit_node_status("ignored", payload={"status": "explicit"})
+
+    assert received == [{"status": "explicit"}]
+
+
+@pytest.mark.asyncio
+async def test_task_node_call_streams_status_through_tool_progress_callback() -> None:
+    received: list[Mapping[str, Any]] = []
+
+    async def progress(step: Mapping[str, Any]) -> None:
+        received.append(dict(step))
+
+    node = _StatusReportingTaskNode(name="reporter")
+
+    with tool_progress_context(progress):
+        result = await node(State({"results": {}}), RunnableConfig())
+
+    assert result == {"results": {"reporter": {"value": "done"}}}
+    assert [step["event"] for step in received] == ["node_status"] * 3
+    assert all(step["node"] == "reporter" for step in received)
+    payloads = [step["payload"] for step in received]
+    assert payloads[0] == {"status": "starting"}
+    assert payloads[1] == {"status": "progress", "completed": 1, "total": 3}
+    assert payloads[2] == {"message": "finalising", "percent": 100}
+
+
+@pytest.mark.asyncio
+async def test_ai_node_call_streams_status_through_tool_progress_callback() -> None:
+    received: list[Mapping[str, Any]] = []
+
+    async def progress(step: Mapping[str, Any]) -> None:
+        received.append(dict(step))
+
+    node = _StatusReportingAINode(name="responder")
+
+    with tool_progress_context(progress):
+        await node(State({"results": {}}), RunnableConfig())
+
+    assert received == [
+        {
+            "node": "responder",
+            "event": "node_status",
+            "payload": {"status": "thinking"},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_node_call_does_not_emit_when_no_progress_callback_bound() -> None:
+    node = _StatusReportingTaskNode(name="reporter")
+    # Without a tool progress context, the emitter is None and run() is a no-op
+    # for the streaming side effects.
+    result = await node(State({"results": {}}), RunnableConfig())
+    assert result == {"results": {"reporter": {"value": "done"}}}
+
+
+@pytest.mark.asyncio
+async def test_node_status_context_resets_after_run_exception() -> None:
+    received: list[Mapping[str, Any]] = []
+
+    async def progress(step: Mapping[str, Any]) -> None:
+        received.append(dict(step))
+
+    class _FailingNode(TaskNode):
+        async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+            del state, config
+            await emit_node_status("about_to_fail")
+            raise RuntimeError("boom")
+
+    node = _FailingNode(name="failing")
+
+    with tool_progress_context(progress):
+        with pytest.raises(RuntimeError, match="boom"):
+            await node(State({"results": {}}), RunnableConfig())
+        # Emitter must be cleared even when run() raised.
+        assert get_active_node_status_emitter() is None
+
+    assert received == [
+        {
+            "node": "failing",
+            "event": "node_status",
+            "payload": {"status": "about_to_fail"},
+        }
+    ]

--- a/tests/sdk/test_cli_plugin.py
+++ b/tests/sdk/test_cli_plugin.py
@@ -328,21 +328,23 @@ def test_plugin_install_human_mode_emits_progress(
         plugin_module,
         "install_plugin_data",
         lambda ref, *, progress=None: (
-            progress("Creating isolated plugin environment")
-            if progress is not None
-            else None
-        )
-        or {
-            "plugin": {"name": "example"},
-            "impact": PluginImpactSummary(
-                change_type="install",
-                affected_component_kinds=[],
-                affected_component_ids=[],
-                activation_mode="silent_hot_reload",
-                prompt_required=False,
-                restart_required=False,
-            ),
-        },
+            (
+                progress("Creating isolated plugin environment")
+                if progress is not None
+                else None
+            )
+            or {
+                "plugin": {"name": "example"},
+                "impact": PluginImpactSummary(
+                    change_type="install",
+                    affected_component_kinds=[],
+                    affected_component_ids=[],
+                    activation_mode="silent_hot_reload",
+                    prompt_required=False,
+                    restart_required=False,
+                ),
+            }
+        ),
     )
 
     plugin_module.install_plugin(None, "example-ref", runtime="auto")


### PR DESCRIPTION
## Summary
This PR introduces an in-node status streaming API that allows node implementations to emit optional intermediate status updates during execution without directly depending on streaming infrastructure. Status updates are automatically persisted to history and streamed to connected clients.

## Key Changes

- **New status emission API** (`emit_node_status`): Nodes can now call `emit_node_status()` from within their `run()` method to publish intermediate progress updates. The call is a no-op when no streaming context is active, allowing unconditional usage.

- **Context management** (`node_status_context`): Added context manager to bind a status emitter for the duration of a node's execution. Both `AINode` and `TaskNode` now wrap their `run()` invocations with this context.

- **Emitter wrapping**: Node base classes build an emitter that wraps the active tool progress callback, enveloping status payloads in `{"node": name, "event": "node_status", "payload": ...}` format for consistent streaming.

- **Workflow integration**: Updated `_stream_workflow_updates()` to bind the tool progress callback as the status emitter context, filtering and forwarding `node_status` events through the same persistence and streaming pipeline as other workflow steps.

- **ChatKit formatting**: Added `_format_node_status_update()` to render status payloads as human-readable progress text, supporting `message`, `text`, and `status` fields with sensible defaults.

- **Comprehensive test coverage**: Added 10 new tests covering context binding, emitter lifecycle, exception handling, and integration with both node types and workflow execution.

## Implementation Details

- Status updates are wrapped in an envelope structure so existing streaming consumers (ChatKit, websocket clients) can recognize and handle them consistently with other node events.
- The emitter is built lazily only when a tool progress callback is active, avoiding overhead in non-streaming scenarios.
- Exception safety is maintained: the context manager properly resets the emitter even when `run()` raises.
- Payload merging follows a clear precedence: explicit `status` key in payload takes priority over the `status` parameter.

https://claude.ai/code/session_015Pog1PLnRkrL4VdnSqNQqa