### PR TITLE
Refactor profile fallback data and make joinDate optional

### DIFF
--- a/apps/canvas/src/features/account/pages/profile.tsx
+++ b/apps/canvas/src/features/account/pages/profile.tsx
@@ -19,7 +19,7 @@ const LOCAL_DEV_PROFILE: ProfileUser = {
   email: "local@orcheo.dev",
   avatar: "https://avatar.vercel.sh/orcheo-local",
   role: "Local development",
-  joinDate: "Local development session",
+  joinDate: undefined,
   twoFactorEnabled: false,
 };
 

--- a/apps/canvas/src/features/account/pages/profile.tsx
+++ b/apps/canvas/src/features/account/pages/profile.tsx
@@ -14,12 +14,12 @@ import { ProfileGeneralTab } from "./profile/components/profile-general-tab";
 import { ProfileSecurityTab } from "./profile/components/profile-security-tab";
 import { ProfileApiKeysTab } from "./profile/components/profile-api-keys-tab";
 
-const FALLBACK_PROFILE: ProfileUser = {
-  name: "Avery Chen",
-  email: "avery@orcheo.dev",
-  avatar: "https://avatar.vercel.sh/avery",
-  role: "Admin",
-  joinDate: "January 2023",
+const LOCAL_DEV_PROFILE: ProfileUser = {
+  name: "Local Developer",
+  email: "local@orcheo.dev",
+  avatar: "https://avatar.vercel.sh/orcheo-local",
+  role: "Local development",
+  joinDate: "Local development session",
   twoFactorEnabled: false,
 };
 
@@ -31,18 +31,18 @@ export default function Profile() {
   const authUser = useMemo(() => getAuthenticatedUserProfile(), []);
   const user = useMemo<ProfileUser>(() => {
     if (!authUser) {
-      return FALLBACK_PROFILE;
+      return LOCAL_DEV_PROFILE;
     }
 
     const avatarSeed = authUser.subject ?? authUser.email ?? authUser.name;
     return {
-      ...FALLBACK_PROFILE,
       name: authUser.name,
-      email: authUser.email ?? FALLBACK_PROFILE.email,
+      email: authUser.email ?? "",
       avatar:
         authUser.avatar ??
         `https://avatar.vercel.sh/${encodeURIComponent(avatarSeed)}`,
-      role: authUser.role ?? FALLBACK_PROFILE.role,
+      role: authUser.role ?? "Member",
+      twoFactorEnabled: false,
     };
   }, [authUser]);
 

--- a/apps/canvas/src/features/account/pages/profile/components/profile-general-tab.tsx
+++ b/apps/canvas/src/features/account/pages/profile/components/profile-general-tab.tsx
@@ -39,9 +39,11 @@ export function ProfileGeneralTab({ user }: ProfileGeneralTabProps) {
               <h3 className="font-medium">{user.name}</h3>
               <div className="flex items-center space-x-2">
                 <Badge variant="outline">{user.role}</Badge>
-                <span className="text-sm text-muted-foreground">
-                  Member since {user.joinDate}
-                </span>
+                {user.joinDate ? (
+                  <span className="text-sm text-muted-foreground">
+                    Member since {user.joinDate}
+                  </span>
+                ) : null}
               </div>
               <Button size="sm" variant="outline">
                 Change Avatar

--- a/apps/canvas/src/features/account/pages/profile/types.ts
+++ b/apps/canvas/src/features/account/pages/profile/types.ts
@@ -3,6 +3,6 @@ export interface ProfileUser {
   email: string;
   avatar: string;
   role: string;
-  joinDate: string;
+  joinDate?: string;
   twoFactorEnabled: boolean;
 }


### PR DESCRIPTION
## Summary
This PR refactors the profile fallback/default data handling to better represent local development scenarios and makes the `joinDate` field optional in the ProfileUser interface.

## Key Changes
- Renamed `FALLBACK_PROFILE` constant to `LOCAL_DEV_PROFILE` with updated values to clearly indicate it's for local development use
- Made `joinDate` optional in the `ProfileUser` interface by changing it from `string` to `string | undefined`
- Updated profile initialization logic to only spread necessary fields instead of spreading the entire fallback object
- Added conditional rendering in `ProfileGeneralTab` to only display the "Member since" text when `joinDate` is provided
- Changed default values for missing auth user data:
  - `email`: now defaults to empty string instead of fallback email
  - `role`: now defaults to "Member" instead of fallback role
  - Added explicit `twoFactorEnabled: false` initialization

## Implementation Details
The refactoring improves the separation of concerns by:
1. Making it clear that the default profile is specifically for local development, not a general fallback
2. Allowing the profile to gracefully handle missing `joinDate` data without requiring a placeholder value
3. Reducing unnecessary data spreading and making the profile construction more explicit about which fields come from the authenticated user vs. defaults

https://claude.ai/code/session_01MH9Yr9PRj6sHRYQombpjCX