### PR TITLE
Lift inline configurable schema split into server-side ingest

### DIFF
--- a/apps/backend/src/orcheo_backend/app/routers/workflows.py
+++ b/apps/backend/src/orcheo_backend/app/routers/workflows.py
@@ -13,6 +13,10 @@ from orcheo.models import (
     WorkflowDraftAccess,
     WorkflowVersion,
 )
+from orcheo.runtime.configurable_schema import (
+    ConfigurableSchemaError,
+    split_configurable,
+)
 from orcheo.runtime.runnable_config import RunnableConfigModel
 from orcheo_backend.app.authentication import (
     AuthorizationError,
@@ -119,6 +123,46 @@ def _serialize_runnable_config(
         exclude_defaults=True,
         exclude_none=True,
     )
+
+
+def _merge_configurable_schema(
+    existing: Any,
+    inline: dict[str, Any],
+) -> dict[str, Any]:
+    """Merge inline schema declarations with caller-supplied schema metadata.
+
+    A sibling ``*.schema.json`` file (delivered via ``metadata``) is authored
+    explicitly, so it wins over annotations inferred from the runnable config.
+    """
+    if isinstance(existing, dict):
+        return {**inline, **existing}
+    return inline
+
+
+def _resolve_ingest_configurable_schema(
+    runnable_config: RunnableConfigModel | None,
+    metadata: dict[str, Any],
+) -> tuple[RunnableConfigModel | None, dict[str, Any]]:
+    """Lift inline ``configurable`` schema annotations into version metadata."""
+    if runnable_config is None or not runnable_config.configurable:
+        return runnable_config, metadata
+    try:
+        resolved, inline_schema = split_configurable(runnable_config.configurable)
+    except ConfigurableSchemaError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    if not inline_schema:
+        return runnable_config, metadata
+    runnable_config = runnable_config.model_copy(update={"configurable": resolved})
+    metadata = {
+        **metadata,
+        "configurable_schema": _merge_configurable_schema(
+            metadata.get("configurable_schema"), inline_schema
+        ),
+    }
+    return runnable_config, metadata
 
 
 def _serialize_public_workflow(
@@ -604,14 +648,19 @@ async def ingest_workflow_version(
             detail=str(exc),
         ) from exc
 
+    runnable_config, metadata = _resolve_ingest_configurable_schema(
+        request.runnable_config,
+        request.metadata,
+    )
+
     try:
         version = await repository.create_version(
             workflow.id,
             graph=graph_payload,
-            metadata=request.metadata,
+            metadata=metadata,
             notes=request.notes,
             created_by=request.created_by,
-            runnable_config=_serialize_runnable_config(request.runnable_config),
+            runnable_config=_serialize_runnable_config(runnable_config),
         )
         return _attach_mermaid(version)
     except WorkflowNotFoundError as exc:

--- a/packages/sdk/src/orcheo_sdk/cli/workflow/frontmatter.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflow/frontmatter.py
@@ -47,40 +47,6 @@ _ALLOWED_FIELDS = frozenset(
     }
 )
 _ENCODING_RE = re.compile(r"coding[=:]\s*([-\w.]+)")
-_SCHEMA_KEYS = frozenset(
-    {
-        "type",
-        "enum",
-        "items",
-        "properties",
-        "oneOf",
-        "anyOf",
-        "allOf",
-        "const",
-        "default",
-        "format",
-        "minimum",
-        "maximum",
-        "exclusiveMinimum",
-        "exclusiveMaximum",
-        "multipleOf",
-        "pattern",
-        "additionalProperties",
-    }
-)
-_SCHEMA_DISCRIMINATOR_KEYS = frozenset(
-    {
-        "enum",
-        "items",
-        "properties",
-        "oneOf",
-        "anyOf",
-        "allOf",
-        "const",
-        "default",
-        "additionalProperties",
-    }
-)
 
 
 def _encoding_from_cookie(line: bytes) -> str | None:
@@ -311,9 +277,13 @@ def resolve_frontmatter_config_bundle(
     workflow_path: Path,
     config_path: str,
 ) -> tuple[dict[str, Any], dict[str, Any] | None]:
-    """Load runnable config and typed schema declarations from frontmatter.
+    """Load runnable config and optional sibling schema declarations.
 
-    Relative paths resolve against the workflow file's parent directory.
+    Relative paths resolve against the workflow file's parent directory. The
+    config is forwarded verbatim: inline JSON Schema annotations embedded in
+    ``configurable`` values are resolved server-side during ingestion. Only a
+    companion ``*.schema.json`` file is loaded here, since it cannot be seen
+    once the workflow leaves the local filesystem.
     """
     candidate = Path(config_path).expanduser()
     if not candidate.is_absolute():
@@ -338,10 +308,7 @@ def resolve_frontmatter_config_bundle(
             f"Frontmatter config file '{config_path}' must contain a JSON object."
         )
 
-    sibling_schema = _load_sibling_schema_file(resolved)
-    raw_config, inline_schema = _split_annotated_config(data, config_path=config_path)
-    schema_definitions = _merge_schema_definitions(inline_schema, sibling_schema)
-    return raw_config, schema_definitions or None
+    return data, _load_sibling_schema_file(resolved)
 
 
 def _load_sibling_schema_file(resolved_config: Path) -> dict[str, Any] | None:
@@ -367,40 +334,6 @@ def _load_sibling_schema_file(resolved_config: Path) -> dict[str, Any] | None:
     return _normalize_schema_definition_map(schema_payload, schema_path.name)
 
 
-def _split_annotated_config(
-    config: dict[str, Any],
-    *,
-    config_path: str,
-) -> tuple[dict[str, Any], dict[str, Any] | None]:
-    """Split annotated runnable config values from their schema definitions."""
-    configurable = config.get("configurable")
-    if not isinstance(configurable, dict):
-        return config, None
-
-    raw_config = dict(config)
-    raw_configurable = dict(configurable)
-    schema_definitions: dict[str, Any] = {}
-
-    for key, value in configurable.items():
-        if not _is_schema_declaration(value):
-            continue
-        if not isinstance(value, Mapping):
-            continue
-        schema = _normalize_schema_definition(value, key=key, config_path=config_path)
-        raw_configurable[key] = _resolve_schema_default(
-            schema,
-            key=key,
-            config_path=config_path,
-        )
-        schema_definitions[key] = schema
-
-    if schema_definitions:
-        raw_config["configurable"] = raw_configurable
-        return raw_config, schema_definitions
-
-    return config, None
-
-
 def _normalize_schema_definition_map(
     payload: dict[str, Any],
     config_path: str,
@@ -421,75 +354,6 @@ def _normalize_schema_definition_map(
             )
         normalized[key] = dict(value)
     return normalized
-
-
-def _merge_schema_definitions(
-    *schema_maps: dict[str, Any] | None,
-) -> dict[str, Any] | None:
-    """Merge schema definition maps with later entries taking precedence."""
-    merged: dict[str, Any] = {}
-    for schema_map in schema_maps:
-        if not schema_map:
-            continue
-        for key, value in schema_map.items():
-            merged[key] = value
-    return merged or None
-
-
-def _is_schema_declaration(value: object) -> bool:
-    """Return True when ``value`` is an explicit typed schema annotation."""
-    if not isinstance(value, Mapping):
-        return False
-    if not any(key in value for key in _SCHEMA_KEYS):
-        return False
-    return any(key in value for key in _SCHEMA_DISCRIMINATOR_KEYS)
-
-
-def _normalize_schema_definition(
-    value: Mapping[str, Any],
-    *,
-    key: str,
-    config_path: str,
-) -> dict[str, Any]:
-    """Copy a schema declaration into a JSON-serializable mapping."""
-    schema = dict(value)
-    if not _schema_has_runtime_default(schema):
-        raise CLIError(
-            f"Frontmatter config field '{key}' in '{config_path}' declares schema "
-            "metadata but no runtime default. Add a 'default' value or an 'enum'."
-        )
-    return schema
-
-
-def _schema_has_runtime_default(schema: Mapping[str, Any]) -> bool:
-    """Return True when a schema declaration can resolve to a runtime value."""
-    if "default" in schema:
-        return True
-    const_value = schema.get("const")
-    if const_value is not None:
-        return True
-    enum_value = schema.get("enum")
-    return isinstance(enum_value, list) and len(enum_value) > 0
-
-
-def _resolve_schema_default(
-    schema: Mapping[str, Any],
-    *,
-    key: str,
-    config_path: str,
-) -> Any:
-    """Return a runtime value from a schema declaration."""
-    if "default" in schema:
-        return schema["default"]
-    if schema.get("const") is not None:
-        return schema["const"]
-    enum_value = schema.get("enum")
-    if isinstance(enum_value, list) and enum_value:
-        return enum_value[0]
-    raise CLIError(
-        f"Frontmatter config field '{key}' in '{config_path}' declares schema "
-        "metadata but no runtime default. Add a 'default' value or an 'enum'."
-    )
 
 
 __all__ = [

--- a/src/orcheo/runtime/configurable_schema.py
+++ b/src/orcheo/runtime/configurable_schema.py
@@ -1,0 +1,106 @@
+"""Resolve inline JSON Schema annotations embedded in runnable config values.
+
+A workflow's ``configurable`` mapping may declare a field as an inline JSON
+Schema object (``{"type": ..., "enum": ..., "default": ...}``) so the Canvas
+config form can render a typed widget. The workflow runtime, however, only
+expects the resolved value. :func:`split_configurable` separates the two: it
+returns the runtime values alongside the schema declarations so the latter can
+be stored as version metadata instead of leaking into the runnable config.
+"""
+
+from __future__ import annotations
+from collections.abc import Mapping
+from typing import Any
+
+
+_SCHEMA_KEYS = frozenset(
+    {
+        "type",
+        "enum",
+        "items",
+        "properties",
+        "oneOf",
+        "anyOf",
+        "allOf",
+        "const",
+        "default",
+        "format",
+        "minimum",
+        "maximum",
+        "exclusiveMinimum",
+        "exclusiveMaximum",
+        "multipleOf",
+        "pattern",
+        "additionalProperties",
+    }
+)
+_SCHEMA_DISCRIMINATOR_KEYS = frozenset(
+    {
+        "enum",
+        "items",
+        "properties",
+        "oneOf",
+        "anyOf",
+        "allOf",
+        "const",
+        "default",
+        "additionalProperties",
+    }
+)
+
+
+class ConfigurableSchemaError(ValueError):
+    """Raised when an inline schema annotation cannot resolve a runtime value."""
+
+
+def is_schema_declaration(value: object) -> bool:
+    """Return True when ``value`` is an explicit inline JSON Schema annotation."""
+    if not isinstance(value, Mapping):
+        return False
+    if not any(key in value for key in _SCHEMA_KEYS):
+        return False
+    return any(key in value for key in _SCHEMA_DISCRIMINATOR_KEYS)
+
+
+def _resolve_runtime_default(schema: Mapping[str, Any], *, key: str) -> Any:
+    """Return the runtime value declared by an inline schema annotation."""
+    if "default" in schema:
+        return schema["default"]
+    if schema.get("const") is not None:
+        return schema["const"]
+    enum_value = schema.get("enum")
+    if isinstance(enum_value, list) and enum_value:
+        return enum_value[0]
+    raise ConfigurableSchemaError(
+        f"Configurable field '{key}' declares schema metadata but no runtime "
+        "default. Add a 'default' value or a non-empty 'enum'."
+    )
+
+
+def split_configurable(
+    configurable: Mapping[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Split inline schema annotations out of a ``configurable`` mapping.
+
+    Returns a ``(resolved, schema_definitions)`` tuple where ``resolved`` carries
+    the runtime values (each annotated entry replaced by its declared default)
+    and ``schema_definitions`` maps every annotated key to its schema object.
+    Plain (non-annotated) values pass through unchanged.
+    """
+    resolved: dict[str, Any] = {}
+    schema_definitions: dict[str, Any] = {}
+    for key, value in configurable.items():
+        if is_schema_declaration(value):
+            schema = dict(value)
+            resolved[key] = _resolve_runtime_default(schema, key=key)
+            schema_definitions[key] = schema
+        else:
+            resolved[key] = value
+    return resolved, schema_definitions
+
+
+__all__ = [
+    "ConfigurableSchemaError",
+    "is_schema_declaration",
+    "split_configurable",
+]

--- a/src/orcheo/runtime/configurable_schema.py
+++ b/src/orcheo/runtime/configurable_schema.py
@@ -66,7 +66,7 @@ def _resolve_runtime_default(schema: Mapping[str, Any], *, key: str) -> Any:
     """Return the runtime value declared by an inline schema annotation."""
     if "default" in schema:
         return schema["default"]
-    if schema.get("const") is not None:
+    if "const" in schema:
         return schema["const"]
     enum_value = schema.get("enum")
     if isinstance(enum_value, list) and enum_value:

--- a/tests/backend/test_app_workflow_versions_create.py
+++ b/tests/backend/test_app_workflow_versions_create.py
@@ -249,6 +249,169 @@ async def test_ingest_workflow_version_not_found() -> None:
     assert exc_info.value.status_code == 404
 
 
+_INGEST_SCRIPT = (
+    "from langgraph.graph import StateGraph\n"
+    "graph = StateGraph(dict)\n"
+    "graph.add_node('test', lambda x: x)"
+)
+
+
+def _build_capturing_repository(workflow_id, captured):
+    """Return a repository stub that records create_version arguments."""
+
+    class Repository:
+        async def resolve_workflow_ref(
+            self, workflow_ref, *, include_archived=True, workspace_id=None
+        ):
+            del workflow_ref, include_archived, workspace_id
+            return workflow_id
+
+        async def create_version(
+            self,
+            wf_id,
+            graph,
+            metadata,
+            notes,
+            created_by,
+            runnable_config=None,
+        ):
+            captured["metadata"] = metadata
+            captured["runnable_config"] = runnable_config
+            return WorkflowVersion(
+                id=uuid4(),
+                workflow_id=wf_id,
+                version=1,
+                graph=graph,
+                created_by=created_by,
+                created_at=datetime.now(tz=UTC),
+                updated_at=datetime.now(tz=UTC),
+            )
+
+    return Repository()
+
+
+@pytest.mark.asyncio()
+async def test_ingest_workflow_version_lifts_inline_configurable_schema() -> None:
+    """Inline schema annotations resolve to runtime values plus version metadata."""
+    workflow_id = uuid4()
+    captured: dict[str, object] = {}
+    request = WorkflowVersionIngestRequest(
+        script=_INGEST_SCRIPT,
+        entrypoint="graph",
+        runnable_config={
+            "configurable": {
+                "ai_model": {
+                    "type": "string",
+                    "enum": ["openai:gpt-4.1-mini", "openai:gpt-5.4-mini"],
+                    "title": "Model",
+                    "default": "openai:gpt-4.1-mini",
+                }
+            }
+        },
+        created_by="admin",
+    )
+
+    await ingest_workflow_version(
+        str(workflow_id),
+        request,
+        _build_capturing_repository(workflow_id, captured),
+        _MOCK_WORKSPACE,
+    )
+
+    assert captured["runnable_config"] == {
+        "configurable": {"ai_model": "openai:gpt-4.1-mini"}
+    }
+    assert captured["metadata"]["configurable_schema"] == {
+        "ai_model": {
+            "type": "string",
+            "enum": ["openai:gpt-4.1-mini", "openai:gpt-5.4-mini"],
+            "title": "Model",
+            "default": "openai:gpt-4.1-mini",
+        }
+    }
+
+
+@pytest.mark.asyncio()
+async def test_ingest_workflow_version_keeps_sibling_schema_over_inline() -> None:
+    """A schema supplied via metadata wins over annotations inferred inline."""
+    workflow_id = uuid4()
+    captured: dict[str, object] = {}
+    request = WorkflowVersionIngestRequest(
+        script=_INGEST_SCRIPT,
+        entrypoint="graph",
+        runnable_config={
+            "configurable": {"ai_model": {"type": "string", "default": "inline"}}
+        },
+        metadata={
+            "configurable_schema": {
+                "ai_model": {"type": "string", "default": "from-sibling"}
+            }
+        },
+        created_by="admin",
+    )
+
+    await ingest_workflow_version(
+        str(workflow_id),
+        request,
+        _build_capturing_repository(workflow_id, captured),
+        _MOCK_WORKSPACE,
+    )
+
+    assert captured["runnable_config"] == {"configurable": {"ai_model": "inline"}}
+    assert captured["metadata"]["configurable_schema"] == {
+        "ai_model": {"type": "string", "default": "from-sibling"}
+    }
+
+
+@pytest.mark.asyncio()
+async def test_ingest_workflow_version_leaves_plain_configurable_untouched() -> None:
+    """A configurable mapping without annotations is stored unchanged."""
+    workflow_id = uuid4()
+    captured: dict[str, object] = {}
+    request = WorkflowVersionIngestRequest(
+        script=_INGEST_SCRIPT,
+        entrypoint="graph",
+        runnable_config={"configurable": {"ai_model": "openai:gpt-4.1-mini"}},
+        created_by="admin",
+    )
+
+    await ingest_workflow_version(
+        str(workflow_id),
+        request,
+        _build_capturing_repository(workflow_id, captured),
+        _MOCK_WORKSPACE,
+    )
+
+    assert captured["runnable_config"] == {
+        "configurable": {"ai_model": "openai:gpt-4.1-mini"}
+    }
+    assert "configurable_schema" not in captured["metadata"]
+
+
+@pytest.mark.asyncio()
+async def test_ingest_workflow_version_rejects_schema_without_runtime_default() -> None:
+    """An inline schema with no resolvable runtime value raises a 400."""
+    workflow_id = uuid4()
+    captured: dict[str, object] = {}
+    request = WorkflowVersionIngestRequest(
+        script=_INGEST_SCRIPT,
+        entrypoint="graph",
+        runnable_config={"configurable": {"ai_model": {"type": "string", "enum": []}}},
+        created_by="admin",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await ingest_workflow_version(
+            str(workflow_id),
+            request,
+            _build_capturing_repository(workflow_id, captured),
+            _MOCK_WORKSPACE,
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "no runtime default" in str(exc_info.value.detail)
+
+
 @pytest.mark.asyncio()
 async def test_update_workflow_version_runnable_config_success() -> None:
     """Version runnable-config endpoint persists config-only updates."""

--- a/tests/runtime/test_configurable_schema.py
+++ b/tests/runtime/test_configurable_schema.py
@@ -64,6 +64,18 @@ def test_split_configurable_passes_plain_values_through() -> None:
     assert schema_definitions == {}
 
 
+def test_split_configurable_allows_null_const_default() -> None:
+    """A ``const: null`` schema resolves to a ``None`` runtime value."""
+    resolved, schema_definitions = split_configurable(
+        {"nullable": {"type": ["string", "null"], "const": None}}
+    )
+
+    assert resolved == {"nullable": None}
+    assert schema_definitions == {
+        "nullable": {"type": ["string", "null"], "const": None}
+    }
+
+
 def test_split_configurable_rejects_declaration_without_runtime_default() -> None:
     """A schema annotation that cannot resolve a value raises an error."""
     with pytest.raises(ConfigurableSchemaError, match="no runtime default"):

--- a/tests/runtime/test_configurable_schema.py
+++ b/tests/runtime/test_configurable_schema.py
@@ -1,0 +1,70 @@
+"""Tests for inline configurable-schema resolution."""
+
+from __future__ import annotations
+import pytest
+from orcheo.runtime.configurable_schema import (
+    ConfigurableSchemaError,
+    is_schema_declaration,
+    split_configurable,
+)
+
+
+def test_is_schema_declaration_detects_inline_annotation() -> None:
+    """A mapping with a schema key and a discriminator is a declaration."""
+    assert (
+        is_schema_declaration({"type": "string", "enum": ["a", "b"], "default": "a"})
+        is True
+    )
+
+
+def test_is_schema_declaration_rejects_non_mapping() -> None:
+    """Plain runtime values are never schema declarations."""
+    assert is_schema_declaration("openai:gpt-4.1-mini") is False
+
+
+def test_is_schema_declaration_rejects_mapping_without_schema_keys() -> None:
+    """A mapping carrying no JSON Schema keys stays a runtime value."""
+    assert is_schema_declaration({"label": "Model"}) is False
+
+
+def test_is_schema_declaration_requires_a_discriminator_key() -> None:
+    """Ambiguous schema keys alone are not enough to flag a declaration."""
+    assert is_schema_declaration({"type": "provider", "pattern": "^openai"}) is False
+
+
+def test_split_configurable_resolves_default_const_and_enum() -> None:
+    """Annotated entries resolve via default, const, then the first enum value."""
+    resolved, schema_definitions = split_configurable(
+        {
+            "mode": {"type": "string", "default": "draft"},
+            "variant": {"type": "string", "const": "stable"},
+            "choice": {"type": "string", "enum": ["alpha", "beta"]},
+            "plain": "keep",
+        }
+    )
+
+    assert resolved == {
+        "mode": "draft",
+        "variant": "stable",
+        "choice": "alpha",
+        "plain": "keep",
+    }
+    assert schema_definitions == {
+        "mode": {"type": "string", "default": "draft"},
+        "variant": {"type": "string", "const": "stable"},
+        "choice": {"type": "string", "enum": ["alpha", "beta"]},
+    }
+
+
+def test_split_configurable_passes_plain_values_through() -> None:
+    """A configurable mapping with no annotations yields no schema definitions."""
+    resolved, schema_definitions = split_configurable({"plain": "value"})
+
+    assert resolved == {"plain": "value"}
+    assert schema_definitions == {}
+
+
+def test_split_configurable_rejects_declaration_without_runtime_default() -> None:
+    """A schema annotation that cannot resolve a value raises an error."""
+    with pytest.raises(ConfigurableSchemaError, match="no runtime default"):
+        split_configurable({"mode": {"type": "string", "enum": []}})

--- a/tests/sdk/test_cli_workflow_frontmatter.py
+++ b/tests/sdk/test_cli_workflow_frontmatter.py
@@ -495,71 +495,24 @@ def test_load_from_file_with_invalid_encoding(tmp_path: Path) -> None:
         frontmatter.load_workflow_frontmatter(py_file)
 
 
-def test_is_schema_declaration_requires_explicit_schema_keys() -> None:
-    """Objects with ambiguous keys alone should remain runtime config values."""
-    assert frontmatter._is_schema_declaration({"type": "provider"}) is False
-    assert frontmatter._is_schema_declaration({"pattern": "^openai"}) is False
-
-
-def test_is_schema_declaration_accepts_inline_schema_annotation() -> None:
-    """Inline schema annotations with explicit schema keys are detected."""
-    assert (
-        frontmatter._is_schema_declaration(
-            {"type": "string", "enum": ["a", "b"], "default": "a"}
-        )
-        is True
-    )
-
-
-def test_is_schema_declaration_rejects_non_mapping_values() -> None:
-    """Non-mapping values are never treated as schema declarations."""
-    assert frontmatter._is_schema_declaration("nope") is False
-
-
-def test_is_schema_declaration_rejects_mappings_without_schema_keys() -> None:
-    """Plain mappings without schema keys should not be treated as annotations."""
-    assert frontmatter._is_schema_declaration({"value": "plain"}) is False
-
-
-def test_resolve_frontmatter_config_bundle_merges_inline_and_sibling_schema(
+def test_resolve_frontmatter_config_bundle_forwards_raw_config_and_sibling_schema(
     tmp_path: Path,
 ) -> None:
-    """Inline schema defaults are resolved while sibling schema defs override metadata."""
+    """The config is forwarded verbatim; only the sibling schema file is loaded."""
     workflow = tmp_path / "workflow.py"
     workflow.write_text("# noop\n", encoding="utf-8")
+    config_payload = {
+        "configurable": {
+            "mode": {"type": "string", "default": "inline"},
+            "count": 3,
+        }
+    }
     config_path = tmp_path / "workflow.config.json"
-    config_path.write_text(
-        json.dumps(
-            {
-                "configurable": {
-                    "mode": {
-                        "type": "string",
-                        "default": "inline",
-                    },
-                    "count": {
-                        "type": "integer",
-                        "default": 3,
-                    },
-                }
-            }
-        ),
-        encoding="utf-8",
-    )
+    config_path.write_text(json.dumps(config_payload), encoding="utf-8")
     schema_path = tmp_path / "workflow.config.schema.json"
     schema_path.write_text(
         json.dumps(
-            {
-                "configurable": {
-                    "mode": {
-                        "type": "string",
-                        "default": "schema",
-                    },
-                    "extra": {
-                        "type": "string",
-                        "default": "from-schema",
-                    },
-                }
-            }
+            {"configurable": {"extra": {"type": "string", "default": "from-schema"}}}
         ),
         encoding="utf-8",
     )
@@ -569,17 +522,31 @@ def test_resolve_frontmatter_config_bundle_merges_inline_and_sibling_schema(
         "workflow.config.json",
     )
 
-    assert raw_config == {
-        "configurable": {
-            "mode": "inline",
-            "count": 3,
-        }
-    }
+    # Inline schema annotations are preserved for server-side resolution.
+    assert raw_config == config_payload
     assert schema_definitions == {
-        "mode": {"type": "string", "default": "schema"},
-        "count": {"type": "integer", "default": 3},
         "extra": {"type": "string", "default": "from-schema"},
     }
+
+
+def test_resolve_frontmatter_config_bundle_without_sibling_schema(
+    tmp_path: Path,
+) -> None:
+    """The schema definitions are None when no sibling schema file exists."""
+    workflow = tmp_path / "workflow.py"
+    workflow.write_text("# noop\n", encoding="utf-8")
+    config_path = tmp_path / "workflow.config.json"
+    config_path.write_text(
+        json.dumps({"configurable": {"mode": "plain"}}), encoding="utf-8"
+    )
+
+    raw_config, schema_definitions = frontmatter.resolve_frontmatter_config_bundle(
+        workflow,
+        "workflow.config.json",
+    )
+
+    assert raw_config == {"configurable": {"mode": "plain"}}
+    assert schema_definitions is None
 
 
 def test_resolve_frontmatter_config_bundle_rejects_schema_directory(
@@ -631,66 +598,6 @@ def test_resolve_frontmatter_config_bundle_rejects_non_object_schema_payload(
         frontmatter.resolve_frontmatter_config_bundle(workflow, "workflow.config.json")
 
 
-def test_split_annotated_config_returns_original_when_unannotated() -> None:
-    """Configs without annotated values should pass through unchanged."""
-    config = {"configurable": {"plain": "value"}}
-
-    raw_config, schema_definitions = frontmatter._split_annotated_config(
-        config,
-        config_path="workflow.config.json",
-    )
-
-    assert raw_config == config
-    assert schema_definitions is None
-
-
-def test_split_annotated_config_can_skip_non_mapping_values(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The helper should skip values that fail the mapping guard."""
-    monkeypatch.setattr(frontmatter, "_is_schema_declaration", lambda value: True)
-
-    config = {"configurable": {"broken": 1}}
-    raw_config, schema_definitions = frontmatter._split_annotated_config(
-        config,
-        config_path="workflow.config.json",
-    )
-
-    assert raw_config == config
-    assert schema_definitions is None
-
-
-def test_split_annotated_config_resolves_schema_defaults() -> None:
-    """Annotated values should be replaced with their runtime defaults."""
-    config = {
-        "configurable": {
-            "mode": {"type": "string", "default": "draft"},
-            "variant": {"type": "string", "const": "stable"},
-            "choice": {"type": "string", "enum": ["alpha", "beta"]},
-            "plain": "keep",
-        }
-    }
-
-    raw_config, schema_definitions = frontmatter._split_annotated_config(
-        config,
-        config_path="workflow.config.json",
-    )
-
-    assert raw_config == {
-        "configurable": {
-            "mode": "draft",
-            "variant": "stable",
-            "choice": "alpha",
-            "plain": "keep",
-        }
-    }
-    assert schema_definitions == {
-        "mode": {"type": "string", "default": "draft"},
-        "variant": {"type": "string", "const": "stable"},
-        "choice": {"type": "string", "enum": ["alpha", "beta"]},
-    }
-
-
 def test_normalize_schema_definition_map_uses_payload_when_configurable_missing() -> (
     None
 ):
@@ -706,71 +613,3 @@ def test_normalize_schema_definition_map_rejects_non_object_fields() -> None:
     """Every schema field must be a JSON object."""
     with pytest.raises(frontmatter.CLIError, match="must be an object"):
         frontmatter._normalize_schema_definition_map({"mode": 1}, "schema.json")
-
-
-def test_merge_schema_definitions_prefers_later_entries() -> None:
-    """Later schema maps should overwrite earlier keys."""
-    assert frontmatter._merge_schema_definitions(
-        None,
-        {"mode": {"default": "inline"}},
-        {"mode": {"default": "schema"}, "extra": {"default": "x"}},
-    ) == {
-        "mode": {"default": "schema"},
-        "extra": {"default": "x"},
-    }
-
-
-def test_schema_has_runtime_default_covers_supported_shapes() -> None:
-    """Schema defaults can come from default, const, or enum declarations."""
-    assert frontmatter._schema_has_runtime_default({"default": 1}) is True
-    assert frontmatter._schema_has_runtime_default({"const": "x"}) is True
-    assert frontmatter._schema_has_runtime_default({"enum": ["a"]}) is True
-    assert frontmatter._schema_has_runtime_default({"enum": []}) is False
-
-
-def test_normalize_schema_definition_requires_runtime_default() -> None:
-    """Schema metadata without a runtime default should fail fast."""
-    with pytest.raises(frontmatter.CLIError, match="no runtime default"):
-        frontmatter._normalize_schema_definition(
-            {"type": "string"},
-            key="mode",
-            config_path="workflow.config.json",
-        )
-
-
-def test_resolve_schema_default_covers_all_supported_defaults() -> None:
-    """Runtime defaults resolve from default, const, or enum in that order."""
-    assert (
-        frontmatter._resolve_schema_default(
-            {"default": "draft"},
-            key="mode",
-            config_path="workflow.config.json",
-        )
-        == "draft"
-    )
-    assert (
-        frontmatter._resolve_schema_default(
-            {"const": "stable"},
-            key="mode",
-            config_path="workflow.config.json",
-        )
-        == "stable"
-    )
-    assert (
-        frontmatter._resolve_schema_default(
-            {"enum": ["alpha", "beta"]},
-            key="mode",
-            config_path="workflow.config.json",
-        )
-        == "alpha"
-    )
-
-
-def test_resolve_schema_default_raises_without_runtime_default() -> None:
-    """Missing runtime defaults should raise a CLIError."""
-    with pytest.raises(frontmatter.CLIError, match="no runtime default"):
-        frontmatter._resolve_schema_default(
-            {},
-            key="mode",
-            config_path="workflow.config.json",
-        )


### PR DESCRIPTION
## Summary
- Inline JSON Schema annotations in a workflow's `configurable` map were only resolved by the SDK CLI upload path. Canvas → ingest (colleague-candidate onboarding, file upload) stored raw annotated config, so the runtime saw `type`/`enum`/`title` as values and the config form couldn't render typed widgets (e.g. select).
- Adds `src/orcheo/runtime/configurable_schema.py` with `split_configurable` / `is_schema_declaration` / `ConfigurableSchemaError` to separate runtime values from schema declarations in a single place.
- Calls the split from the shared `ingest_workflow_version` endpoint in `apps/backend/.../routers/workflows.py`, so CLI upload, candidate onboarding, and Canvas file upload all resolve annotations consistently and lift schema metadata into the version's `configurable_schema` metadata. A caller-supplied sibling `*.schema.json` (via `metadata.configurable_schema`) still wins over inferred annotations.
- Trims the now-redundant inline split logic out of `apps/sdk/.../cli/workflow/frontmatter.py`, leaving only the file-only sibling `*.schema.json` loader on the SDK side (~150 LOC removed).
- Adds runtime unit tests (`tests/runtime/test_configurable_schema.py`), backend ingest tests covering annotation lifting + merge precedence (`tests/backend/test_app_workflow_versions_create.py`), and prunes the SDK tests that previously covered the inline split.