### PR TITLE
Add workspace-scoped API key management

### DIFF
--- a/apps/backend/src/orcheo_backend/app/authentication/service_tokens.py
+++ b/apps/backend/src/orcheo_backend/app/authentication/service_tokens.py
@@ -17,6 +17,7 @@ class ServiceTokenRecord:
 
     identifier: str
     secret_hash: str
+    secret_preview: str | None = None
     scopes: frozenset[str] = field(default_factory=frozenset)
     workspace_ids: frozenset[str] = field(default_factory=frozenset)
     issued_at: datetime | None = None
@@ -144,6 +145,7 @@ class ServiceTokenManager:
         record = ServiceTokenRecord(
             identifier=identifier or digest[:8],
             secret_hash=digest,
+            secret_preview=secret[-4:],
             scopes=frozenset(scopes),
             workspace_ids=frozenset(workspace_ids),
             issued_at=now,

--- a/apps/backend/src/orcheo_backend/app/routers/workflows.py
+++ b/apps/backend/src/orcheo_backend/app/routers/workflows.py
@@ -13,6 +13,10 @@ from orcheo.models import (
     WorkflowDraftAccess,
     WorkflowVersion,
 )
+from orcheo.runtime.configurable_schema import (
+    ConfigurableSchemaError,
+    split_configurable,
+)
 from orcheo.runtime.runnable_config import RunnableConfigModel
 from orcheo_backend.app.authentication import (
     AuthorizationError,
@@ -119,6 +123,46 @@ def _serialize_runnable_config(
         exclude_defaults=True,
         exclude_none=True,
     )
+
+
+def _merge_configurable_schema(
+    existing: Any,
+    inline: dict[str, Any],
+) -> dict[str, Any]:
+    """Merge inline schema declarations with caller-supplied schema metadata.
+
+    A sibling ``*.schema.json`` file (delivered via ``metadata``) is authored
+    explicitly, so it wins over annotations inferred from the runnable config.
+    """
+    if isinstance(existing, dict):
+        return {**inline, **existing}
+    return inline
+
+
+def _resolve_ingest_configurable_schema(
+    runnable_config: RunnableConfigModel | None,
+    metadata: dict[str, Any],
+) -> tuple[RunnableConfigModel | None, dict[str, Any]]:
+    """Lift inline ``configurable`` schema annotations into version metadata."""
+    if runnable_config is None or not runnable_config.configurable:
+        return runnable_config, metadata
+    try:
+        resolved, inline_schema = split_configurable(runnable_config.configurable)
+    except ConfigurableSchemaError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    if not inline_schema:
+        return runnable_config, metadata
+    runnable_config = runnable_config.model_copy(update={"configurable": resolved})
+    metadata = {
+        **metadata,
+        "configurable_schema": _merge_configurable_schema(
+            metadata.get("configurable_schema"), inline_schema
+        ),
+    }
+    return runnable_config, metadata
 
 
 def _serialize_public_workflow(
@@ -604,14 +648,19 @@ async def ingest_workflow_version(
             detail=str(exc),
         ) from exc
 
+    runnable_config, metadata = _resolve_ingest_configurable_schema(
+        request.runnable_config,
+        request.metadata,
+    )
+
     try:
         version = await repository.create_version(
             workflow.id,
             graph=graph_payload,
-            metadata=request.metadata,
+            metadata=metadata,
             notes=request.notes,
             created_by=request.created_by,
-            runnable_config=_serialize_runnable_config(request.runnable_config),
+            runnable_config=_serialize_runnable_config(runnable_config),
         )
         return _attach_mermaid(version)
     except WorkflowNotFoundError as exc:

--- a/apps/backend/src/orcheo_backend/app/schemas/service_tokens.py
+++ b/apps/backend/src/orcheo_backend/app/schemas/service_tokens.py
@@ -6,7 +6,11 @@ from pydantic import BaseModel, Field
 
 
 class CreateServiceTokenRequest(BaseModel):
-    """Request payload for creating a new service token."""
+    """Request payload for creating a new service token.
+
+    The token is always scoped to the workspace that mints it, so the caller
+    does not supply workspace identifiers.
+    """
 
     identifier: str | None = Field(
         default=None,
@@ -15,10 +19,6 @@ class CreateServiceTokenRequest(BaseModel):
     scopes: list[str] = Field(
         default_factory=list,
         description="Scopes/permissions granted to the token",
-    )
-    workspace_ids: list[str] = Field(
-        default_factory=list,
-        description="Workspace IDs the token can access",
     )
     expires_in_seconds: int | None = Field(
         default=None,
@@ -34,6 +34,10 @@ class ServiceTokenResponse(BaseModel):
     secret: str | None = Field(
         default=None,
         description="Raw token secret (only shown once on creation)",
+    )
+    secret_preview: str | None = Field(
+        default=None,
+        description="Last characters of the secret for display in listings",
     )
     scopes: list[str] = Field(description="Scopes granted to the token")
     workspace_ids: list[str] = Field(description="Workspaces the token can access")

--- a/apps/backend/src/orcheo_backend/app/service_token_endpoints.py
+++ b/apps/backend/src/orcheo_backend/app/service_token_endpoints.py
@@ -1,11 +1,17 @@
-"""FastAPI endpoints for service token management."""
+"""FastAPI endpoints for service token management.
+
+Service tokens are scoped to the workspace that mints them: the minting
+workspace is the only workspace the token may ever resolve to, and tokens
+belonging to other workspaces are never listed or addressable here.
+"""
 
 from __future__ import annotations
 from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, status
-from orcheo.workspace import WorkspaceAuditEvent
+from orcheo.workspace import WorkspaceAuditEvent, WorkspaceContext
 from orcheo_backend.app.authentication import (
     AuthorizationPolicy,
+    ServiceTokenManager,
     ServiceTokenRecord,
     get_authorization_policy,
     get_service_token_manager,
@@ -33,6 +39,7 @@ def _record_to_response(
     return ServiceTokenResponse(
         identifier=record.identifier,
         secret=secret,
+        secret_preview=record.secret_preview,
         scopes=sorted(record.scopes),
         workspace_ids=sorted(record.workspace_ids),
         issued_at=record.issued_at,
@@ -46,6 +53,28 @@ def _record_to_response(
     )
 
 
+async def _require_workspace_token(
+    token_id: str,
+    token_manager: ServiceTokenManager,
+    workspace: WorkspaceContext,
+) -> ServiceTokenRecord:
+    """Return ``token_id`` only when it belongs to the active workspace.
+
+    Tokens owned by other workspaces are reported as missing so callers cannot
+    probe for or act on tokens outside their own workspace.
+    """
+    record = await token_manager._repository.find_by_id(token_id)
+    if record is None or record.workspace_id != str(workspace.workspace_id):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "message": f"Service token '{token_id}' not found",
+                "code": "token.not_found",
+            },
+        )
+    return record
+
+
 @router.post(
     "", response_model=ServiceTokenResponse, status_code=status.HTTP_201_CREATED
 )
@@ -54,29 +83,30 @@ async def create_service_token(
     policy: Annotated[AuthorizationPolicy, Depends(get_authorization_policy)],
     workspace: WorkspaceContextDep,
 ) -> ServiceTokenResponse:
-    """Create a new service token.
+    """Mint a new service token scoped to the active workspace.
 
-    Requires 'admin:tokens:write' scope.
-    The secret is only shown once in the response and cannot be retrieved later.
+    Any authenticated member of the workspace may mint a token. The token can
+    only ever access the workspace that minted it; the secret is shown once in
+    the response and cannot be retrieved later.
     """
     policy.require_authenticated()
-    policy.require_scopes("admin:tokens:write")
 
     token_manager = get_service_token_manager()
+    workspace_id = str(workspace.workspace_id)
 
     secret, record = await token_manager.mint(
         identifier=request.identifier,
         scopes=request.scopes,
-        workspace_ids=request.workspace_ids,
+        workspace_ids=[workspace_id],
         expires_in=request.expires_in_seconds,
-        workspace_id=str(workspace.workspace_id),
+        workspace_id=workspace_id,
     )
     try:
         get_workspace_repository().record_audit_event(
             WorkspaceAuditEvent(
                 workspace_id=workspace.workspace_id,
                 action="service_token.created",
-                actor=policy.context.subject if policy.context else None,
+                actor=policy.context.subject,
                 subject=record.identifier,
                 resource_type="service_token",
                 resource_id=record.identifier,
@@ -96,17 +126,19 @@ async def create_service_token(
 @router.get("", response_model=ServiceTokenListResponse)
 async def list_service_tokens(
     policy: Annotated[AuthorizationPolicy, Depends(get_authorization_policy)],
+    workspace: WorkspaceContextDep,
 ) -> ServiceTokenListResponse:
-    """List all service tokens.
+    """List service tokens owned by the active workspace.
 
-    Requires 'admin:tokens:read' scope.
-    Secrets are never returned in the list.
+    Tokens belonging to other workspaces are never returned. Secrets are never
+    included in the list.
     """
     policy.require_authenticated()
-    policy.require_scopes("admin:tokens:read")
 
     token_manager = get_service_token_manager()
-    records = await token_manager.all()
+    records = await token_manager._repository.list_for_workspace(
+        str(workspace.workspace_id)
+    )
 
     tokens = [_record_to_response(record) for record in records]
     return ServiceTokenListResponse(tokens=tokens, total=len(tokens))
@@ -116,25 +148,13 @@ async def list_service_tokens(
 async def get_service_token(
     token_id: str,
     policy: Annotated[AuthorizationPolicy, Depends(get_authorization_policy)],
+    workspace: WorkspaceContextDep,
 ) -> ServiceTokenResponse:
-    """Get details for a specific service token.
-
-    Requires 'admin:tokens:read' scope.
-    """
+    """Get details for a service token owned by the active workspace."""
     policy.require_authenticated()
-    policy.require_scopes("admin:tokens:read")
 
     token_manager = get_service_token_manager()
-    record = await token_manager._repository.find_by_id(token_id)
-
-    if record is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail={
-                "message": f"Service token '{token_id}' not found",
-                "code": "token.not_found",
-            },
-        )
+    record = await _require_workspace_token(token_id, token_manager, workspace)
 
     return _record_to_response(record)
 
@@ -146,31 +166,21 @@ async def rotate_service_token(
     policy: Annotated[AuthorizationPolicy, Depends(get_authorization_policy)],
     workspace: WorkspaceContextDep,
 ) -> ServiceTokenResponse:
-    """Rotate a service token, generating a new secret.
+    """Rotate a workspace service token, generating a new secret.
 
-    Requires 'admin:tokens:write' scope.
-    The old token remains valid during the overlap period.
-    The new secret is only shown once.
+    The old token remains valid during the overlap period. The replacement
+    token stays scoped to the same workspace. The new secret is shown once.
     """
     policy.require_authenticated()
-    policy.require_scopes("admin:tokens:write")
 
     token_manager = get_service_token_manager()
+    await _require_workspace_token(token_id, token_manager, workspace)
 
-    try:
-        secret, new_record = await token_manager.rotate(
-            token_id,
-            overlap_seconds=request.overlap_seconds,
-            expires_in=request.expires_in_seconds,
-        )
-    except KeyError:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail={
-                "message": f"Service token '{token_id}' not found",
-                "code": "token.not_found",
-            },
-        ) from None
+    secret, new_record = await token_manager.rotate(
+        token_id,
+        overlap_seconds=request.overlap_seconds,
+        expires_in=request.expires_in_seconds,
+    )
 
     message = (
         f"New token created. Old token '{token_id}' "
@@ -181,7 +191,7 @@ async def rotate_service_token(
             WorkspaceAuditEvent(
                 workspace_id=workspace.workspace_id,
                 action="service_token.rotated",
-                actor=policy.context.subject if policy.context else None,
+                actor=policy.context.subject,
                 subject=token_id,
                 resource_type="service_token",
                 resource_id=token_id,
@@ -200,32 +210,22 @@ async def revoke_service_token(
     policy: Annotated[AuthorizationPolicy, Depends(get_authorization_policy)],
     workspace: WorkspaceContextDep,
 ) -> None:
-    """Revoke a service token immediately.
+    """Revoke a workspace service token immediately.
 
-    Requires 'admin:tokens:write' scope.
     The token will no longer be usable for authentication.
     """
     policy.require_authenticated()
-    policy.require_scopes("admin:tokens:write")
 
     token_manager = get_service_token_manager()
+    await _require_workspace_token(token_id, token_manager, workspace)
 
-    try:
-        await token_manager.revoke(token_id, reason=request.reason)
-    except KeyError:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail={
-                "message": f"Service token '{token_id}' not found",
-                "code": "token.not_found",
-            },
-        ) from None
+    await token_manager.revoke(token_id, reason=request.reason)
     try:
         get_workspace_repository().record_audit_event(
             WorkspaceAuditEvent(
                 workspace_id=workspace.workspace_id,
                 action="service_token.revoked",
-                actor=policy.context.subject if policy.context else None,
+                actor=policy.context.subject,
                 subject=token_id,
                 resource_type="service_token",
                 resource_id=token_id,

--- a/apps/backend/src/orcheo_backend/app/service_token_endpoints.py
+++ b/apps/backend/src/orcheo_backend/app/service_token_endpoints.py
@@ -90,6 +90,7 @@ async def create_service_token(
     the response and cannot be retrieved later.
     """
     policy.require_authenticated()
+    policy.require_scopes(*request.scopes)
 
     token_manager = get_service_token_manager()
     workspace_id = str(workspace.workspace_id)

--- a/apps/backend/src/orcheo_backend/app/service_token_repository/postgres_repository.py
+++ b/apps/backend/src/orcheo_backend/app/service_token_repository/postgres_repository.py
@@ -32,6 +32,7 @@ POSTGRES_SERVICE_TOKEN_SCHEMA = """
 CREATE TABLE IF NOT EXISTS service_tokens (
     identifier TEXT PRIMARY KEY,
     secret_hash TEXT NOT NULL,
+    secret_preview TEXT,
     scopes JSONB,
     workspace_ids JSONB,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL,
@@ -50,6 +51,8 @@ CREATE TABLE IF NOT EXISTS service_tokens (
     rate_limit_override INTEGER,
     workspace_id TEXT
 );
+
+ALTER TABLE service_tokens ADD COLUMN IF NOT EXISTS secret_preview TEXT;
 
 CREATE INDEX IF NOT EXISTS idx_service_tokens_hash
     ON service_tokens(secret_hash);
@@ -107,6 +110,7 @@ def _row_to_record(row: dict[str, Any]) -> ServiceTokenRecord:
     return ServiceTokenRecord(
         identifier=row["identifier"],
         secret_hash=row["secret_hash"],
+        secret_preview=row.get("secret_preview"),
         scopes=parse_set(row.get("scopes")),
         workspace_ids=parse_set(row.get("workspace_ids")),
         issued_at=parse_ts(row.get("issued_at")),
@@ -277,15 +281,18 @@ class PostgresServiceTokenRepository(ServiceTokenRepository):
             await conn.execute(
                 """
                 INSERT INTO service_tokens (
-                    identifier, secret_hash, scopes, workspace_ids,
-                    created_at, created_by, issued_at, expires_at,
-                    rotation_expires_at, rotated_to, revoked_at,
+                    identifier, secret_hash, secret_preview, scopes,
+                    workspace_ids, created_at, created_by, issued_at,
+                    expires_at, rotation_expires_at, rotated_to, revoked_at,
                     revoked_by, revocation_reason, workspace_id
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                ) VALUES (
+                    %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
+                )
                 """,
                 (
                     record.identifier,
                     record.secret_hash,
+                    record.secret_preview,
                     serialize_string_set(record.scopes),
                     serialize_string_set(record.workspace_ids),
                     datetime.now(tz=UTC),

--- a/apps/canvas/src/App.tsx
+++ b/apps/canvas/src/App.tsx
@@ -19,6 +19,7 @@ import OAuthCallback from "@features/auth/pages/oauth-callback";
 import Profile from "@features/account/pages/profile";
 import Settings from "@features/account/pages/settings";
 import WorkspaceMembers from "@features/account/pages/workspace-members";
+import ServiceTokens from "@features/account/pages/service-tokens";
 import PublicChatPage from "@features/chatkit/pages/public-chat";
 import {
   getSelectedWorkspaceSlug,
@@ -59,6 +60,15 @@ function WorkspaceMembersRoute() {
   return <WorkspaceMembers />;
 }
 
+function ServiceTokensRoute() {
+  const { workspaceSlug } = useParams<{ workspaceSlug?: string }>();
+  useLayoutEffect(() => {
+    syncWorkspaceSlug(workspaceSlug);
+  }, [workspaceSlug]);
+
+  return <ServiceTokens />;
+}
+
 function WorkspaceCanvasRoute() {
   const { workspaceSlug, workflowId } = useParams<{
     workspaceSlug?: string;
@@ -68,7 +78,11 @@ function WorkspaceCanvasRoute() {
     syncWorkspaceSlug(workspaceSlug);
   }, [workspaceSlug]);
 
-  return <WorkflowCanvas workflowId={workflowId === "new" ? undefined : workflowId} />;
+  return (
+    <WorkflowCanvas
+      workflowId={workflowId === "new" ? undefined : workflowId}
+    />
+  );
 }
 
 export default function OrcheoCanvasApp() {
@@ -85,14 +99,25 @@ export default function OrcheoCanvasApp() {
             <Route element={<RequireAuth />}>
               <Route element={<VibeAuthenticatedLayout />}>
                 <Route path="/" element={<WorkspaceHomeRedirect />} />
-                <Route path="/:workspaceSlug" element={<WorkspaceGalleryRoute />} />
+                <Route
+                  path="/:workspaceSlug"
+                  element={<WorkspaceGalleryRoute />}
+                />
 
                 <Route
                   path="/:workspaceSlug/workspace"
                   element={<WorkspaceMembersRoute />}
                 />
 
-                <Route path="/:workspaceSlug/new" element={<WorkspaceCanvasRoute />} />
+                <Route
+                  path="/:workspaceSlug/tokens"
+                  element={<ServiceTokensRoute />}
+                />
+
+                <Route
+                  path="/:workspaceSlug/new"
+                  element={<WorkspaceCanvasRoute />}
+                />
                 <Route
                   path="/:workspaceSlug/:workflowId"
                   element={<WorkspaceCanvasRoute />}

--- a/apps/canvas/src/features/account/pages/service-tokens.test.tsx
+++ b/apps/canvas/src/features/account/pages/service-tokens.test.tsx
@@ -1,0 +1,239 @@
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import ServiceTokens from "./service-tokens";
+
+const {
+  getActiveWorkspaceMock,
+  listServiceTokensMock,
+  createServiceTokenMock,
+  rotateServiceTokenMock,
+  revokeServiceTokenMock,
+  toastMock,
+} = vi.hoisted(() => ({
+  getActiveWorkspaceMock: vi.fn(),
+  listServiceTokensMock: vi.fn(),
+  createServiceTokenMock: vi.fn(),
+  rotateServiceTokenMock: vi.fn(),
+  revokeServiceTokenMock: vi.fn(),
+  toastMock: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  getActiveWorkspace: getActiveWorkspaceMock,
+  listServiceTokens: listServiceTokensMock,
+  createServiceToken: createServiceTokenMock,
+  rotateServiceToken: rotateServiceTokenMock,
+  revokeServiceToken: revokeServiceTokenMock,
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  toast: toastMock,
+}));
+
+vi.mock("@/hooks/use-credential-vault", () => ({
+  default: () => ({
+    credentials: [],
+    isLoading: false,
+    onAddCredential: vi.fn(),
+    onUpdateCredential: vi.fn(),
+    onDeleteCredential: vi.fn(),
+    onRevealCredentialSecret: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/use-page-context", () => ({
+  usePageContext: () => ({
+    setPageContext: vi.fn(),
+    setVaultOpen: vi.fn(),
+    pageContext: { page: "workspace" },
+  }),
+}));
+
+vi.mock("@features/shared/components/top-navigation", () => ({
+  default: () => <header data-testid="top-nav" />,
+}));
+
+interface TokenOverrides {
+  identifier?: string;
+  secret?: string | null;
+  secret_preview?: string | null;
+  scopes?: string[];
+  workspace_ids?: string[];
+  issued_at?: string | null;
+  expires_at?: string | null;
+  last_used_at?: string | null;
+  revoked_at?: string | null;
+  rotated_to?: string | null;
+}
+
+const tokenFixture = (overrides: TokenOverrides = {}) => ({
+  identifier: "tok-1",
+  secret: null,
+  secret_preview: "wxyz",
+  scopes: ["workflows:read"],
+  workspace_ids: ["workspace-1"],
+  issued_at: "2026-05-17T12:00:00Z",
+  expires_at: null,
+  last_used_at: null,
+  use_count: 0,
+  revoked_at: null,
+  revocation_reason: null,
+  rotated_to: null,
+  message: null,
+  ...overrides,
+});
+
+const renderPage = () =>
+  render(
+    <MemoryRouter>
+      <ServiceTokens />
+    </MemoryRouter>,
+  );
+
+describe("ServiceTokens", () => {
+  beforeEach(() => {
+    getActiveWorkspaceMock.mockReset();
+    listServiceTokensMock.mockReset();
+    createServiceTokenMock.mockReset();
+    rotateServiceTokenMock.mockReset();
+    revokeServiceTokenMock.mockReset();
+    toastMock.mockReset();
+
+    getActiveWorkspaceMock.mockResolvedValue({
+      workspace_id: "workspace-1",
+      slug: "acme",
+      name: "Acme",
+      role: "editor",
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("lists the workspace's tokens and shows the scoping notice", async () => {
+    listServiceTokensMock.mockResolvedValue({
+      tokens: [tokenFixture()],
+      total: 1,
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("tok-1")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/cannot access any other workspace/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Acme")).toBeInTheDocument();
+    expect(screen.getByText("••••••••wxyz")).toBeInTheDocument();
+  });
+
+  it("creates a key from the dialog and reveals the secret once", async () => {
+    listServiceTokensMock.mockResolvedValue({ tokens: [], total: 0 });
+    createServiceTokenMock.mockResolvedValue(
+      tokenFixture({ identifier: "tok-new", secret: "super-secret-value" }),
+    );
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/No API keys for this workspace yet/i),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: /Create a new key/i }),
+    );
+    const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByLabelText("workflows:read"));
+    await user.click(
+      within(dialog).getByRole("button", { name: /Create a new key/i }),
+    );
+
+    await waitFor(() => {
+      expect(createServiceTokenMock).toHaveBeenCalledWith(
+        expect.objectContaining({ scopes: ["workflows:read"] }),
+      );
+    });
+    expect(await screen.findByText("super-secret-value")).toBeInTheDocument();
+    expect(screen.getByText("API key created")).toBeInTheDocument();
+  });
+
+  it("revokes a token after confirming in the dialog", async () => {
+    listServiceTokensMock.mockResolvedValue({
+      tokens: [tokenFixture()],
+      total: 1,
+    });
+    revokeServiceTokenMock.mockResolvedValue(undefined);
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("tok-1")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /Revoke/i }));
+    const dialog = await screen.findByRole("alertdialog");
+    await user.click(within(dialog).getByRole("button", { name: "Revoke" }));
+
+    await waitFor(() => {
+      expect(revokeServiceTokenMock).toHaveBeenCalledWith(
+        "tok-1",
+        "Revoked via Canvas",
+      );
+    });
+    await waitFor(() => {
+      expect(screen.queryByText("tok-1")).not.toBeInTheDocument();
+    });
+  });
+
+  it("keeps the token when the revoke dialog is cancelled", async () => {
+    listServiceTokensMock.mockResolvedValue({
+      tokens: [tokenFixture()],
+      total: 1,
+    });
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("tok-1")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /Revoke/i }));
+    const dialog = await screen.findByRole("alertdialog");
+    await user.click(within(dialog).getByRole("button", { name: /Cancel/i }));
+
+    expect(revokeServiceTokenMock).not.toHaveBeenCalled();
+    expect(screen.getByText("tok-1")).toBeInTheDocument();
+  });
+
+  it("shows an error toast when loading fails", async () => {
+    listServiceTokensMock.mockRejectedValue(new Error("network"));
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Failed to load API keys",
+          variant: "destructive",
+        }),
+      );
+    });
+  });
+});

--- a/apps/canvas/src/features/account/pages/service-tokens.tsx
+++ b/apps/canvas/src/features/account/pages/service-tokens.tsx
@@ -1,0 +1,553 @@
+import { useEffect, useState } from "react";
+import { Copy, KeyRound, RotateCw, Trash2 } from "lucide-react";
+import { Button } from "@/design-system/ui/button";
+import { Input } from "@/design-system/ui/input";
+import { Label } from "@/design-system/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/design-system/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/design-system/ui/table";
+import { Badge } from "@/design-system/ui/badge";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/design-system/ui/alert-dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/design-system/ui/dialog";
+import useCredentialVault from "@/hooks/use-credential-vault";
+import { usePageContext } from "@/hooks/use-page-context";
+import { toast } from "@/hooks/use-toast";
+import TopNavigation from "@features/shared/components/top-navigation";
+import {
+  createServiceToken,
+  getActiveWorkspace,
+  listServiceTokens,
+  revokeServiceToken,
+  rotateServiceToken,
+  type ServiceToken,
+} from "@/lib/api";
+
+const AVAILABLE_SCOPES = [
+  "workflows:read",
+  "workflows:write",
+  "workflows:execute",
+  "vault:read",
+  "vault:write",
+] as const;
+
+const EXPIRY_OPTIONS = [
+  { value: "never", label: "Never", seconds: null },
+  { value: "1h", label: "1 hour", seconds: 3600 },
+  { value: "1d", label: "1 day", seconds: 86400 },
+  { value: "7d", label: "7 days", seconds: 604800 },
+  { value: "30d", label: "30 days", seconds: 2592000 },
+] as const;
+
+const ROTATION_OVERLAP_SECONDS = 300;
+
+const formatDate = (value: string | null | undefined): string =>
+  value ? new Date(value).toLocaleString() : "—";
+
+const tokenStatus = (token: ServiceToken): "Revoked" | "Rotated" | "Active" => {
+  if (token.revoked_at) {
+    return "Revoked";
+  }
+  if (token.rotated_to) {
+    return "Rotated";
+  }
+  return "Active";
+};
+
+interface RevealedSecret {
+  title: string;
+  identifier: string;
+  secret: string;
+}
+
+export default function ServiceTokens() {
+  const { setPageContext } = usePageContext();
+  useEffect(() => {
+    setPageContext({ page: "workspace" });
+  }, [setPageContext]);
+
+  const {
+    credentials,
+    isLoading: isCredentialsLoading,
+    onAddCredential,
+    onUpdateCredential,
+    onDeleteCredential,
+    onRevealCredentialSecret,
+  } = useCredentialVault();
+
+  const [tokens, setTokens] = useState<ServiceToken[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [workspaceName, setWorkspaceName] = useState<string | null>(null);
+
+  const [createOpen, setCreateOpen] = useState(false);
+  const [identifier, setIdentifier] = useState("");
+  const [selectedScopes, setSelectedScopes] = useState<Set<string>>(new Set());
+  const [expiry, setExpiry] = useState<string>("never");
+  const [isMinting, setIsMinting] = useState(false);
+
+  const [revealed, setRevealed] = useState<RevealedSecret | null>(null);
+  const [rotatingId, setRotatingId] = useState<string | null>(null);
+  const [revokingId, setRevokingId] = useState<string | null>(null);
+  const [revokeTarget, setRevokeTarget] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+
+    const loadData = async () => {
+      try {
+        const [workspace, tokenList] = await Promise.all([
+          getActiveWorkspace(),
+          listServiceTokens(),
+        ]);
+        if (!active) {
+          return;
+        }
+        setWorkspaceName(workspace.name);
+        setTokens(tokenList.tokens);
+      } catch (err) {
+        if (active) {
+          toast({
+            title: "Failed to load API keys",
+            description: err instanceof Error ? err.message : undefined,
+            variant: "destructive",
+          });
+        }
+      } finally {
+        if (active) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void loadData();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const resetCreateForm = () => {
+    setIdentifier("");
+    setSelectedScopes(new Set());
+    setExpiry("never");
+  };
+
+  const toggleScope = (scope: string) => {
+    setSelectedScopes((prev) => {
+      const next = new Set(prev);
+      if (next.has(scope)) {
+        next.delete(scope);
+      } else {
+        next.add(scope);
+      }
+      return next;
+    });
+  };
+
+  const handleMint = async () => {
+    setIsMinting(true);
+    try {
+      const expiryOption = EXPIRY_OPTIONS.find(
+        (option) => option.value === expiry,
+      );
+      const token = await createServiceToken({
+        identifier: identifier.trim() || undefined,
+        scopes: [...selectedScopes],
+        expires_in_seconds: expiryOption?.seconds ?? undefined,
+      });
+      setTokens((prev) => [token, ...prev]);
+      setRevealed({
+        title: "API key created",
+        identifier: token.identifier,
+        secret: token.secret ?? "",
+      });
+      resetCreateForm();
+      setCreateOpen(false);
+      toast({ title: "API key created" });
+    } catch (err) {
+      toast({
+        title: "Failed to create API key",
+        description: err instanceof Error ? err.message : undefined,
+        variant: "destructive",
+      });
+    } finally {
+      setIsMinting(false);
+    }
+  };
+
+  const handleRotate = async (tokenId: string) => {
+    setRotatingId(tokenId);
+    try {
+      const rotated = await rotateServiceToken(
+        tokenId,
+        ROTATION_OVERLAP_SECONDS,
+      );
+      const tokenList = await listServiceTokens();
+      setTokens(tokenList.tokens);
+      setRevealed({
+        title: "API key rotated",
+        identifier: rotated.identifier,
+        secret: rotated.secret ?? "",
+      });
+      toast({ title: "API key rotated" });
+    } catch (err) {
+      toast({
+        title: "Failed to rotate API key",
+        description: err instanceof Error ? err.message : undefined,
+        variant: "destructive",
+      });
+    } finally {
+      setRotatingId(null);
+    }
+  };
+
+  const handleRevoke = async () => {
+    const tokenId = revokeTarget;
+    if (!tokenId) {
+      return;
+    }
+    setRevokeTarget(null);
+    setRevokingId(tokenId);
+    try {
+      await revokeServiceToken(tokenId, "Revoked via Canvas");
+      setTokens((prev) => prev.filter((token) => token.identifier !== tokenId));
+      toast({ title: "API key revoked" });
+    } catch (err) {
+      toast({
+        title: "Failed to revoke API key",
+        description: err instanceof Error ? err.message : undefined,
+        variant: "destructive",
+      });
+    } finally {
+      setRevokingId(null);
+    }
+  };
+
+  const handleCopySecret = async (secret: string) => {
+    try {
+      await navigator.clipboard.writeText(secret);
+      toast({ title: "Secret copied to clipboard" });
+    } catch {
+      toast({
+        title: "Could not copy secret",
+        description: "Copy it manually from the field above.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden">
+      <TopNavigation
+        credentials={credentials}
+        isCredentialsLoading={isCredentialsLoading}
+        onAddCredential={onAddCredential}
+        onUpdateCredential={onUpdateCredential}
+        onDeleteCredential={onDeleteCredential}
+        onRevealCredentialSecret={onRevealCredentialSecret}
+      />
+
+      <main className="flex-1 min-h-0 overflow-auto">
+        <div className="mx-auto flex w-full max-w-7xl flex-col space-y-6 p-8 pt-6">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h2 className="text-3xl font-bold tracking-tight">API Keys</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                API keys created here are scoped to{" "}
+                <span className="font-medium text-foreground">
+                  {workspaceName ?? "this workspace"}
+                </span>{" "}
+                and cannot access any other workspace.
+              </p>
+            </div>
+            <Button onClick={() => setCreateOpen(true)}>
+              <KeyRound className="mr-2 h-4 w-4" />
+              Create a new key
+            </Button>
+          </div>
+
+          {isLoading ? (
+            <p className="text-sm text-muted-foreground">Loading API keys...</p>
+          ) : tokens.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No API keys for this workspace yet.
+            </p>
+          ) : (
+            <div className="rounded-lg border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Identifier</TableHead>
+                    <TableHead>Key</TableHead>
+                    <TableHead>Scopes</TableHead>
+                    <TableHead>Issued</TableHead>
+                    <TableHead>Expires</TableHead>
+                    <TableHead>Last used</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead className="text-right">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {tokens.map((token) => {
+                    const status = tokenStatus(token);
+                    const isActive = status === "Active";
+                    return (
+                      <TableRow key={token.identifier}>
+                        <TableCell className="font-mono text-sm">
+                          {token.identifier}
+                        </TableCell>
+                        <TableCell className="font-mono text-sm text-muted-foreground">
+                          {token.secret_preview
+                            ? `••••••••${token.secret_preview}`
+                            : "—"}
+                        </TableCell>
+                        <TableCell className="text-sm">
+                          {token.scopes.length > 0 ? (
+                            <div className="flex flex-wrap gap-1">
+                              {token.scopes.map((scope) => (
+                                <Badge key={scope} variant="secondary">
+                                  {scope}
+                                </Badge>
+                              ))}
+                            </div>
+                          ) : (
+                            <span className="text-muted-foreground">—</span>
+                          )}
+                        </TableCell>
+                        <TableCell className="text-sm text-muted-foreground">
+                          {formatDate(token.issued_at)}
+                        </TableCell>
+                        <TableCell className="text-sm text-muted-foreground">
+                          {token.expires_at
+                            ? formatDate(token.expires_at)
+                            : "Never"}
+                        </TableCell>
+                        <TableCell className="text-sm text-muted-foreground">
+                          {formatDate(token.last_used_at)}
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant={isActive ? "default" : "outline"}>
+                            {status}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="text-right">
+                          <div className="flex justify-end gap-1">
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() =>
+                                void handleRotate(token.identifier)
+                              }
+                              disabled={
+                                !isActive ||
+                                rotatingId === token.identifier ||
+                                revokingId === token.identifier
+                              }
+                            >
+                              <RotateCw className="mr-2 h-4 w-4" />
+                              {rotatingId === token.identifier
+                                ? "Rotating..."
+                                : "Rotate"}
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="text-destructive hover:text-destructive"
+                              onClick={() => setRevokeTarget(token.identifier)}
+                              disabled={
+                                !isActive ||
+                                rotatingId === token.identifier ||
+                                revokingId === token.identifier
+                              }
+                            >
+                              <Trash2 className="mr-2 h-4 w-4" />
+                              {revokingId === token.identifier
+                                ? "Revoking..."
+                                : "Revoke"}
+                            </Button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </div>
+      </main>
+
+      <Dialog
+        open={createOpen}
+        onOpenChange={(open) => {
+          if (!isMinting) {
+            setCreateOpen(open);
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create API key</DialogTitle>
+            <DialogDescription>
+              The key is scoped to this workspace. Its secret is shown once
+              after creation.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="token-identifier">Identifier (optional)</Label>
+              <Input
+                id="token-identifier"
+                placeholder="Auto-generated if left blank"
+                value={identifier}
+                onChange={(event) => setIdentifier(event.target.value)}
+                disabled={isMinting}
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label>Scopes</Label>
+              <div className="flex flex-wrap gap-x-4 gap-y-2">
+                {AVAILABLE_SCOPES.map((scope) => (
+                  <label
+                    key={scope}
+                    className="flex items-center gap-2 text-sm"
+                  >
+                    <input
+                      type="checkbox"
+                      className="h-4 w-4 rounded border-border"
+                      checked={selectedScopes.has(scope)}
+                      onChange={() => toggleScope(scope)}
+                      disabled={isMinting}
+                    />
+                    <span className="font-mono">{scope}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            <div className="w-44 space-y-1.5">
+              <Label htmlFor="token-expiry">Expires</Label>
+              <Select
+                value={expiry}
+                onValueChange={setExpiry}
+                disabled={isMinting}
+              >
+                <SelectTrigger id="token-expiry">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {EXPIRY_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button onClick={() => void handleMint()} disabled={isMinting}>
+              {isMinting ? "Creating..." : "Create a new key"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {revealed && (
+        <Dialog
+          open
+          onOpenChange={(open) => {
+            if (!open) {
+              setRevealed(null);
+            }
+          }}
+        >
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>{revealed.title}</DialogTitle>
+              <DialogDescription>
+                Copy this secret now — it will not be shown again.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-2">
+              <p className="text-sm">
+                <span className="text-muted-foreground">ID: </span>
+                <span className="font-mono">{revealed.identifier}</span>
+              </p>
+              <p className="break-all rounded border bg-muted p-3 font-mono text-sm">
+                {revealed.secret}
+              </p>
+            </div>
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => void handleCopySecret(revealed.secret)}
+              >
+                <Copy className="mr-2 h-4 w-4" />
+                Copy secret
+              </Button>
+              <Button onClick={() => setRevealed(null)}>Done</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      )}
+
+      <AlertDialog
+        open={revokeTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setRevokeTarget(null);
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Revoke API key</AlertDialogTitle>
+            <AlertDialogDescription>
+              Revoking <span className="font-mono">{revokeTarget}</span>{" "}
+              immediately disables it. Any client using this key will lose
+              access. This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={() => void handleRevoke()}
+            >
+              Revoke
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/apps/canvas/src/features/shared/components/top-navigation/account-menu.tsx
+++ b/apps/canvas/src/features/shared/components/top-navigation/account-menu.tsx
@@ -16,7 +16,7 @@ import {
   DialogDescription,
   DialogTitle,
 } from "@/design-system/ui/dialog";
-import { Key, LogOut, Settings, User, Users } from "lucide-react";
+import { Key, KeyRound, LogOut, Settings, User, Users } from "lucide-react";
 import {
   clearAuthSession,
   getAuthenticatedUserProfile,
@@ -123,24 +123,31 @@ export default function AccountMenu({
               </Link>
             </DropdownMenuItem>
           )}
-          <DropdownMenuItem
-            asChild
-          >
+          {workspaceSlug && (
+            <DropdownMenuItem asChild>
+              <Link
+                to={`/${workspaceSlug}/tokens`}
+                className="flex w-full items-center gap-0"
+              >
+                <KeyRound className="mr-2 h-4 w-4" />
+                <span>API Keys</span>
+              </Link>
+            </DropdownMenuItem>
+          )}
+          <DropdownMenuItem asChild>
             <button
               type="button"
               className="flex w-full items-center gap-0"
               onClick={() => {
-              handleVaultOpenChange(true);
+                handleVaultOpenChange(true);
               }}
             >
               <Key className="mr-2 h-4 w-4" />
-            <span>Credential Vault</span>
+              <span>Credential Vault</span>
             </button>
           </DropdownMenuItem>
           <DropdownMenuSeparator />
-          <DropdownMenuItem
-            asChild
-          >
+          <DropdownMenuItem asChild>
             <button
               type="button"
               className="flex w-full items-center gap-0"
@@ -150,7 +157,7 @@ export default function AccountMenu({
               }}
             >
               <LogOut className="mr-2 h-4 w-4" />
-            <span>Log out</span>
+              <span>Log out</span>
             </button>
           </DropdownMenuItem>
         </DropdownMenuContent>

--- a/apps/canvas/src/lib/api.ts
+++ b/apps/canvas/src/lib/api.ts
@@ -286,13 +286,17 @@ async function requestSystemJson<T>(
   options: { includeWorkspaceHeaders?: boolean } = {},
 ): Promise<T> {
   const url = buildBackendHttpUrl(path, baseUrl);
-  const response = await authFetch(url, {
-    ...init,
-    headers: {
-      "Content-Type": "application/json",
-      ...(init.headers ?? {}),
+  const response = await authFetch(
+    url,
+    {
+      ...init,
+      headers: {
+        "Content-Type": "application/json",
+        ...(init.headers ?? {}),
+      },
     },
-  }, options);
+    options,
+  );
 
   if (!response.ok) {
     const errorData = await response.json().catch(() => ({
@@ -434,4 +438,134 @@ export async function removeWorkspaceMember(
     }));
     throw new Error(errorData.detail || `HTTP ${response.status}`);
   }
+}
+
+export interface ServiceToken {
+  identifier: string;
+  secret?: string | null;
+  secret_preview?: string | null;
+  scopes: string[];
+  workspace_ids: string[];
+  issued_at: string | null;
+  expires_at: string | null;
+  last_used_at?: string | null;
+  use_count?: number | null;
+  revoked_at?: string | null;
+  revocation_reason?: string | null;
+  rotated_to?: string | null;
+  message?: string | null;
+}
+
+export interface ServiceTokenListResponse {
+  tokens: ServiceToken[];
+  total: number;
+}
+
+export interface CreateServiceTokenRequest {
+  identifier?: string;
+  scopes?: string[];
+  expires_in_seconds?: number | null;
+}
+
+const extractErrorMessage = (data: unknown, fallback: string): string => {
+  if (!data || typeof data !== "object" || !("detail" in data)) {
+    return fallback;
+  }
+  const detail = (data as { detail: unknown }).detail;
+  if (typeof detail === "string") {
+    return detail;
+  }
+  if (detail && typeof detail === "object") {
+    const record = detail as Record<string, unknown>;
+    if (typeof record.message === "string") {
+      return record.message;
+    }
+    const nested = record.error;
+    if (
+      nested &&
+      typeof nested === "object" &&
+      typeof (nested as Record<string, unknown>).message === "string"
+    ) {
+      return (nested as Record<string, string>).message;
+    }
+  }
+  return fallback;
+};
+
+async function serviceTokenRequest<T>(
+  path: string,
+  init: RequestInit,
+  fallbackError: string,
+  baseUrl?: string,
+): Promise<T> {
+  const url = buildBackendHttpUrl(path, baseUrl);
+  const response = await authFetch(url, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init.headers ?? {}),
+    },
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => null);
+    throw new Error(extractErrorMessage(errorData, fallbackError));
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+  return response.json();
+}
+
+export async function listServiceTokens(
+  baseUrl?: string,
+): Promise<ServiceTokenListResponse> {
+  return serviceTokenRequest<ServiceTokenListResponse>(
+    "/api/admin/service-tokens",
+    { method: "GET" },
+    "Failed to load service tokens",
+    baseUrl,
+  );
+}
+
+export async function createServiceToken(
+  request: CreateServiceTokenRequest,
+  baseUrl?: string,
+): Promise<ServiceToken> {
+  return serviceTokenRequest<ServiceToken>(
+    "/api/admin/service-tokens",
+    { method: "POST", body: JSON.stringify(request) },
+    "Failed to create service token",
+    baseUrl,
+  );
+}
+
+export async function rotateServiceToken(
+  tokenId: string,
+  overlapSeconds: number,
+  baseUrl?: string,
+): Promise<ServiceToken> {
+  return serviceTokenRequest<ServiceToken>(
+    `/api/admin/service-tokens/${encodeURIComponent(tokenId)}/rotate`,
+    {
+      method: "POST",
+      body: JSON.stringify({ overlap_seconds: overlapSeconds }),
+    },
+    "Failed to rotate service token",
+    baseUrl,
+  );
+}
+
+export async function revokeServiceToken(
+  tokenId: string,
+  reason: string,
+  baseUrl?: string,
+): Promise<void> {
+  await serviceTokenRequest<void>(
+    `/api/admin/service-tokens/${encodeURIComponent(tokenId)}`,
+    { method: "DELETE", body: JSON.stringify({ reason }) },
+    "Failed to revoke service token",
+    baseUrl,
+  );
 }

--- a/packages/sdk/src/orcheo_sdk/cli/workflow/frontmatter.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflow/frontmatter.py
@@ -47,40 +47,6 @@ _ALLOWED_FIELDS = frozenset(
     }
 )
 _ENCODING_RE = re.compile(r"coding[=:]\s*([-\w.]+)")
-_SCHEMA_KEYS = frozenset(
-    {
-        "type",
-        "enum",
-        "items",
-        "properties",
-        "oneOf",
-        "anyOf",
-        "allOf",
-        "const",
-        "default",
-        "format",
-        "minimum",
-        "maximum",
-        "exclusiveMinimum",
-        "exclusiveMaximum",
-        "multipleOf",
-        "pattern",
-        "additionalProperties",
-    }
-)
-_SCHEMA_DISCRIMINATOR_KEYS = frozenset(
-    {
-        "enum",
-        "items",
-        "properties",
-        "oneOf",
-        "anyOf",
-        "allOf",
-        "const",
-        "default",
-        "additionalProperties",
-    }
-)
 
 
 def _encoding_from_cookie(line: bytes) -> str | None:
@@ -311,9 +277,13 @@ def resolve_frontmatter_config_bundle(
     workflow_path: Path,
     config_path: str,
 ) -> tuple[dict[str, Any], dict[str, Any] | None]:
-    """Load runnable config and typed schema declarations from frontmatter.
+    """Load runnable config and optional sibling schema declarations.
 
-    Relative paths resolve against the workflow file's parent directory.
+    Relative paths resolve against the workflow file's parent directory. The
+    config is forwarded verbatim: inline JSON Schema annotations embedded in
+    ``configurable`` values are resolved server-side during ingestion. Only a
+    companion ``*.schema.json`` file is loaded here, since it cannot be seen
+    once the workflow leaves the local filesystem.
     """
     candidate = Path(config_path).expanduser()
     if not candidate.is_absolute():
@@ -338,10 +308,7 @@ def resolve_frontmatter_config_bundle(
             f"Frontmatter config file '{config_path}' must contain a JSON object."
         )
 
-    sibling_schema = _load_sibling_schema_file(resolved)
-    raw_config, inline_schema = _split_annotated_config(data, config_path=config_path)
-    schema_definitions = _merge_schema_definitions(inline_schema, sibling_schema)
-    return raw_config, schema_definitions or None
+    return data, _load_sibling_schema_file(resolved)
 
 
 def _load_sibling_schema_file(resolved_config: Path) -> dict[str, Any] | None:
@@ -367,40 +334,6 @@ def _load_sibling_schema_file(resolved_config: Path) -> dict[str, Any] | None:
     return _normalize_schema_definition_map(schema_payload, schema_path.name)
 
 
-def _split_annotated_config(
-    config: dict[str, Any],
-    *,
-    config_path: str,
-) -> tuple[dict[str, Any], dict[str, Any] | None]:
-    """Split annotated runnable config values from their schema definitions."""
-    configurable = config.get("configurable")
-    if not isinstance(configurable, dict):
-        return config, None
-
-    raw_config = dict(config)
-    raw_configurable = dict(configurable)
-    schema_definitions: dict[str, Any] = {}
-
-    for key, value in configurable.items():
-        if not _is_schema_declaration(value):
-            continue
-        if not isinstance(value, Mapping):
-            continue
-        schema = _normalize_schema_definition(value, key=key, config_path=config_path)
-        raw_configurable[key] = _resolve_schema_default(
-            schema,
-            key=key,
-            config_path=config_path,
-        )
-        schema_definitions[key] = schema
-
-    if schema_definitions:
-        raw_config["configurable"] = raw_configurable
-        return raw_config, schema_definitions
-
-    return config, None
-
-
 def _normalize_schema_definition_map(
     payload: dict[str, Any],
     config_path: str,
@@ -421,75 +354,6 @@ def _normalize_schema_definition_map(
             )
         normalized[key] = dict(value)
     return normalized
-
-
-def _merge_schema_definitions(
-    *schema_maps: dict[str, Any] | None,
-) -> dict[str, Any] | None:
-    """Merge schema definition maps with later entries taking precedence."""
-    merged: dict[str, Any] = {}
-    for schema_map in schema_maps:
-        if not schema_map:
-            continue
-        for key, value in schema_map.items():
-            merged[key] = value
-    return merged or None
-
-
-def _is_schema_declaration(value: object) -> bool:
-    """Return True when ``value`` is an explicit typed schema annotation."""
-    if not isinstance(value, Mapping):
-        return False
-    if not any(key in value for key in _SCHEMA_KEYS):
-        return False
-    return any(key in value for key in _SCHEMA_DISCRIMINATOR_KEYS)
-
-
-def _normalize_schema_definition(
-    value: Mapping[str, Any],
-    *,
-    key: str,
-    config_path: str,
-) -> dict[str, Any]:
-    """Copy a schema declaration into a JSON-serializable mapping."""
-    schema = dict(value)
-    if not _schema_has_runtime_default(schema):
-        raise CLIError(
-            f"Frontmatter config field '{key}' in '{config_path}' declares schema "
-            "metadata but no runtime default. Add a 'default' value or an 'enum'."
-        )
-    return schema
-
-
-def _schema_has_runtime_default(schema: Mapping[str, Any]) -> bool:
-    """Return True when a schema declaration can resolve to a runtime value."""
-    if "default" in schema:
-        return True
-    const_value = schema.get("const")
-    if const_value is not None:
-        return True
-    enum_value = schema.get("enum")
-    return isinstance(enum_value, list) and len(enum_value) > 0
-
-
-def _resolve_schema_default(
-    schema: Mapping[str, Any],
-    *,
-    key: str,
-    config_path: str,
-) -> Any:
-    """Return a runtime value from a schema declaration."""
-    if "default" in schema:
-        return schema["default"]
-    if schema.get("const") is not None:
-        return schema["const"]
-    enum_value = schema.get("enum")
-    if isinstance(enum_value, list) and enum_value:
-        return enum_value[0]
-    raise CLIError(
-        f"Frontmatter config field '{key}' in '{config_path}' declares schema "
-        "metadata but no runtime default. Add a 'default' value or an 'enum'."
-    )
 
 
 __all__ = [

--- a/src/orcheo/runtime/configurable_schema.py
+++ b/src/orcheo/runtime/configurable_schema.py
@@ -1,0 +1,106 @@
+"""Resolve inline JSON Schema annotations embedded in runnable config values.
+
+A workflow's ``configurable`` mapping may declare a field as an inline JSON
+Schema object (``{"type": ..., "enum": ..., "default": ...}``) so the Canvas
+config form can render a typed widget. The workflow runtime, however, only
+expects the resolved value. :func:`split_configurable` separates the two: it
+returns the runtime values alongside the schema declarations so the latter can
+be stored as version metadata instead of leaking into the runnable config.
+"""
+
+from __future__ import annotations
+from collections.abc import Mapping
+from typing import Any
+
+
+_SCHEMA_KEYS = frozenset(
+    {
+        "type",
+        "enum",
+        "items",
+        "properties",
+        "oneOf",
+        "anyOf",
+        "allOf",
+        "const",
+        "default",
+        "format",
+        "minimum",
+        "maximum",
+        "exclusiveMinimum",
+        "exclusiveMaximum",
+        "multipleOf",
+        "pattern",
+        "additionalProperties",
+    }
+)
+_SCHEMA_DISCRIMINATOR_KEYS = frozenset(
+    {
+        "enum",
+        "items",
+        "properties",
+        "oneOf",
+        "anyOf",
+        "allOf",
+        "const",
+        "default",
+        "additionalProperties",
+    }
+)
+
+
+class ConfigurableSchemaError(ValueError):
+    """Raised when an inline schema annotation cannot resolve a runtime value."""
+
+
+def is_schema_declaration(value: object) -> bool:
+    """Return True when ``value`` is an explicit inline JSON Schema annotation."""
+    if not isinstance(value, Mapping):
+        return False
+    if not any(key in value for key in _SCHEMA_KEYS):
+        return False
+    return any(key in value for key in _SCHEMA_DISCRIMINATOR_KEYS)
+
+
+def _resolve_runtime_default(schema: Mapping[str, Any], *, key: str) -> Any:
+    """Return the runtime value declared by an inline schema annotation."""
+    if "default" in schema:
+        return schema["default"]
+    if "const" in schema:
+        return schema["const"]
+    enum_value = schema.get("enum")
+    if isinstance(enum_value, list) and enum_value:
+        return enum_value[0]
+    raise ConfigurableSchemaError(
+        f"Configurable field '{key}' declares schema metadata but no runtime "
+        "default. Add a 'default' value or a non-empty 'enum'."
+    )
+
+
+def split_configurable(
+    configurable: Mapping[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Split inline schema annotations out of a ``configurable`` mapping.
+
+    Returns a ``(resolved, schema_definitions)`` tuple where ``resolved`` carries
+    the runtime values (each annotated entry replaced by its declared default)
+    and ``schema_definitions`` maps every annotated key to its schema object.
+    Plain (non-annotated) values pass through unchanged.
+    """
+    resolved: dict[str, Any] = {}
+    schema_definitions: dict[str, Any] = {}
+    for key, value in configurable.items():
+        if is_schema_declaration(value):
+            schema = dict(value)
+            resolved[key] = _resolve_runtime_default(schema, key=key)
+            schema_definitions[key] = schema
+        else:
+            resolved[key] = value
+    return resolved, schema_definitions
+
+
+__all__ = [
+    "ConfigurableSchemaError",
+    "is_schema_declaration",
+    "split_configurable",
+]

--- a/tests/backend/test_app_workflow_versions_create.py
+++ b/tests/backend/test_app_workflow_versions_create.py
@@ -249,6 +249,169 @@ async def test_ingest_workflow_version_not_found() -> None:
     assert exc_info.value.status_code == 404
 
 
+_INGEST_SCRIPT = (
+    "from langgraph.graph import StateGraph\n"
+    "graph = StateGraph(dict)\n"
+    "graph.add_node('test', lambda x: x)"
+)
+
+
+def _build_capturing_repository(workflow_id, captured):
+    """Return a repository stub that records create_version arguments."""
+
+    class Repository:
+        async def resolve_workflow_ref(
+            self, workflow_ref, *, include_archived=True, workspace_id=None
+        ):
+            del workflow_ref, include_archived, workspace_id
+            return workflow_id
+
+        async def create_version(
+            self,
+            wf_id,
+            graph,
+            metadata,
+            notes,
+            created_by,
+            runnable_config=None,
+        ):
+            captured["metadata"] = metadata
+            captured["runnable_config"] = runnable_config
+            return WorkflowVersion(
+                id=uuid4(),
+                workflow_id=wf_id,
+                version=1,
+                graph=graph,
+                created_by=created_by,
+                created_at=datetime.now(tz=UTC),
+                updated_at=datetime.now(tz=UTC),
+            )
+
+    return Repository()
+
+
+@pytest.mark.asyncio()
+async def test_ingest_workflow_version_lifts_inline_configurable_schema() -> None:
+    """Inline schema annotations resolve to runtime values plus version metadata."""
+    workflow_id = uuid4()
+    captured: dict[str, object] = {}
+    request = WorkflowVersionIngestRequest(
+        script=_INGEST_SCRIPT,
+        entrypoint="graph",
+        runnable_config={
+            "configurable": {
+                "ai_model": {
+                    "type": "string",
+                    "enum": ["openai:gpt-4.1-mini", "openai:gpt-5.4-mini"],
+                    "title": "Model",
+                    "default": "openai:gpt-4.1-mini",
+                }
+            }
+        },
+        created_by="admin",
+    )
+
+    await ingest_workflow_version(
+        str(workflow_id),
+        request,
+        _build_capturing_repository(workflow_id, captured),
+        _MOCK_WORKSPACE,
+    )
+
+    assert captured["runnable_config"] == {
+        "configurable": {"ai_model": "openai:gpt-4.1-mini"}
+    }
+    assert captured["metadata"]["configurable_schema"] == {
+        "ai_model": {
+            "type": "string",
+            "enum": ["openai:gpt-4.1-mini", "openai:gpt-5.4-mini"],
+            "title": "Model",
+            "default": "openai:gpt-4.1-mini",
+        }
+    }
+
+
+@pytest.mark.asyncio()
+async def test_ingest_workflow_version_keeps_sibling_schema_over_inline() -> None:
+    """A schema supplied via metadata wins over annotations inferred inline."""
+    workflow_id = uuid4()
+    captured: dict[str, object] = {}
+    request = WorkflowVersionIngestRequest(
+        script=_INGEST_SCRIPT,
+        entrypoint="graph",
+        runnable_config={
+            "configurable": {"ai_model": {"type": "string", "default": "inline"}}
+        },
+        metadata={
+            "configurable_schema": {
+                "ai_model": {"type": "string", "default": "from-sibling"}
+            }
+        },
+        created_by="admin",
+    )
+
+    await ingest_workflow_version(
+        str(workflow_id),
+        request,
+        _build_capturing_repository(workflow_id, captured),
+        _MOCK_WORKSPACE,
+    )
+
+    assert captured["runnable_config"] == {"configurable": {"ai_model": "inline"}}
+    assert captured["metadata"]["configurable_schema"] == {
+        "ai_model": {"type": "string", "default": "from-sibling"}
+    }
+
+
+@pytest.mark.asyncio()
+async def test_ingest_workflow_version_leaves_plain_configurable_untouched() -> None:
+    """A configurable mapping without annotations is stored unchanged."""
+    workflow_id = uuid4()
+    captured: dict[str, object] = {}
+    request = WorkflowVersionIngestRequest(
+        script=_INGEST_SCRIPT,
+        entrypoint="graph",
+        runnable_config={"configurable": {"ai_model": "openai:gpt-4.1-mini"}},
+        created_by="admin",
+    )
+
+    await ingest_workflow_version(
+        str(workflow_id),
+        request,
+        _build_capturing_repository(workflow_id, captured),
+        _MOCK_WORKSPACE,
+    )
+
+    assert captured["runnable_config"] == {
+        "configurable": {"ai_model": "openai:gpt-4.1-mini"}
+    }
+    assert "configurable_schema" not in captured["metadata"]
+
+
+@pytest.mark.asyncio()
+async def test_ingest_workflow_version_rejects_schema_without_runtime_default() -> None:
+    """An inline schema with no resolvable runtime value raises a 400."""
+    workflow_id = uuid4()
+    captured: dict[str, object] = {}
+    request = WorkflowVersionIngestRequest(
+        script=_INGEST_SCRIPT,
+        entrypoint="graph",
+        runnable_config={"configurable": {"ai_model": {"type": "string", "enum": []}}},
+        created_by="admin",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await ingest_workflow_version(
+            str(workflow_id),
+            request,
+            _build_capturing_repository(workflow_id, captured),
+            _MOCK_WORKSPACE,
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "no runtime default" in str(exc_info.value.detail)
+
+
 @pytest.mark.asyncio()
 async def test_update_workflow_version_runnable_config_success() -> None:
     """Version runnable-config endpoint persists config-only updates."""

--- a/tests/backend/test_authentication_service_token_manager.py
+++ b/tests/backend/test_authentication_service_token_manager.py
@@ -43,6 +43,7 @@ async def test_service_token_manager_with_custom_clock() -> None:
     secret, record = await manager.mint()
 
     assert record.issued_at == fixed_time
+    assert record.secret_preview == secret[-4:]
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_service_token_endpoints_create.py
+++ b/tests/backend/test_service_token_endpoints_create.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from orcheo_backend.app.authentication import (
     AuthenticationError,
+    AuthorizationError,
     AuthorizationPolicy,
     RequestContext,
     ServiceTokenRecord,
@@ -21,7 +22,7 @@ async def test_create_service_token_success(admin_policy, mock_workspace):
     """Endpoint should mint a token scoped to the active workspace."""
     request = CreateServiceTokenRequest(
         identifier="my-token",
-        scopes=["read", "write"],
+        scopes=["admin:tokens:read", "admin:tokens:write"],
         expires_in_seconds=3600,
     )
     workspace_id = str(mock_workspace.workspace_id)
@@ -34,7 +35,7 @@ async def test_create_service_token_success(admin_policy, mock_workspace):
         mock_record = ServiceTokenRecord(
             identifier="my-token",
             secret_hash="hash123",
-            scopes=frozenset(["read", "write"]),
+            scopes=frozenset(["admin:tokens:read", "admin:tokens:write"]),
             workspace_ids=frozenset([workspace_id]),
             issued_at=datetime.now(tz=UTC),
             expires_at=datetime.now(tz=UTC) + timedelta(hours=1),
@@ -51,7 +52,7 @@ async def test_create_service_token_success(admin_policy, mock_workspace):
         assert "Store this token securely" in response.message
         mock_manager.mint.assert_called_once_with(
             identifier="my-token",
-            scopes=["read", "write"],
+            scopes=["admin:tokens:read", "admin:tokens:write"],
             workspace_ids=[workspace_id],
             expires_in=3600,
             workspace_id=workspace_id,
@@ -124,6 +125,23 @@ async def test_create_service_token_allows_non_admin_member(mock_workspace):
 
         assert response.identifier == "member-token"
         assert response.secret == "member-secret"
+
+
+@pytest.mark.asyncio
+async def test_create_service_token_rejects_scope_escalation(mock_workspace):
+    """Callers may only mint tokens with scopes they already possess."""
+    context = RequestContext(
+        subject="member",
+        identity_type="user",
+        scopes=frozenset(["workflows:read"]),
+    )
+    policy = AuthorizationPolicy(context)
+    request = CreateServiceTokenRequest(scopes=["workflows:read", "vault:write"])
+
+    with pytest.raises(AuthorizationError) as exc_info:
+        await create_service_token(request, policy, mock_workspace)
+
+    assert exc_info.value.code == "auth.missing_scope"
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_service_token_endpoints_create.py
+++ b/tests/backend/test_service_token_endpoints_create.py
@@ -3,12 +3,9 @@
 from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, patch
-from uuid import uuid4
 import pytest
-from orcheo.workspace import Role, WorkspaceContext
 from orcheo_backend.app.authentication import (
     AuthenticationError,
-    AuthorizationError,
     AuthorizationPolicy,
     RequestContext,
     ServiceTokenRecord,
@@ -19,24 +16,15 @@ from orcheo_backend.app.service_token_endpoints import (
 )
 
 
-def _make_workspace_context(workspace_id=None, slug="acme") -> WorkspaceContext:
-    return WorkspaceContext(
-        workspace_id=workspace_id or uuid4(),
-        workspace_slug=slug,
-        user_id="user",
-        role=Role.ADMIN,
-    )
-
-
 @pytest.mark.asyncio
-async def test_create_service_token_success(admin_policy):
-    """Endpoint should mint and return a new token."""
+async def test_create_service_token_success(admin_policy, mock_workspace):
+    """Endpoint should mint a token scoped to the active workspace."""
     request = CreateServiceTokenRequest(
         identifier="my-token",
         scopes=["read", "write"],
-        workspace_ids=["ws-1"],
         expires_in_seconds=3600,
     )
+    workspace_id = str(mock_workspace.workspace_id)
 
     with patch(
         "orcheo_backend.app.service_token_endpoints.get_service_token_manager"
@@ -47,32 +35,34 @@ async def test_create_service_token_success(admin_policy):
             identifier="my-token",
             secret_hash="hash123",
             scopes=frozenset(["read", "write"]),
-            workspace_ids=frozenset(["ws-1"]),
+            workspace_ids=frozenset([workspace_id]),
             issued_at=datetime.now(tz=UTC),
             expires_at=datetime.now(tz=UTC) + timedelta(hours=1),
+            workspace_id=workspace_id,
         )
         mock_manager.mint.return_value = (mock_secret, mock_record)
         mock_get_manager.return_value = mock_manager
 
-        workspace = _make_workspace_context()
-        response = await create_service_token(request, admin_policy, workspace)
+        response = await create_service_token(request, admin_policy, mock_workspace)
 
         assert response.identifier == "my-token"
         assert response.secret == mock_secret
+        assert response.workspace_ids == [workspace_id]
         assert "Store this token securely" in response.message
         mock_manager.mint.assert_called_once_with(
             identifier="my-token",
             scopes=["read", "write"],
-            workspace_ids=["ws-1"],
+            workspace_ids=[workspace_id],
             expires_in=3600,
-            workspace_id=str(workspace.workspace_id),
+            workspace_id=workspace_id,
         )
 
 
 @pytest.mark.asyncio
-async def test_create_service_token_with_default_values(admin_policy):
-    """Endpoint should allow minimal payload with defaults."""
+async def test_create_service_token_with_default_values(admin_policy, mock_workspace):
+    """Endpoint should allow a minimal payload while still scoping the token."""
     request = CreateServiceTokenRequest()
+    workspace_id = str(mock_workspace.workspace_id)
 
     with patch(
         "orcheo_backend.app.service_token_endpoints.get_service_token_manager"
@@ -83,49 +73,65 @@ async def test_create_service_token_with_default_values(admin_policy):
             identifier="auto-generated-id",
             secret_hash="hash",
             scopes=frozenset(),
-            workspace_ids=frozenset(),
+            workspace_ids=frozenset([workspace_id]),
             issued_at=datetime.now(tz=UTC),
+            workspace_id=workspace_id,
         )
         mock_manager.mint.return_value = (mock_secret, mock_record)
         mock_get_manager.return_value = mock_manager
 
-        workspace = _make_workspace_context()
-        response = await create_service_token(request, admin_policy, workspace)
+        response = await create_service_token(request, admin_policy, mock_workspace)
 
         assert response.identifier == "auto-generated-id"
         assert response.secret == mock_secret
         mock_manager.mint.assert_called_once_with(
             identifier=None,
             scopes=[],
-            workspace_ids=[],
+            workspace_ids=[workspace_id],
             expires_in=None,
-            workspace_id=str(workspace.workspace_id),
+            workspace_id=workspace_id,
         )
 
 
 @pytest.mark.asyncio
-async def test_create_service_token_without_authentication():
-    """Anonymous users should be rejected."""
-    anonymous_context = RequestContext.anonymous()
-    policy = AuthorizationPolicy(anonymous_context)
-    workspace = _make_workspace_context()
-    request = CreateServiceTokenRequest()
+async def test_create_service_token_allows_non_admin_member(mock_workspace):
+    """Any authenticated workspace member may mint a token."""
+    context = RequestContext(
+        subject="member",
+        identity_type="user",
+        scopes=frozenset(["workflows:read"]),
+    )
+    policy = AuthorizationPolicy(context)
+    request = CreateServiceTokenRequest(scopes=["workflows:read"])
+    workspace_id = str(mock_workspace.workspace_id)
 
-    with pytest.raises(AuthenticationError):
-        await create_service_token(request, policy, workspace)
+    with patch(
+        "orcheo_backend.app.service_token_endpoints.get_service_token_manager"
+    ) as mock_get_manager:
+        mock_manager = AsyncMock()
+        mock_record = ServiceTokenRecord(
+            identifier="member-token",
+            secret_hash="hash",
+            scopes=frozenset(["workflows:read"]),
+            workspace_ids=frozenset([workspace_id]),
+            issued_at=datetime.now(tz=UTC),
+            workspace_id=workspace_id,
+        )
+        mock_manager.mint.return_value = ("member-secret", mock_record)
+        mock_get_manager.return_value = mock_manager
+
+        response = await create_service_token(request, policy, mock_workspace)
+
+        assert response.identifier == "member-token"
+        assert response.secret == "member-secret"
 
 
 @pytest.mark.asyncio
-async def test_create_service_token_without_required_scope():
-    """Missing admin:tokens:write scope should raise AuthorizationError."""
-    context = RequestContext(
-        subject="user",
-        identity_type="user",
-        scopes=frozenset(["read"]),
-    )
-    policy = AuthorizationPolicy(context)
-    workspace = _make_workspace_context()
+async def test_create_service_token_without_authentication(mock_workspace):
+    """Anonymous users should be rejected."""
+    anonymous_context = RequestContext.anonymous()
+    policy = AuthorizationPolicy(anonymous_context)
     request = CreateServiceTokenRequest()
 
-    with pytest.raises(AuthorizationError):
-        await create_service_token(request, policy, workspace)
+    with pytest.raises(AuthenticationError):
+        await create_service_token(request, policy, mock_workspace)

--- a/tests/backend/test_service_token_endpoints_get.py
+++ b/tests/backend/test_service_token_endpoints_get.py
@@ -7,7 +7,6 @@ import pytest
 from fastapi import HTTPException, status
 from orcheo_backend.app.authentication import (
     AuthenticationError,
-    AuthorizationError,
     AuthorizationPolicy,
     RequestContext,
     ServiceTokenRecord,
@@ -16,14 +15,16 @@ from orcheo_backend.app.service_token_endpoints import get_service_token
 
 
 @pytest.mark.asyncio
-async def test_get_service_token_success(admin_policy):
+async def test_get_service_token_success(admin_policy, mock_workspace):
     """Endpoint should return token metadata without secret."""
+    workspace_id = str(mock_workspace.workspace_id)
     mock_record = ServiceTokenRecord(
         identifier="token-123",
         secret_hash="hash123",
         scopes=frozenset(["read", "write"]),
-        workspace_ids=frozenset(["ws-1"]),
+        workspace_ids=frozenset([workspace_id]),
         issued_at=datetime.now(tz=UTC),
+        workspace_id=workspace_id,
     )
 
     with patch(
@@ -33,17 +34,17 @@ async def test_get_service_token_success(admin_policy):
         mock_manager._repository.find_by_id.return_value = mock_record
         mock_get_manager.return_value = mock_manager
 
-        response = await get_service_token("token-123", admin_policy)
+        response = await get_service_token("token-123", admin_policy, mock_workspace)
 
         assert response.identifier == "token-123"
         assert response.scopes == ["read", "write"]
-        assert response.workspace_ids == ["ws-1"]
+        assert response.workspace_ids == [workspace_id]
         assert response.secret is None
         mock_manager._repository.find_by_id.assert_called_once_with("token-123")
 
 
 @pytest.mark.asyncio
-async def test_get_service_token_not_found(admin_policy):
+async def test_get_service_token_not_found(admin_policy, mock_workspace):
     """Non-existent tokens should raise HTTP 404."""
     with patch(
         "orcheo_backend.app.service_token_endpoints.get_service_token_manager"
@@ -53,44 +54,56 @@ async def test_get_service_token_not_found(admin_policy):
         mock_get_manager.return_value = mock_manager
 
         with pytest.raises(HTTPException) as exc_info:
-            await get_service_token("nonexistent-token", admin_policy)
+            await get_service_token("nonexistent-token", admin_policy, mock_workspace)
 
         assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
         assert "not found" in str(exc_info.value.detail)
 
 
 @pytest.mark.asyncio
-async def test_get_service_token_without_authentication():
+async def test_get_service_token_other_workspace(admin_policy, mock_workspace):
+    """Tokens owned by another workspace should be reported as missing."""
+    foreign_record = ServiceTokenRecord(
+        identifier="foreign-token",
+        secret_hash="hash",
+        scopes=frozenset(["read"]),
+        workspace_ids=frozenset(["other-workspace"]),
+        issued_at=datetime.now(tz=UTC),
+        workspace_id="other-workspace",
+    )
+
+    with patch(
+        "orcheo_backend.app.service_token_endpoints.get_service_token_manager"
+    ) as mock_get_manager:
+        mock_manager = AsyncMock()
+        mock_manager._repository.find_by_id.return_value = foreign_record
+        mock_get_manager.return_value = mock_manager
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_service_token("foreign-token", admin_policy, mock_workspace)
+
+        assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_get_service_token_without_authentication(mock_workspace):
     """Anonymous users should be rejected."""
     anonymous_context = RequestContext.anonymous()
     policy = AuthorizationPolicy(anonymous_context)
 
     with pytest.raises(AuthenticationError):
-        await get_service_token("token-123", policy)
+        await get_service_token("token-123", policy, mock_workspace)
 
 
 @pytest.mark.asyncio
-async def test_get_service_token_without_required_scope():
-    """Missing admin:tokens:read scope should raise AuthorizationError."""
-    context = RequestContext(
-        subject="user",
-        identity_type="user",
-        scopes=frozenset(["write"]),
-    )
-    policy = AuthorizationPolicy(context)
-
-    with pytest.raises(AuthorizationError):
-        await get_service_token("token-123", policy)
-
-
-@pytest.mark.asyncio
-async def test_get_service_token_with_all_fields(admin_policy):
+async def test_get_service_token_with_all_fields(admin_policy, mock_workspace):
     """All record fields should be surfaced and sorted."""
+    workspace_id = str(mock_workspace.workspace_id)
     mock_record = ServiceTokenRecord(
         identifier="complete-token",
         secret_hash="hash",
         scopes=frozenset(["admin", "read", "write"]),
-        workspace_ids=frozenset(["ws-1", "ws-2", "ws-3"]),
+        workspace_ids=frozenset([workspace_id]),
         issued_at=datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC),
         expires_at=datetime(2025, 12, 31, 23, 59, 59, tzinfo=UTC),
         last_used_at=datetime(2025, 6, 15, 12, 30, 0, tzinfo=UTC),
@@ -98,6 +111,7 @@ async def test_get_service_token_with_all_fields(admin_policy):
         revoked_at=None,
         revocation_reason=None,
         rotated_to=None,
+        workspace_id=workspace_id,
     )
 
     with patch(
@@ -107,10 +121,12 @@ async def test_get_service_token_with_all_fields(admin_policy):
         mock_manager._repository.find_by_id.return_value = mock_record
         mock_get_manager.return_value = mock_manager
 
-        response = await get_service_token("complete-token", admin_policy)
+        response = await get_service_token(
+            "complete-token", admin_policy, mock_workspace
+        )
 
         assert response.identifier == "complete-token"
         assert response.scopes == ["admin", "read", "write"]
-        assert response.workspace_ids == ["ws-1", "ws-2", "ws-3"]
+        assert response.workspace_ids == [workspace_id]
         assert response.use_count == 999
         assert response.last_used_at == datetime(2025, 6, 15, 12, 30, 0, tzinfo=UTC)

--- a/tests/backend/test_service_token_endpoints_list.py
+++ b/tests/backend/test_service_token_endpoints_list.py
@@ -6,7 +6,6 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from orcheo_backend.app.authentication import (
     AuthenticationError,
-    AuthorizationError,
     AuthorizationPolicy,
     RequestContext,
     ServiceTokenRecord,
@@ -15,8 +14,9 @@ from orcheo_backend.app.service_token_endpoints import list_service_tokens
 
 
 @pytest.mark.asyncio
-async def test_list_service_tokens_success(admin_policy):
-    """Endpoint should return all tokens without exposing secrets."""
+async def test_list_service_tokens_success(admin_policy, mock_workspace):
+    """Endpoint should return the active workspace's tokens without secrets."""
+    workspace_id = str(mock_workspace.workspace_id)
     with patch(
         "orcheo_backend.app.service_token_endpoints.get_service_token_manager"
     ) as mock_get_manager:
@@ -26,21 +26,23 @@ async def test_list_service_tokens_success(admin_policy):
                 identifier="token-1",
                 secret_hash="hash1",
                 scopes=frozenset(["read"]),
-                workspace_ids=frozenset(["ws-1"]),
+                workspace_ids=frozenset([workspace_id]),
                 issued_at=datetime.now(tz=UTC),
+                workspace_id=workspace_id,
             ),
             ServiceTokenRecord(
                 identifier="token-2",
                 secret_hash="hash2",
                 scopes=frozenset(["write"]),
-                workspace_ids=frozenset(["ws-2"]),
+                workspace_ids=frozenset([workspace_id]),
                 issued_at=datetime.now(tz=UTC),
+                workspace_id=workspace_id,
             ),
         ]
-        mock_manager.all.return_value = mock_records
+        mock_manager._repository.list_for_workspace.return_value = mock_records
         mock_get_manager.return_value = mock_manager
 
-        response = await list_service_tokens(admin_policy)
+        response = await list_service_tokens(admin_policy, mock_workspace)
 
         assert response.total == 2
         assert len(response.tokens) == 2
@@ -48,44 +50,32 @@ async def test_list_service_tokens_success(admin_policy):
         assert response.tokens[1].identifier == "token-2"
         assert response.tokens[0].secret is None
         assert response.tokens[1].secret is None
-        mock_manager.all.assert_called_once()
+        mock_manager._repository.list_for_workspace.assert_called_once_with(
+            workspace_id
+        )
 
 
 @pytest.mark.asyncio
-async def test_list_service_tokens_empty(admin_policy):
-    """Empty repositories should return zero results."""
+async def test_list_service_tokens_empty(admin_policy, mock_workspace):
+    """A workspace with no tokens should return zero results."""
     with patch(
         "orcheo_backend.app.service_token_endpoints.get_service_token_manager"
     ) as mock_get_manager:
         mock_manager = AsyncMock()
-        mock_manager.all.return_value = []
+        mock_manager._repository.list_for_workspace.return_value = []
         mock_get_manager.return_value = mock_manager
 
-        response = await list_service_tokens(admin_policy)
+        response = await list_service_tokens(admin_policy, mock_workspace)
 
         assert response.total == 0
         assert len(response.tokens) == 0
 
 
 @pytest.mark.asyncio
-async def test_list_service_tokens_without_authentication():
+async def test_list_service_tokens_without_authentication(mock_workspace):
     """Anonymous users cannot list tokens."""
     anonymous_context = RequestContext.anonymous()
     policy = AuthorizationPolicy(anonymous_context)
 
     with pytest.raises(AuthenticationError):
-        await list_service_tokens(policy)
-
-
-@pytest.mark.asyncio
-async def test_list_service_tokens_without_required_scope():
-    """Missing admin:tokens:read scope should raise AuthorizationError."""
-    context = RequestContext(
-        subject="user",
-        identity_type="user",
-        scopes=frozenset(["write"]),
-    )
-    policy = AuthorizationPolicy(context)
-
-    with pytest.raises(AuthorizationError):
-        await list_service_tokens(policy)
+        await list_service_tokens(policy, mock_workspace)

--- a/tests/backend/test_service_token_endpoints_revoke.py
+++ b/tests/backend/test_service_token_endpoints_revoke.py
@@ -1,14 +1,15 @@
 """Tests for the revoke_service_token endpoint."""
 
 from __future__ import annotations
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 import pytest
 from fastapi import HTTPException, status
 from orcheo_backend.app.authentication import (
     AuthenticationError,
-    AuthorizationError,
     AuthorizationPolicy,
     RequestContext,
+    ServiceTokenRecord,
 )
 from orcheo_backend.app.service_token_endpoints import (
     RevokeServiceTokenRequest,
@@ -16,15 +17,30 @@ from orcheo_backend.app.service_token_endpoints import (
 )
 
 
+def _owned_record(token_id: str, workspace_id: str) -> ServiceTokenRecord:
+    return ServiceTokenRecord(
+        identifier=token_id,
+        secret_hash="hash",
+        scopes=frozenset(["read"]),
+        workspace_ids=frozenset([workspace_id]),
+        issued_at=datetime.now(tz=UTC),
+        workspace_id=workspace_id,
+    )
+
+
 @pytest.mark.asyncio
 async def test_revoke_service_token_success(admin_policy, mock_workspace):
     """Endpoint should revoke tokens and return 204."""
+    workspace_id = str(mock_workspace.workspace_id)
     request = RevokeServiceTokenRequest(reason="Security breach detected")
 
     with patch(
         "orcheo_backend.app.service_token_endpoints.get_service_token_manager"
     ) as mock_get_manager:
         mock_manager = AsyncMock()
+        mock_manager._repository.find_by_id.return_value = _owned_record(
+            "token-to-revoke", workspace_id
+        )
         mock_manager.revoke.return_value = None
         mock_get_manager.return_value = mock_manager
 
@@ -48,7 +64,7 @@ async def test_revoke_service_token_not_found(admin_policy, mock_workspace):
         "orcheo_backend.app.service_token_endpoints.get_service_token_manager"
     ) as mock_get_manager:
         mock_manager = AsyncMock()
-        mock_manager.revoke.side_effect = KeyError("Token not found")
+        mock_manager._repository.find_by_id.return_value = None
         mock_get_manager.return_value = mock_manager
 
         with pytest.raises(HTTPException) as exc_info:
@@ -58,6 +74,30 @@ async def test_revoke_service_token_not_found(admin_policy, mock_workspace):
 
         assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
         assert "not found" in str(exc_info.value.detail)
+        mock_manager.revoke.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_revoke_service_token_other_workspace(admin_policy, mock_workspace):
+    """Tokens owned by another workspace cannot be revoked."""
+    request = RevokeServiceTokenRequest(reason="Test")
+
+    with patch(
+        "orcheo_backend.app.service_token_endpoints.get_service_token_manager"
+    ) as mock_get_manager:
+        mock_manager = AsyncMock()
+        mock_manager._repository.find_by_id.return_value = _owned_record(
+            "foreign-token", "other-workspace"
+        )
+        mock_get_manager.return_value = mock_manager
+
+        with pytest.raises(HTTPException) as exc_info:
+            await revoke_service_token(
+                "foreign-token", request, admin_policy, mock_workspace
+            )
+
+        assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+        mock_manager.revoke.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -68,19 +108,4 @@ async def test_revoke_service_token_without_authentication(mock_workspace):
     request = RevokeServiceTokenRequest(reason="Test")
 
     with pytest.raises(AuthenticationError):
-        await revoke_service_token("token-123", request, policy, mock_workspace)
-
-
-@pytest.mark.asyncio
-async def test_revoke_service_token_without_required_scope(mock_workspace):
-    """Missing admin:tokens:write scope should raise AuthorizationError."""
-    context = RequestContext(
-        subject="user",
-        identity_type="user",
-        scopes=frozenset(["read"]),
-    )
-    policy = AuthorizationPolicy(context)
-    request = RevokeServiceTokenRequest(reason="Test")
-
-    with pytest.raises(AuthorizationError):
         await revoke_service_token("token-123", request, policy, mock_workspace)

--- a/tests/backend/test_service_token_endpoints_rotate.py
+++ b/tests/backend/test_service_token_endpoints_rotate.py
@@ -7,7 +7,6 @@ import pytest
 from fastapi import HTTPException, status
 from orcheo_backend.app.authentication import (
     AuthenticationError,
-    AuthorizationError,
     AuthorizationPolicy,
     RequestContext,
     ServiceTokenRecord,
@@ -18,9 +17,21 @@ from orcheo_backend.app.service_token_endpoints import (
 )
 
 
+def _owned_record(token_id: str, workspace_id: str) -> ServiceTokenRecord:
+    return ServiceTokenRecord(
+        identifier=token_id,
+        secret_hash="hash",
+        scopes=frozenset(["read"]),
+        workspace_ids=frozenset([workspace_id]),
+        issued_at=datetime.now(tz=UTC),
+        workspace_id=workspace_id,
+    )
+
+
 @pytest.mark.asyncio
 async def test_rotate_service_token_success(admin_policy, mock_workspace):
     """Endpoint should return the new token details."""
+    workspace_id = str(mock_workspace.workspace_id)
     request = RotateServiceTokenRequest(
         overlap_seconds=300,
         expires_in_seconds=7200,
@@ -31,15 +42,19 @@ async def test_rotate_service_token_success(admin_policy, mock_workspace):
         identifier="new-token-id",
         secret_hash="new-hash",
         scopes=frozenset(["read"]),
-        workspace_ids=frozenset(["ws-1"]),
+        workspace_ids=frozenset([workspace_id]),
         issued_at=datetime.now(tz=UTC),
         expires_at=datetime.now(tz=UTC) + timedelta(hours=2),
+        workspace_id=workspace_id,
     )
 
     with patch(
         "orcheo_backend.app.service_token_endpoints.get_service_token_manager"
     ) as mock_get_manager:
         mock_manager = AsyncMock()
+        mock_manager._repository.find_by_id.return_value = _owned_record(
+            "old-token-id", workspace_id
+        )
         mock_manager.rotate.return_value = (mock_new_secret, mock_new_record)
         mock_get_manager.return_value = mock_manager
 
@@ -60,6 +75,7 @@ async def test_rotate_service_token_success(admin_policy, mock_workspace):
 @pytest.mark.asyncio
 async def test_rotate_service_token_with_default_overlap(admin_policy, mock_workspace):
     """Default overlap of 300 seconds should be applied."""
+    workspace_id = str(mock_workspace.workspace_id)
     request = RotateServiceTokenRequest()
 
     mock_new_secret = "new-secret"
@@ -67,14 +83,18 @@ async def test_rotate_service_token_with_default_overlap(admin_policy, mock_work
         identifier="new-token",
         secret_hash="hash",
         scopes=frozenset(),
-        workspace_ids=frozenset(),
+        workspace_ids=frozenset([workspace_id]),
         issued_at=datetime.now(tz=UTC),
+        workspace_id=workspace_id,
     )
 
     with patch(
         "orcheo_backend.app.service_token_endpoints.get_service_token_manager"
     ) as mock_get_manager:
         mock_manager = AsyncMock()
+        mock_manager._repository.find_by_id.return_value = _owned_record(
+            "old-token", workspace_id
+        )
         mock_manager.rotate.return_value = (mock_new_secret, mock_new_record)
         mock_get_manager.return_value = mock_manager
 
@@ -99,7 +119,7 @@ async def test_rotate_service_token_not_found(admin_policy, mock_workspace):
         "orcheo_backend.app.service_token_endpoints.get_service_token_manager"
     ) as mock_get_manager:
         mock_manager = AsyncMock()
-        mock_manager.rotate.side_effect = KeyError("Token not found")
+        mock_manager._repository.find_by_id.return_value = None
         mock_get_manager.return_value = mock_manager
 
         with pytest.raises(HTTPException) as exc_info:
@@ -109,6 +129,30 @@ async def test_rotate_service_token_not_found(admin_policy, mock_workspace):
 
         assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
         assert "not found" in str(exc_info.value.detail)
+        mock_manager.rotate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rotate_service_token_other_workspace(admin_policy, mock_workspace):
+    """Tokens owned by another workspace cannot be rotated."""
+    request = RotateServiceTokenRequest()
+
+    with patch(
+        "orcheo_backend.app.service_token_endpoints.get_service_token_manager"
+    ) as mock_get_manager:
+        mock_manager = AsyncMock()
+        mock_manager._repository.find_by_id.return_value = _owned_record(
+            "foreign-token", "other-workspace"
+        )
+        mock_get_manager.return_value = mock_manager
+
+        with pytest.raises(HTTPException) as exc_info:
+            await rotate_service_token(
+                "foreign-token", request, admin_policy, mock_workspace
+            )
+
+        assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+        mock_manager.rotate.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -119,19 +163,4 @@ async def test_rotate_service_token_without_authentication(mock_workspace):
     request = RotateServiceTokenRequest()
 
     with pytest.raises(AuthenticationError):
-        await rotate_service_token("token-123", request, policy, mock_workspace)
-
-
-@pytest.mark.asyncio
-async def test_rotate_service_token_without_required_scope(mock_workspace):
-    """Missing admin:tokens:write scope should raise AuthorizationError."""
-    context = RequestContext(
-        subject="user",
-        identity_type="user",
-        scopes=frozenset(["read"]),
-    )
-    policy = AuthorizationPolicy(context)
-    request = RotateServiceTokenRequest()
-
-    with pytest.raises(AuthorizationError):
         await rotate_service_token("token-123", request, policy, mock_workspace)

--- a/tests/backend/test_service_token_repository_postgres.py
+++ b/tests/backend/test_service_token_repository_postgres.py
@@ -131,6 +131,7 @@ def _token_row(identifier: str, **overrides: Any) -> dict[str, Any]:
     base = {
         "identifier": identifier,
         "secret_hash": "hash-" + identifier,
+        "secret_preview": "ab12",
         "scopes": json.dumps(["read", "write"]),
         "workspace_ids": json.dumps(["ws-1"]),
         "issued_at": now,
@@ -305,6 +306,7 @@ async def test_postgres_service_token_repository_find_by_id(
 
     assert token is not None
     assert token.identifier == "token-1"
+    assert token.secret_preview == "ab12"
 
 
 @pytest.mark.asyncio
@@ -362,6 +364,7 @@ async def test_postgres_service_token_repository_create(
     record = ServiceTokenRecord(
         identifier="token-1",
         secret_hash="hash-1",
+        secret_preview="ab12",
         scopes=frozenset({"read", "write"}),
         workspace_ids=frozenset({"ws-1"}),
         issued_at=now,

--- a/tests/runtime/test_configurable_schema.py
+++ b/tests/runtime/test_configurable_schema.py
@@ -1,0 +1,82 @@
+"""Tests for inline configurable-schema resolution."""
+
+from __future__ import annotations
+import pytest
+from orcheo.runtime.configurable_schema import (
+    ConfigurableSchemaError,
+    is_schema_declaration,
+    split_configurable,
+)
+
+
+def test_is_schema_declaration_detects_inline_annotation() -> None:
+    """A mapping with a schema key and a discriminator is a declaration."""
+    assert (
+        is_schema_declaration({"type": "string", "enum": ["a", "b"], "default": "a"})
+        is True
+    )
+
+
+def test_is_schema_declaration_rejects_non_mapping() -> None:
+    """Plain runtime values are never schema declarations."""
+    assert is_schema_declaration("openai:gpt-4.1-mini") is False
+
+
+def test_is_schema_declaration_rejects_mapping_without_schema_keys() -> None:
+    """A mapping carrying no JSON Schema keys stays a runtime value."""
+    assert is_schema_declaration({"label": "Model"}) is False
+
+
+def test_is_schema_declaration_requires_a_discriminator_key() -> None:
+    """Ambiguous schema keys alone are not enough to flag a declaration."""
+    assert is_schema_declaration({"type": "provider", "pattern": "^openai"}) is False
+
+
+def test_split_configurable_resolves_default_const_and_enum() -> None:
+    """Annotated entries resolve via default, const, then the first enum value."""
+    resolved, schema_definitions = split_configurable(
+        {
+            "mode": {"type": "string", "default": "draft"},
+            "variant": {"type": "string", "const": "stable"},
+            "choice": {"type": "string", "enum": ["alpha", "beta"]},
+            "plain": "keep",
+        }
+    )
+
+    assert resolved == {
+        "mode": "draft",
+        "variant": "stable",
+        "choice": "alpha",
+        "plain": "keep",
+    }
+    assert schema_definitions == {
+        "mode": {"type": "string", "default": "draft"},
+        "variant": {"type": "string", "const": "stable"},
+        "choice": {"type": "string", "enum": ["alpha", "beta"]},
+    }
+
+
+def test_split_configurable_passes_plain_values_through() -> None:
+    """A configurable mapping with no annotations yields no schema definitions."""
+    resolved, schema_definitions = split_configurable({"plain": "value"})
+
+    assert resolved == {"plain": "value"}
+    assert schema_definitions == {}
+
+
+def test_split_configurable_allows_null_const_default() -> None:
+    """A ``const: null`` schema resolves to a ``None`` runtime value."""
+    resolved, schema_definitions = split_configurable(
+        {"nullable": {"type": ["string", "null"], "const": None}}
+    )
+
+    assert resolved == {"nullable": None}
+    assert schema_definitions == {
+        "nullable": {"type": ["string", "null"], "const": None}
+    }
+
+
+def test_split_configurable_rejects_declaration_without_runtime_default() -> None:
+    """A schema annotation that cannot resolve a value raises an error."""
+    with pytest.raises(ConfigurableSchemaError, match="no runtime default"):
+        split_configurable({"mode": {"type": "string", "enum": []}})

--- a/tests/sdk/test_cli_workflow_frontmatter.py
+++ b/tests/sdk/test_cli_workflow_frontmatter.py
@@ -495,71 +495,24 @@ def test_load_from_file_with_invalid_encoding(tmp_path: Path) -> None:
         frontmatter.load_workflow_frontmatter(py_file)
 
 
-def test_is_schema_declaration_requires_explicit_schema_keys() -> None:
-    """Objects with ambiguous keys alone should remain runtime config values."""
-    assert frontmatter._is_schema_declaration({"type": "provider"}) is False
-    assert frontmatter._is_schema_declaration({"pattern": "^openai"}) is False
-
-
-def test_is_schema_declaration_accepts_inline_schema_annotation() -> None:
-    """Inline schema annotations with explicit schema keys are detected."""
-    assert (
-        frontmatter._is_schema_declaration(
-            {"type": "string", "enum": ["a", "b"], "default": "a"}
-        )
-        is True
-    )
-
-
-def test_is_schema_declaration_rejects_non_mapping_values() -> None:
-    """Non-mapping values are never treated as schema declarations."""
-    assert frontmatter._is_schema_declaration("nope") is False
-
-
-def test_is_schema_declaration_rejects_mappings_without_schema_keys() -> None:
-    """Plain mappings without schema keys should not be treated as annotations."""
-    assert frontmatter._is_schema_declaration({"value": "plain"}) is False
-
-
-def test_resolve_frontmatter_config_bundle_merges_inline_and_sibling_schema(
+def test_resolve_frontmatter_config_bundle_forwards_raw_config_and_sibling_schema(
     tmp_path: Path,
 ) -> None:
-    """Inline schema defaults are resolved while sibling schema defs override metadata."""
+    """The config is forwarded verbatim; only the sibling schema file is loaded."""
     workflow = tmp_path / "workflow.py"
     workflow.write_text("# noop\n", encoding="utf-8")
+    config_payload = {
+        "configurable": {
+            "mode": {"type": "string", "default": "inline"},
+            "count": 3,
+        }
+    }
     config_path = tmp_path / "workflow.config.json"
-    config_path.write_text(
-        json.dumps(
-            {
-                "configurable": {
-                    "mode": {
-                        "type": "string",
-                        "default": "inline",
-                    },
-                    "count": {
-                        "type": "integer",
-                        "default": 3,
-                    },
-                }
-            }
-        ),
-        encoding="utf-8",
-    )
+    config_path.write_text(json.dumps(config_payload), encoding="utf-8")
     schema_path = tmp_path / "workflow.config.schema.json"
     schema_path.write_text(
         json.dumps(
-            {
-                "configurable": {
-                    "mode": {
-                        "type": "string",
-                        "default": "schema",
-                    },
-                    "extra": {
-                        "type": "string",
-                        "default": "from-schema",
-                    },
-                }
-            }
+            {"configurable": {"extra": {"type": "string", "default": "from-schema"}}}
         ),
         encoding="utf-8",
     )
@@ -569,17 +522,31 @@ def test_resolve_frontmatter_config_bundle_merges_inline_and_sibling_schema(
         "workflow.config.json",
     )
 
-    assert raw_config == {
-        "configurable": {
-            "mode": "inline",
-            "count": 3,
-        }
-    }
+    # Inline schema annotations are preserved for server-side resolution.
+    assert raw_config == config_payload
     assert schema_definitions == {
-        "mode": {"type": "string", "default": "schema"},
-        "count": {"type": "integer", "default": 3},
         "extra": {"type": "string", "default": "from-schema"},
     }
+
+
+def test_resolve_frontmatter_config_bundle_without_sibling_schema(
+    tmp_path: Path,
+) -> None:
+    """The schema definitions are None when no sibling schema file exists."""
+    workflow = tmp_path / "workflow.py"
+    workflow.write_text("# noop\n", encoding="utf-8")
+    config_path = tmp_path / "workflow.config.json"
+    config_path.write_text(
+        json.dumps({"configurable": {"mode": "plain"}}), encoding="utf-8"
+    )
+
+    raw_config, schema_definitions = frontmatter.resolve_frontmatter_config_bundle(
+        workflow,
+        "workflow.config.json",
+    )
+
+    assert raw_config == {"configurable": {"mode": "plain"}}
+    assert schema_definitions is None
 
 
 def test_resolve_frontmatter_config_bundle_rejects_schema_directory(
@@ -631,66 +598,6 @@ def test_resolve_frontmatter_config_bundle_rejects_non_object_schema_payload(
         frontmatter.resolve_frontmatter_config_bundle(workflow, "workflow.config.json")
 
 
-def test_split_annotated_config_returns_original_when_unannotated() -> None:
-    """Configs without annotated values should pass through unchanged."""
-    config = {"configurable": {"plain": "value"}}
-
-    raw_config, schema_definitions = frontmatter._split_annotated_config(
-        config,
-        config_path="workflow.config.json",
-    )
-
-    assert raw_config == config
-    assert schema_definitions is None
-
-
-def test_split_annotated_config_can_skip_non_mapping_values(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The helper should skip values that fail the mapping guard."""
-    monkeypatch.setattr(frontmatter, "_is_schema_declaration", lambda value: True)
-
-    config = {"configurable": {"broken": 1}}
-    raw_config, schema_definitions = frontmatter._split_annotated_config(
-        config,
-        config_path="workflow.config.json",
-    )
-
-    assert raw_config == config
-    assert schema_definitions is None
-
-
-def test_split_annotated_config_resolves_schema_defaults() -> None:
-    """Annotated values should be replaced with their runtime defaults."""
-    config = {
-        "configurable": {
-            "mode": {"type": "string", "default": "draft"},
-            "variant": {"type": "string", "const": "stable"},
-            "choice": {"type": "string", "enum": ["alpha", "beta"]},
-            "plain": "keep",
-        }
-    }
-
-    raw_config, schema_definitions = frontmatter._split_annotated_config(
-        config,
-        config_path="workflow.config.json",
-    )
-
-    assert raw_config == {
-        "configurable": {
-            "mode": "draft",
-            "variant": "stable",
-            "choice": "alpha",
-            "plain": "keep",
-        }
-    }
-    assert schema_definitions == {
-        "mode": {"type": "string", "default": "draft"},
-        "variant": {"type": "string", "const": "stable"},
-        "choice": {"type": "string", "enum": ["alpha", "beta"]},
-    }
-
-
 def test_normalize_schema_definition_map_uses_payload_when_configurable_missing() -> (
     None
 ):
@@ -706,71 +613,3 @@ def test_normalize_schema_definition_map_rejects_non_object_fields() -> None:
     """Every schema field must be a JSON object."""
     with pytest.raises(frontmatter.CLIError, match="must be an object"):
         frontmatter._normalize_schema_definition_map({"mode": 1}, "schema.json")
-
-
-def test_merge_schema_definitions_prefers_later_entries() -> None:
-    """Later schema maps should overwrite earlier keys."""
-    assert frontmatter._merge_schema_definitions(
-        None,
-        {"mode": {"default": "inline"}},
-        {"mode": {"default": "schema"}, "extra": {"default": "x"}},
-    ) == {
-        "mode": {"default": "schema"},
-        "extra": {"default": "x"},
-    }
-
-
-def test_schema_has_runtime_default_covers_supported_shapes() -> None:
-    """Schema defaults can come from default, const, or enum declarations."""
-    assert frontmatter._schema_has_runtime_default({"default": 1}) is True
-    assert frontmatter._schema_has_runtime_default({"const": "x"}) is True
-    assert frontmatter._schema_has_runtime_default({"enum": ["a"]}) is True
-    assert frontmatter._schema_has_runtime_default({"enum": []}) is False
-
-
-def test_normalize_schema_definition_requires_runtime_default() -> None:
-    """Schema metadata without a runtime default should fail fast."""
-    with pytest.raises(frontmatter.CLIError, match="no runtime default"):
-        frontmatter._normalize_schema_definition(
-            {"type": "string"},
-            key="mode",
-            config_path="workflow.config.json",
-        )
-
-
-def test_resolve_schema_default_covers_all_supported_defaults() -> None:
-    """Runtime defaults resolve from default, const, or enum in that order."""
-    assert (
-        frontmatter._resolve_schema_default(
-            {"default": "draft"},
-            key="mode",
-            config_path="workflow.config.json",
-        )
-        == "draft"
-    )
-    assert (
-        frontmatter._resolve_schema_default(
-            {"const": "stable"},
-            key="mode",
-            config_path="workflow.config.json",
-        )
-        == "stable"
-    )
-    assert (
-        frontmatter._resolve_schema_default(
-            {"enum": ["alpha", "beta"]},
-            key="mode",
-            config_path="workflow.config.json",
-        )
-        == "alpha"
-    )
-
-
-def test_resolve_schema_default_raises_without_runtime_default() -> None:
-    """Missing runtime defaults should raise a CLIError."""
-    with pytest.raises(frontmatter.CLIError, match="no runtime default"):
-        frontmatter._resolve_schema_default(
-            {},
-            key="mode",
-            config_path="workflow.config.json",
-        )


### PR DESCRIPTION
## Summary
- Make service tokens workspace-scoped: create, list, get, rotate, and revoke now operate only on tokens owned by the active workspace.
- Persist and expose a secret preview so token lists can show a masked key without revealing the full secret again.
- Add a Canvas "API Keys" page at `/:workspaceSlug/tokens` with create, rotate, revoke, and copy-secret flows, plus a navigation entry in the account menu.
- Update backend and frontend tests to cover the new workspace-isolation and UI flows.

## Notes
- Token minting now always binds the token to the active workspace.
- The secret is still shown only once at creation/rotation time.

## Testing
- Backend and frontend test coverage was added/updated for the new service-token flows.