### PR TITLE
Route sandbox execution through a dedicated runtime service

### DIFF
--- a/Dockerfile.sandbox-runtime
+++ b/Dockerfile.sandbox-runtime
@@ -8,8 +8,10 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
+    docker-cli \
     docker.io \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && docker --version
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
@@ -17,7 +19,7 @@ COPY pyproject.toml uv.lock README.md ./
 COPY packages/ packages/
 COPY apps/backend/ apps/backend/
 
-RUN uv sync --frozen --no-dev
+RUN uv sync --frozen --no-dev --group sandbox-runtime
 
 COPY src/ src/
 

--- a/Dockerfile.sandbox-runtime
+++ b/Dockerfile.sandbox-runtime
@@ -1,7 +1,31 @@
-FROM alpine:3.20
+FROM python:3.12-slim
 
-WORKDIR /scratch
+WORKDIR /app
 
-# This sidecar currently only reserves the Docker socket mount so compose can
-# start without depending on a private registry image.
-CMD ["sh", "-c", "trap : TERM INT; tail -f /dev/null"]
+# We talk to the host Docker engine over /var/run/docker.sock and shell out
+# to `docker exec` for in-sandbox commands. The runtime service is the ONLY
+# Orcheo container that mounts the socket (root-equivalent on the host).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    docker.io \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+COPY pyproject.toml uv.lock README.md ./
+COPY packages/ packages/
+COPY apps/backend/ apps/backend/
+
+RUN uv sync --frozen --no-dev
+
+COPY src/ src/
+
+ENV PYTHONPATH=/app/src:/app/apps/backend/src \
+    PATH=/app/.venv/bin:$PATH \
+    ORCHEO_SANDBOX_RUNTIME_HOST=0.0.0.0 \
+    ORCHEO_SANDBOX_RUNTIME_PORT=9090
+
+EXPOSE 9090
+
+CMD ["uv", "run", "uvicorn", "orcheo.sandbox.service:build_service_app", "--factory", "--host", "0.0.0.0", "--port", "9090"]

--- a/Dockerfile.workspace-sandbox
+++ b/Dockerfile.workspace-sandbox
@@ -11,7 +11,6 @@
 
 FROM python:3.12-slim AS base
 
-ARG ORCHEO_VERSION=latest
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
@@ -37,15 +36,18 @@ RUN npm install --global \
         @google/gemini-cli \
     && npm cache clean --force
 
-# Install Orcheo (workflow runner) + SDK / CLI.
+# Install Orcheo (workflow runner) + SDK / CLI from this checkout. Sandboxes
+# must run the same code as the runtime that dispatches into them.
+COPY pyproject.toml README.md ./
+COPY src/ src/
+COPY packages/ packages/
 RUN pip install --upgrade pip \
-    && pip install \
-        "orcheo==${ORCHEO_VERSION}" \
-        "orcheo-sdk==${ORCHEO_VERSION}" || pip install orcheo orcheo-sdk
+    && pip install . packages/agentensor packages/sdk
 
 USER orcheo
 WORKDIR /workspace
 
-# Default entrypoint starts the workflow runner stdin loop. The Sandbox
-# Runtime Manager overrides CMD via `docker exec` for agent sessions.
-ENTRYPOINT ["python", "-m", "orcheo.sandbox.workflow_runner"]
+# The runtime leases this container and uses `docker exec` for agent sessions
+# and workflow-runner invocations. Keep PID 1 idle so detached startup does
+# not close stdin and end the sandbox before the first exec arrives.
+CMD ["tail", "-f", "/dev/null"]

--- a/Makefile
+++ b/Makefile
@@ -59,16 +59,15 @@ docker-down:
 docker-restart:
 	docker compose restart
 
-docker-build: workspace-sandbox-build
+docker-build:
 	docker compose build
 
-# Build the workspace-sandbox image that the sandbox-runtime service
-# spawns on demand. The image is declared under the `build-only` profile so
-# `docker compose up` ignores it; this target explicitly opts the profile
-# in for the build phase. Run this once after cloning, then again whenever
-# Dockerfile.workspace-sandbox changes.
+# Build just the workspace-sandbox image that the sandbox-runtime service
+# spawns on demand. `docker-build` already covers this; keep the target for
+# operators who only want to rebuild this one image after editing
+# Dockerfile.workspace-sandbox.
 workspace-sandbox-build:
-	docker compose --profile build-only build workspace-sandbox
+	docker compose build workspace-sandbox
 
 docker-logs:
 	docker compose logs -f

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: dev-server test lint format canvas-lint canvas-format canvas-test redis worker celery-beat \
-       docker-up docker-down docker-build docker-logs staging-env staging-up staging-down staging-restart \
+       docker-up docker-down docker-build docker-logs workspace-sandbox-build \
+       staging-env staging-up staging-down staging-restart \
        staging-build staging-logs staging-config
 
 UV ?= uv
@@ -58,8 +59,16 @@ docker-down:
 docker-restart:
 	docker compose restart
 
-docker-build:
+docker-build: workspace-sandbox-build
 	docker compose build
+
+# Build the workspace-sandbox image that the sandbox-runtime service
+# spawns on demand. The image is declared under the `build-only` profile so
+# `docker compose up` ignores it; this target explicitly opts the profile
+# in for the build phase. Run this once after cloning, then again whenever
+# Dockerfile.workspace-sandbox changes.
+workspace-sandbox-build:
+	docker compose --profile build-only build workspace-sandbox
 
 docker-logs:
 	docker compose logs -f

--- a/apps/backend/src/orcheo_backend/app/chatkit/workflow_executor.py
+++ b/apps/backend/src/orcheo_backend/app/chatkit/workflow_executor.py
@@ -19,6 +19,7 @@ from orcheo.nodes.ai.tools.context import tool_progress_context
 from orcheo.persistence import create_checkpointer, create_graph_store
 from orcheo.runtime.credentials import CredentialResolver, credential_resolution
 from orcheo.runtime.runnable_config import merge_runnable_configs
+from orcheo.sandbox.dispatch import use_launcher
 from orcheo.vault import BaseCredentialVault
 from orcheo_backend.app.chatkit.message_utils import (
     build_initial_state,
@@ -44,6 +45,12 @@ from orcheo_backend.app.repository import (
     WorkflowNotFoundError,
     WorkflowRepository,
     WorkflowRun,
+)
+from orcheo_backend.app.sandbox import (
+    build_workflow_run_spec,
+    ensure_sandbox_configured,
+    get_sandbox_dispatcher,
+    get_sandbox_launcher,
 )
 
 
@@ -368,7 +375,35 @@ class WorkflowExecutor:
         step_callback: Callable[[Mapping[str, Any]], Awaitable[None]] | None,
         workspace_id: str | None = None,
     ) -> Any:
-        """Execute the compiled graph and return the final state payload."""
+        """Execute the compiled graph and return the final state payload.
+
+        Routes through the per-workspace sandbox dispatcher when the graph
+        contains anything other than trusted built-in node types (or when the
+        operator's fast-path flag is off). For trusted-only graphs the
+        execution still runs in-process but with the sandbox launcher bound so
+        any ``ExternalAgentNode`` (vibe-agent) subprocess is itself confined
+        to the workspace sandbox.
+        """
+        ensure_sandbox_configured()
+        spec = build_workflow_run_spec(
+            execution_id=str(uuid4()),
+            workspace_id=workspace_id or "",
+            graph_config=dict(graph_config),
+            inputs=dict(inputs),
+            runnable_config=dict(config),
+            state_config=dict(state_config),
+        )
+        dispatcher = get_sandbox_dispatcher()
+        if dispatcher.should_sandbox(spec):
+            if not workspace_id:
+                msg = "workspace_id is required to dispatch a sandboxed ChatKit run"
+                raise RuntimeError(msg)
+            return await self._dispatch_sandboxed(
+                dispatcher=dispatcher,
+                spec=spec,
+                step_callback=step_callback,
+            )
+
         settings = get_settings()
         vault = self._vault_provider()
         credential_context = CredentialAccessContext(
@@ -400,6 +435,7 @@ class WorkflowExecutor:
                     )
 
                 with (
+                    use_launcher(get_sandbox_launcher()),
                     _patched_environment(external_agent_environ),
                     credential_resolution(credential_resolver),
                 ):
@@ -427,6 +463,35 @@ class WorkflowExecutor:
                             return getattr(snapshot, "values", snapshot)
 
                     return await compiled.ainvoke(payload, config=config)
+
+    @staticmethod
+    async def _dispatch_sandboxed(
+        *,
+        dispatcher: Any,
+        spec: Any,
+        step_callback: Callable[[Mapping[str, Any]], Awaitable[None]] | None,
+    ) -> Mapping[str, Any]:
+        """Run ``spec`` through the per-workspace sandbox dispatcher.
+
+        The sandbox returns a single ``WorkflowRunResult`` instead of a stream;
+        we surface a single ``sandbox_result`` step so the chat surface still
+        sees progress, then return the aggregated outputs as the final state.
+        Failure inside the sandbox is raised so the caller's error path fires.
+        """
+        result = await dispatcher.dispatch(spec)
+        payload: dict[str, Any] = {
+            "event": "sandbox_result",
+            "status": result.status,
+            "outputs": dict(result.outputs),
+        }
+        if result.error:
+            payload["error"] = result.error
+        if step_callback is not None:
+            await step_callback(payload)
+        if result.status != "succeeded":
+            msg = result.error or f"sandboxed run finished with {result.status}"
+            raise RuntimeError(msg)
+        return dict(result.outputs)
 
     async def _mark_run_succeeded(
         self,

--- a/apps/backend/src/orcheo_backend/app/factory.py
+++ b/apps/backend/src/orcheo_backend/app/factory.py
@@ -78,6 +78,7 @@ from orcheo_backend.app.routers import (
 from orcheo_backend.app.routers import (
     workspaces as workspaces_router,
 )
+from orcheo_backend.app.sandbox import configure_sandbox
 from orcheo_backend.app.service_token_endpoints import router as service_token_router
 from orcheo_backend.app.workflow_execution import configure_sensitive_logging
 from orcheo_backend.app.workspace import (
@@ -194,7 +195,14 @@ def _build_credential_broker() -> CredentialBroker:
                 return vault.reveal_secret(credential_id=metadata.id, context=context)
         raise KeyError(credential_name)
 
-    broker_secret = os.getenv("ORCHEO_CREDENTIAL_BROKER_SECRET", "dev-insecure-secret")
+    broker_secret = os.getenv("ORCHEO_CREDENTIAL_BROKER_SECRET")
+    if not broker_secret:
+        msg = (
+            "ORCHEO_CREDENTIAL_BROKER_SECRET is not set. Sandboxing is always on; "
+            "generate a secret with `python -m orcheo.sandbox.broker --gen-secret` "
+            "and export it before starting the backend."
+        )
+        raise RuntimeError(msg)
     return CredentialBroker(secret=broker_secret, resolver=_resolve_credential)
 
 
@@ -282,9 +290,9 @@ def _configure_application(application: FastAPI) -> None:
     application.include_router(triggers.workspace_webhook_router)
     application.include_router(chatkit_assets.router)
     application.include_router(websocket.router)
-    application.include_router(
-        build_credential_broker_router(_build_credential_broker())
-    )
+    broker = _build_credential_broker()
+    configure_sandbox(broker)
+    application.include_router(build_credential_broker_router(broker))
     application.add_exception_handler(
         AuthenticationError, _authentication_error_handler
     )

--- a/apps/backend/src/orcheo_backend/app/factory.py
+++ b/apps/backend/src/orcheo_backend/app/factory.py
@@ -6,16 +6,13 @@ import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import cast
-from uuid import UUID
 from dotenv import load_dotenv
 from fastapi import APIRouter, Depends, FastAPI, Request, Response
 from fastapi.exception_handlers import http_exception_handler
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import PlainTextResponse
 from orcheo.agentensor.checkpoints import AgentensorCheckpointStore
-from orcheo.models.credential_scope import CredentialAccessContext
 from orcheo.plugins import load_enabled_plugins
-from orcheo.sandbox.broker import CredentialBroker
 from orcheo.vault.oauth import OAuthCredentialService
 from orcheo_backend.app.authentication import (
     AuthenticationError,
@@ -78,7 +75,7 @@ from orcheo_backend.app.routers import (
 from orcheo_backend.app.routers import (
     workspaces as workspaces_router,
 )
-from orcheo_backend.app.sandbox import configure_sandbox
+from orcheo_backend.app.sandbox import build_credential_broker, configure_sandbox
 from orcheo_backend.app.service_token_endpoints import router as service_token_router
 from orcheo_backend.app.workflow_execution import configure_sensitive_logging
 from orcheo_backend.app.workspace import (
@@ -181,31 +178,6 @@ def _build_api_router() -> APIRouter:
 api_router = _build_api_router()
 
 
-def _build_credential_broker() -> CredentialBroker:
-    """Create a process-local credential broker for sandbox credential resolution."""
-
-    def _resolve_credential(*, workspace_id: str, credential_name: str) -> str:
-        vault = get_vault()
-        context = CredentialAccessContext(workspace_id=UUID(workspace_id))
-        for metadata in vault.list_credentials(
-            context=context,
-            workspace_id=workspace_id,
-        ):
-            if metadata.name == credential_name:
-                return vault.reveal_secret(credential_id=metadata.id, context=context)
-        raise KeyError(credential_name)
-
-    broker_secret = os.getenv("ORCHEO_CREDENTIAL_BROKER_SECRET")
-    if not broker_secret:
-        msg = (
-            "ORCHEO_CREDENTIAL_BROKER_SECRET is not set. Sandboxing is always on; "
-            "generate a secret with `python -m orcheo.sandbox.broker --gen-secret` "
-            "and export it before starting the backend."
-        )
-        raise RuntimeError(msg)
-    return CredentialBroker(secret=broker_secret, resolver=_resolve_credential)
-
-
 _DEFAULT_ALLOWED_ORIGINS = [
     "http://localhost:2026",
     "http://127.0.0.1:2026",
@@ -290,7 +262,7 @@ def _configure_application(application: FastAPI) -> None:
     application.include_router(triggers.workspace_webhook_router)
     application.include_router(chatkit_assets.router)
     application.include_router(websocket.router)
-    broker = _build_credential_broker()
+    broker = build_credential_broker()
     configure_sandbox(broker)
     application.include_router(build_credential_broker_router(broker))
     application.add_exception_handler(

--- a/apps/backend/src/orcheo_backend/app/sandbox.py
+++ b/apps/backend/src/orcheo_backend/app/sandbox.py
@@ -24,6 +24,8 @@ import os
 from collections.abc import Iterable
 from threading import Lock
 from typing import Any
+from uuid import UUID
+from orcheo.models.credential_scope import CredentialAccessContext
 from orcheo.sandbox.broker import CredentialBroker
 from orcheo.sandbox.config import SandboxSettings
 from orcheo.sandbox.errors import SandboxError
@@ -39,6 +41,7 @@ from orcheo.sandbox.workflow import (
     WorkflowRunSpec,
     WorkflowSandboxDispatcher,
 )
+from orcheo_backend.app.dependencies import get_vault
 
 
 logger = logging.getLogger(__name__)
@@ -82,7 +85,7 @@ class _SandboxBootstrap:
             self._runtime = RemoteContainerRuntime(self._runtime_url())
             self._manager = SandboxRuntimeManager(
                 runtime=self._runtime,
-                settings=SandboxSettings(),
+                settings=SandboxSettings.from_env(),
             )
         return self._manager
 
@@ -160,10 +163,10 @@ def collect_node_types(graph_config: Any) -> tuple[str, ...]:
     """Pull the unique node-type names from a graph config dict.
 
     Used by callers to decide whether ``WorkflowSandboxDispatcher`` will
-    fast-path a run. The set is intentionally tolerant: missing or malformed
-    nodes default to an empty list, in which case the dispatcher treats the
-    run as trusted (no untrusted nodes ⇒ no forced sandbox), and the
-    operator's ``ORCHEO_SANDBOX_FAST_PATH_TRUSTED`` setting decides routing.
+    fast-path a run. Returns ``()`` for missing/malformed graphs; downstream
+    decision helpers (``run_uses_trusted_nodes_only`` /
+    ``WorkflowSandboxDispatcher.should_sandbox``) treat an empty tuple as
+    untrusted so an unclassifiable graph always lands in the sandbox.
     """
     if not isinstance(graph_config, dict):
         return ()
@@ -183,6 +186,8 @@ def build_workflow_run_spec(
     workspace_id: str,
     graph_config: dict[str, Any],
     inputs: dict[str, Any],
+    runnable_config: dict[str, Any] | None = None,
+    state_config: dict[str, Any] | None = None,
 ) -> WorkflowRunSpec:
     """Build a ``WorkflowRunSpec`` for the dispatcher."""
     return WorkflowRunSpec(
@@ -191,12 +196,62 @@ def build_workflow_run_spec(
         workflow_definition=graph_config,
         inputs=inputs,
         node_types=collect_node_types(graph_config),
+        runnable_config=runnable_config or {},
+        state_config=state_config or {},
     )
 
 
+def build_credential_broker() -> CredentialBroker:
+    """Build a credential broker bound to the process-local vault.
+
+    Both the FastAPI application and the Celery worker call this helper so
+    sandboxed runs can resolve credentials through a shared, workspace-pinned
+    broker. The lookup is performed lazily — ``get_vault`` is re-resolved via
+    this module on every call so test overrides (which monkeypatch
+    ``orcheo_backend.app.sandbox.get_vault``) and runtime rebinding both work.
+    """
+
+    def _resolve_credential(*, workspace_id: str, credential_name: str) -> str:
+        vault = get_vault()
+        context = CredentialAccessContext(workspace_id=UUID(workspace_id))
+        for metadata in vault.list_credentials(
+            context=context,
+            workspace_id=workspace_id,
+        ):
+            if metadata.name == credential_name:
+                return vault.reveal_secret(credential_id=metadata.id, context=context)
+        raise KeyError(credential_name)
+
+    broker_secret = os.getenv("ORCHEO_CREDENTIAL_BROKER_SECRET")
+    if not broker_secret:
+        msg = (
+            "ORCHEO_CREDENTIAL_BROKER_SECRET is not set. Sandboxing is always on; "
+            "generate a secret with `python -m orcheo.sandbox.broker --gen-secret` "
+            "and export it before starting the backend or worker."
+        )
+        raise RuntimeError(msg)
+    return CredentialBroker(secret=broker_secret, resolver=_resolve_credential)
+
+
+def ensure_sandbox_configured() -> None:
+    """Wire the shared sandbox bootstrap with a fresh broker if unconfigured.
+
+    Safe to call from any entry point — the underlying bootstrap stores a
+    single broker reference behind a lock, so repeated calls are no-ops.
+    """
+    if _bootstrap._broker is None:  # noqa: SLF001 — module-private cache
+        configure_sandbox(build_credential_broker())
+
+
 def run_uses_trusted_nodes_only(node_types: Iterable[str]) -> bool:
-    """Return True iff every node type is in ``TRUSTED_NODE_TYPES``."""
+    """Return True iff every node type is in ``TRUSTED_NODE_TYPES``.
+
+    Fails closed for empty input: an unclassifiable graph (no node types
+    parsed) is treated as untrusted so it cannot silently take the in-worker
+    fast path. Mirrors ``orcheo.sandbox.workflow.requires_sandbox`` so the
+    backend and dispatcher agree on what "trusted-only" means.
+    """
     types = list(node_types)
     if not types:
-        return True
+        return False
     return all(node_type in TRUSTED_NODE_TYPES for node_type in types)

--- a/apps/backend/src/orcheo_backend/app/sandbox.py
+++ b/apps/backend/src/orcheo_backend/app/sandbox.py
@@ -1,0 +1,202 @@
+"""Shared sandbox runtime wiring for the backend / worker processes.
+
+This module owns the *single* set of sandbox primitives used by every
+workflow execution path:
+
+- one :class:`SandboxRuntimeManager` backed by
+  :class:`RemoteContainerRuntime`,
+- one :class:`SandboxedProcessLauncher` for ``ExternalAgentNode``,
+- one :class:`WorkflowSandboxDispatcher` for tenant-authored workflow runs.
+
+Centralizing the construction here keeps Docker-socket access out of the
+backend (per the design's container-runtime socket note) and ensures all
+call sites share lease accounting.
+
+The dispatcher routes runs through a per-workspace gVisor sandbox by
+default. Operators may opt trusted-only graphs into an in-worker fast path
+by setting ``ORCHEO_SANDBOX_FAST_PATH_TRUSTED=true`` — this matches the
+design's Open Issue #1 (fast path vs uniform routing) and is otherwise off.
+"""
+
+from __future__ import annotations
+import logging
+import os
+from collections.abc import Iterable
+from threading import Lock
+from typing import Any
+from orcheo.sandbox.broker import CredentialBroker
+from orcheo.sandbox.config import SandboxSettings
+from orcheo.sandbox.errors import SandboxError
+from orcheo.sandbox.launcher import SandboxedProcessLauncher
+from orcheo.sandbox.manager import SandboxRuntimeManager
+from orcheo.sandbox.remote import (
+    RemoteContainerRuntime,
+    RemoteSandboxExec,
+    RemoteSandboxRunner,
+)
+from orcheo.sandbox.workflow import (
+    TRUSTED_NODE_TYPES,
+    WorkflowRunSpec,
+    WorkflowSandboxDispatcher,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+class SandboxRuntimeNotConfiguredError(SandboxError):
+    """Raised when sandbox primitives are requested without configuration."""
+
+
+class _SandboxBootstrap:
+    """Lazily build and cache the per-process sandbox primitives."""
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._manager: SandboxRuntimeManager | None = None
+        self._launcher: SandboxedProcessLauncher | None = None
+        self._dispatcher: WorkflowSandboxDispatcher | None = None
+        self._runtime: RemoteContainerRuntime | None = None
+        self._exec_backend: RemoteSandboxExec | None = None
+        self._runner: RemoteSandboxRunner | None = None
+        self._broker: CredentialBroker | None = None
+
+    def configure(self, broker: CredentialBroker) -> None:
+        """Bind the credential broker. Must be called before dispatcher use."""
+        with self._lock:
+            self._broker = broker
+
+    def _runtime_url(self) -> str:
+        url = os.getenv("ORCHEO_SANDBOX_RUNTIME_URL")
+        if not url:
+            msg = (
+                "ORCHEO_SANDBOX_RUNTIME_URL is not set. Sandboxing is always on; "
+                "point this at the sandbox-runtime service (e.g. "
+                "http://sandbox-runtime:9090) before starting the backend."
+            )
+            raise SandboxRuntimeNotConfiguredError(msg)
+        return url
+
+    def _ensure_manager(self) -> SandboxRuntimeManager:
+        if self._manager is None:
+            self._runtime = RemoteContainerRuntime(self._runtime_url())
+            self._manager = SandboxRuntimeManager(
+                runtime=self._runtime,
+                settings=SandboxSettings(),
+            )
+        return self._manager
+
+    def launcher(self) -> SandboxedProcessLauncher:
+        """Return the shared ``SandboxedProcessLauncher``."""
+        with self._lock:
+            if self._launcher is None:
+                manager = self._ensure_manager()
+                self._exec_backend = RemoteSandboxExec(self._runtime_url())
+                self._launcher = SandboxedProcessLauncher(
+                    manager, exec_backend=self._exec_backend
+                )
+            return self._launcher
+
+    def dispatcher(self) -> WorkflowSandboxDispatcher:
+        """Return the shared ``WorkflowSandboxDispatcher``."""
+        with self._lock:
+            if self._dispatcher is None:
+                if self._broker is None:
+                    msg = (
+                        "Sandbox dispatcher requested before the credential broker "
+                        "was configured. Call configure_sandbox(broker) first."
+                    )
+                    raise SandboxRuntimeNotConfiguredError(msg)
+                manager = self._ensure_manager()
+                self._runner = RemoteSandboxRunner(self._runtime_url())
+                self._dispatcher = WorkflowSandboxDispatcher(
+                    manager,
+                    self._runner,
+                    self._broker,
+                    allow_in_worker_fast_path=_fast_path_enabled(),
+                )
+            return self._dispatcher
+
+
+_bootstrap = _SandboxBootstrap()
+
+
+def configure_sandbox(broker: CredentialBroker) -> None:
+    """Bind the credential broker into the shared sandbox bootstrap."""
+    _bootstrap.configure(broker)
+
+
+def get_sandbox_launcher() -> SandboxedProcessLauncher:
+    """Return the shared sandbox launcher."""
+    return _bootstrap.launcher()
+
+
+def get_sandbox_dispatcher() -> WorkflowSandboxDispatcher:
+    """Return the shared workflow-sandbox dispatcher."""
+    return _bootstrap.dispatcher()
+
+
+def reset_sandbox_bootstrap() -> None:
+    """Reset the cached bootstrap. Test-only — never call from runtime code."""
+    global _bootstrap  # noqa: PLW0603
+    _bootstrap = _SandboxBootstrap()
+
+
+def install_sandbox_bootstrap(bootstrap: _SandboxBootstrap) -> None:
+    """Replace the bootstrap with a pre-built instance. Test-only injection point."""
+    global _bootstrap  # noqa: PLW0603
+    _bootstrap = bootstrap
+
+
+def _fast_path_enabled() -> bool:
+    return os.getenv("ORCHEO_SANDBOX_FAST_PATH_TRUSTED", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+
+
+def collect_node_types(graph_config: Any) -> tuple[str, ...]:
+    """Pull the unique node-type names from a graph config dict.
+
+    Used by callers to decide whether ``WorkflowSandboxDispatcher`` will
+    fast-path a run. The set is intentionally tolerant: missing or malformed
+    nodes default to an empty list, in which case the dispatcher treats the
+    run as trusted (no untrusted nodes ⇒ no forced sandbox), and the
+    operator's ``ORCHEO_SANDBOX_FAST_PATH_TRUSTED`` setting decides routing.
+    """
+    if not isinstance(graph_config, dict):
+        return ()
+    seen: list[str] = []
+    nodes: Iterable[Any] = graph_config.get("nodes") or []
+    for node in nodes:
+        if isinstance(node, dict):
+            node_type = node.get("type") or node.get("kind")
+            if isinstance(node_type, str) and node_type not in seen:
+                seen.append(node_type)
+    return tuple(seen)
+
+
+def build_workflow_run_spec(
+    *,
+    execution_id: str,
+    workspace_id: str,
+    graph_config: dict[str, Any],
+    inputs: dict[str, Any],
+) -> WorkflowRunSpec:
+    """Build a ``WorkflowRunSpec`` for the dispatcher."""
+    return WorkflowRunSpec(
+        run_id=execution_id,
+        workspace_id=workspace_id,
+        workflow_definition=graph_config,
+        inputs=inputs,
+        node_types=collect_node_types(graph_config),
+    )
+
+
+def run_uses_trusted_nodes_only(node_types: Iterable[str]) -> bool:
+    """Return True iff every node type is in ``TRUSTED_NODE_TYPES``."""
+    types = list(node_types)
+    if not types:
+        return True
+    return all(node_type in TRUSTED_NODE_TYPES for node_type in types)

--- a/apps/backend/src/orcheo_backend/app/workflow_execution.py
+++ b/apps/backend/src/orcheo_backend/app/workflow_execution.py
@@ -27,9 +27,7 @@ from orcheo.runtime.runnable_config import (
 )
 from orcheo.runtime.state_builder import build_initial_state
 from orcheo.sandbox.dispatch import use_launcher
-from orcheo.sandbox.launcher import SandboxedProcessLauncher
-from orcheo.sandbox.manager import SandboxRuntimeManager
-from orcheo.sandbox.runtime import InMemoryContainerRuntime
+from orcheo.sandbox.workflow import WorkflowRunResult
 from orcheo.tracing import (
     get_tracer,
     record_workflow_cancellation,
@@ -60,11 +58,16 @@ from orcheo_backend.app.history import (
     RunHistoryStep,
     RunHistoryStore,
 )
+from orcheo_backend.app.sandbox import (
+    build_workflow_run_spec,
+    get_sandbox_dispatcher,
+    get_sandbox_launcher,
+    run_uses_trusted_nodes_only,
+)
 from orcheo_backend.app.trace_utils import build_trace_update
 
 
 logger = logging.getLogger(__name__)
-_sandbox_launcher: SandboxedProcessLauncher | None = None
 
 
 @contextmanager
@@ -124,14 +127,64 @@ def _log_final_state_debug(state_values: Mapping[str, Any] | Any) -> None:
     app_logger.debug("=" * 80)
 
 
-def _get_sandbox_launcher() -> SandboxedProcessLauncher:
-    """Return a shared sandbox launcher used by external-agent nodes."""
-    global _sandbox_launcher  # noqa: PLW0603
-    if _sandbox_launcher is None:
-        _sandbox_launcher = SandboxedProcessLauncher(
-            SandboxRuntimeManager(runtime=InMemoryContainerRuntime())
+def _get_sandbox_launcher() -> Any:
+    """Return the shared sandbox launcher (delegates to the bootstrap)."""
+    return get_sandbox_launcher()
+
+
+async def _dispatch_sandboxed_run(
+    *,
+    workspace_id: str,
+    execution_id: str,
+    graph_config: dict[str, Any],
+    inputs: dict[str, Any],
+    history_store: RunHistoryStore,
+    websocket: WebSocket,
+    tracer: Tracer,
+    span: Span,
+) -> WorkflowRunResult:
+    """Run a workflow inside the per-workspace sandbox via the dispatcher.
+
+    The dispatcher returns a single ``WorkflowRunResult`` (no live streaming
+    from inside the sandbox). We persist a single ``sandbox_result`` step so
+    history clients still see something, then surface success / failure to
+    the caller for normal completion handling.
+    """
+    dispatcher = get_sandbox_dispatcher()
+    spec = build_workflow_run_spec(
+        execution_id=execution_id,
+        workspace_id=workspace_id,
+        graph_config=graph_config,
+        inputs=inputs,
+    )
+    result = await dispatcher.dispatch(spec)
+    payload: dict[str, Any] = {
+        "event": "sandbox_result",
+        "status": result.status,
+        "outputs": dict(result.outputs),
+    }
+    if result.error:
+        payload["error"] = result.error
+    record_workflow_step(tracer, payload)
+    history_step = await history_store.append_step(execution_id, payload)
+    await _safe_send_json(websocket, _sanitize_public_step_payload(payload))
+    await _emit_trace_update(
+        history_store,
+        websocket,
+        execution_id,
+        step=history_step,
+    )
+    if result.status != "succeeded":
+        error_message = result.error or f"sandboxed run finished with {result.status}"
+        record_workflow_failure(span, RuntimeError(error_message))
+        await _persist_failure_history(
+            history_store,
+            execution_id,
+            {"status": "error", "error": error_message},
+            error_message,
+            span,
         )
-    return _sandbox_launcher
+    return result
 
 
 _CANNOT_SEND_AFTER_CLOSE = 'Cannot call "send" once a close message has been sent.'
@@ -421,6 +474,93 @@ async def _resolve_stored_runnable_config(
     return version.runnable_config
 
 
+async def _execute_sandboxed_workflow(
+    *,
+    workspace_id: str,
+    execution_id: str,
+    graph_config: dict[str, Any],
+    inputs: dict[str, Any],
+    history_store: RunHistoryStore,
+    websocket: WebSocket,
+    tracer: Tracer,
+    span: Span,
+) -> None:
+    """Dispatch a workflow into the per-workspace sandbox and finalize history."""
+    result = await _dispatch_sandboxed_run(
+        workspace_id=workspace_id,
+        execution_id=execution_id,
+        graph_config=graph_config,
+        inputs=inputs,
+        history_store=history_store,
+        websocket=websocket,
+        tracer=tracer,
+        span=span,
+    )
+    if result.status == "succeeded":
+        completion_payload = {"status": "completed"}
+        record_workflow_completion(span)
+        await history_store.append_step(execution_id, completion_payload)
+        await history_store.mark_completed(execution_id)
+        await _safe_send_json(websocket, completion_payload)  # pragma: no cover
+    await _emit_trace_update(
+        history_store,
+        websocket,
+        execution_id,
+        include_root=True,
+        complete=True,
+    )
+
+
+async def _execute_trusted_workflow_in_worker(
+    *,
+    settings: Any,
+    graph_config: dict[str, Any],
+    inputs: dict[str, Any],
+    runtime_config: RunnableConfig,
+    state_config: Mapping[str, Any],
+    history_store: RunHistoryStore,
+    websocket: WebSocket,
+    execution_id: str,
+    tracer: Tracer,
+    span: Span,
+    resolver: CredentialResolver,
+    workspace_id: str | None,
+) -> None:
+    """Run a trusted-only workflow in-worker with the existing streaming path."""
+    from orcheo_backend.app import build_graph, create_checkpointer, create_graph_store
+
+    external_agent_environ = _external_agent_provider_environment(workspace_id)
+    with use_launcher(_get_sandbox_launcher()):
+        with scoped_external_agent_environment(external_agent_environ):
+            with credential_resolution(resolver):
+                async with create_checkpointer(settings) as checkpointer:
+                    async with create_graph_store(settings) as graph_store:
+                        graph = build_graph(graph_config)
+                        compiled_graph = graph.compile(
+                            checkpointer=checkpointer,
+                            store=graph_store,
+                        )
+
+                    state = _build_initial_state(
+                        graph_config,
+                        inputs,
+                        state_config,
+                        workspace_id,
+                    )
+                    _log_sensitive_debug("Initial state: %s", state)
+
+                    await _run_workflow_stream(
+                        compiled_graph,
+                        state,
+                        runtime_config,
+                        history_store,
+                        execution_id,
+                        websocket,
+                        tracer,
+                        span,
+                    )
+
+
 async def execute_workflow(
     workflow_id: str,
     graph_config: dict[str, Any],
@@ -432,8 +572,6 @@ async def execute_workflow(
     stored_runnable_config: Mapping[str, Any] | RunnableConfigModel | None = None,
 ) -> None:
     """Execute a workflow and stream results over the provided websocket."""
-    from orcheo_backend.app import build_graph, create_checkpointer, create_graph_store
-
     logger.info("Starting workflow %s with execution_id: %s", workflow_id, execution_id)
     _log_sensitive_debug("Initial inputs: %s", inputs)
 
@@ -496,36 +634,42 @@ async def execute_workflow(
                 include_root=True,
             )
 
-            external_agent_environ = _external_agent_provider_environment(workspace_id)
-            with use_launcher(_get_sandbox_launcher()):
-                with scoped_external_agent_environment(external_agent_environ):
-                    with credential_resolution(resolver):
-                        async with create_checkpointer(settings) as checkpointer:
-                            async with create_graph_store(settings) as graph_store:
-                                graph = build_graph(graph_config)
-                                compiled_graph = graph.compile(
-                                    checkpointer=checkpointer,
-                                    store=graph_store,
-                                )
+            spec = build_workflow_run_spec(
+                execution_id=execution_id,
+                workspace_id=workspace_id or "",
+                graph_config=graph_config,
+                inputs=inputs,
+            )
+            if not run_uses_trusted_nodes_only(spec.node_types):
+                if not workspace_id:
+                    msg = "workspace_id is required to dispatch a workflow run"
+                    raise RuntimeError(msg)
+                await _execute_sandboxed_workflow(
+                    workspace_id=workspace_id,
+                    execution_id=execution_id,
+                    graph_config=graph_config,
+                    inputs=inputs,
+                    history_store=history_store,
+                    websocket=websocket,
+                    tracer=tracer,
+                    span=span_context.span,
+                )
+                return
 
-                            state = _build_initial_state(
-                                graph_config,
-                                inputs,
-                                state_config,
-                                workspace_id,
-                            )
-                            _log_sensitive_debug("Initial state: %s", state)
-
-                            await _run_workflow_stream(
-                                compiled_graph,
-                                state,
-                                runtime_config,
-                                history_store,
-                                execution_id,
-                                websocket,
-                                tracer,
-                                span_context.span,
-                            )
+            await _execute_trusted_workflow_in_worker(
+                settings=settings,
+                graph_config=graph_config,
+                inputs=inputs,
+                runtime_config=runtime_config,
+                state_config=state_config,
+                history_store=history_store,
+                websocket=websocket,
+                execution_id=execution_id,
+                tracer=tracer,
+                span=span_context.span,
+                resolver=resolver,
+                workspace_id=workspace_id,
+            )
 
             completion_payload = {"status": "completed"}
             record_workflow_completion(span_context.span)

--- a/apps/backend/src/orcheo_backend/app/workflow_execution.py
+++ b/apps/backend/src/orcheo_backend/app/workflow_execution.py
@@ -5,7 +5,7 @@ import asyncio
 import logging
 import os
 import uuid
-from collections.abc import Callable, Iterator, Mapping
+from collections.abc import Callable, Iterable, Iterator, Mapping
 from contextlib import contextmanager
 from typing import Any, cast
 from uuid import UUID
@@ -60,6 +60,7 @@ from orcheo_backend.app.history import (
 )
 from orcheo_backend.app.sandbox import (
     build_workflow_run_spec,
+    collect_node_types,
     get_sandbox_dispatcher,
     get_sandbox_launcher,
     run_uses_trusted_nodes_only,
@@ -68,6 +69,34 @@ from orcheo_backend.app.trace_utils import build_trace_update
 
 
 logger = logging.getLogger(__name__)
+
+
+class UntrustedNodeNotAllowedError(RuntimeError):
+    """Raised when an in-worker path receives an untrusted node type.
+
+    The evaluation / training / single-node paths cannot wrap an entire
+    inner workflow in a sandbox the way ``execute_workflow`` does (they wrap
+    an already-compiled graph or run a single Python node directly). Rather
+    than silently executing tenant code in-worker, those paths reject the
+    request and tell the caller to author the workflow with trusted nodes
+    only or trigger it through the normal sandboxed execution path.
+    """
+
+
+def _require_trusted_node_types(node_types: Iterable[str], *, context: str) -> None:
+    """Reject node types that fall outside the trusted in-worker set.
+
+    Raises ``UntrustedNodeNotAllowedError`` if any node type would have to
+    execute as tenant Python in the host process.
+    """
+    if not run_uses_trusted_nodes_only(node_types):
+        offending = sorted(set(node_types))
+        msg = (
+            f"{context} cannot execute untrusted node types in-worker: "
+            f"{offending}. Refactor the workflow to use trusted built-in nodes "
+            "only, or invoke it through the standard sandboxed execution path."
+        )
+        raise UntrustedNodeNotAllowedError(msg)
 
 
 @contextmanager
@@ -138,6 +167,8 @@ async def _dispatch_sandboxed_run(
     execution_id: str,
     graph_config: dict[str, Any],
     inputs: dict[str, Any],
+    runtime_config: Mapping[str, Any],
+    state_config: Mapping[str, Any],
     history_store: RunHistoryStore,
     websocket: WebSocket,
     tracer: Tracer,
@@ -156,6 +187,8 @@ async def _dispatch_sandboxed_run(
         workspace_id=workspace_id,
         graph_config=graph_config,
         inputs=inputs,
+        runnable_config=dict(runtime_config),
+        state_config=dict(state_config),
     )
     result = await dispatcher.dispatch(spec)
     payload: dict[str, Any] = {
@@ -480,6 +513,8 @@ async def _execute_sandboxed_workflow(
     execution_id: str,
     graph_config: dict[str, Any],
     inputs: dict[str, Any],
+    runtime_config: Mapping[str, Any],
+    state_config: Mapping[str, Any],
     history_store: RunHistoryStore,
     websocket: WebSocket,
     tracer: Tracer,
@@ -491,6 +526,8 @@ async def _execute_sandboxed_workflow(
         execution_id=execution_id,
         graph_config=graph_config,
         inputs=inputs,
+        runtime_config=runtime_config,
+        state_config=state_config,
         history_store=history_store,
         websocket=websocket,
         tracer=tracer,
@@ -639,8 +676,15 @@ async def execute_workflow(
                 workspace_id=workspace_id or "",
                 graph_config=graph_config,
                 inputs=inputs,
+                runnable_config=dict(runtime_config),
+                state_config=dict(state_config),
             )
-            if not run_uses_trusted_nodes_only(spec.node_types):
+            # Consult the dispatcher so the operator's
+            # ORCHEO_SANDBOX_FAST_PATH_TRUSTED flag is authoritative. With the
+            # flag off (the default), every run is sandboxed; with the flag on,
+            # trusted-only graphs may take the in-worker fast path.
+            dispatcher = get_sandbox_dispatcher()
+            if dispatcher.should_sandbox(spec):
                 if not workspace_id:
                     msg = "workspace_id is required to dispatch a workflow run"
                     raise RuntimeError(msg)
@@ -649,6 +693,8 @@ async def execute_workflow(
                     execution_id=execution_id,
                     graph_config=graph_config,
                     inputs=inputs,
+                    runtime_config=runtime_config,
+                    state_config=state_config,
                     history_store=history_store,
                     websocket=websocket,
                     tracer=tracer,
@@ -973,6 +1019,15 @@ async def execute_workflow_evaluation(
         await _safe_send_json(websocket, {"status": "error", "error": error_msg})
         return
 
+    try:
+        _require_trusted_node_types(
+            collect_node_types(graph_config),
+            context="Workflow evaluation",
+        )
+    except UntrustedNodeNotAllowedError as exc:
+        await _safe_send_json(websocket, {"status": "error", "error": str(exc)})
+        return
+
     settings = get_settings()
     history_store = get_history_store()
     vault = get_vault()
@@ -1092,6 +1147,15 @@ async def execute_workflow_training(
         await _safe_send_json(websocket, {"status": "error", "error": error_msg})
         return
 
+    try:
+        _require_trusted_node_types(
+            collect_node_types(graph_config),
+            context="Workflow training",
+        )
+    except UntrustedNodeNotAllowedError as exc:
+        await _safe_send_json(websocket, {"status": "error", "error": str(exc)})
+        return
+
     settings = get_settings()
     history_store = get_history_store()
     checkpoint_store = get_checkpoint_store()
@@ -1195,7 +1259,19 @@ async def execute_node(
     workflow_id: UUID | None = None,
     workspace_id: str | None = None,
 ) -> Any:
-    """Execute a single node instance with credential resolution."""
+    """Execute a single node instance with credential resolution.
+
+    Refuses untrusted node types up front — the single-node path cannot
+    sandbox tenant Python the way ``execute_workflow`` can, so callers must
+    use only first-party trusted node classes here. Untrusted nodes belong
+    inside a workflow run, which dispatches through the per-workspace
+    sandbox.
+    """
+    _require_trusted_node_types(
+        (getattr(node_class, "__name__", ""),),
+        context="Single-node execution",
+    )
+
     vault = get_vault()
     workspace_id = await resolve_workflow_workspace_id(
         get_repository(),

--- a/apps/backend/src/orcheo_backend/worker/celery_app.py
+++ b/apps/backend/src/orcheo_backend/worker/celery_app.py
@@ -1,8 +1,14 @@
 """Celery application configuration for the Orcheo execution worker."""
 
 from __future__ import annotations
+import logging
 import os
+from typing import Any
 from celery import Celery
+from celery.signals import worker_process_init
+
+
+logger = logging.getLogger(__name__)
 
 
 # Configuration from environment
@@ -45,5 +51,25 @@ celery_app.conf.beat_schedule = {
     },
 }
 celery_app.conf.beat_schedule_filename = ORCHEO_CELERY_BEAT_SCHEDULE_FILE
+
+
+@worker_process_init.connect
+def _configure_sandbox_for_worker(**_: Any) -> None:
+    """Bind the shared sandbox bootstrap inside every worker process.
+
+    Celery forks worker processes after import; the shared
+    ``WorkflowSandboxDispatcher`` / ``SandboxedProcessLauncher`` cache lives
+    inside ``orcheo_backend.app.sandbox`` and must be bootstrapped per
+    process so workflow execution paths can dispatch sandboxed runs and
+    bind the launcher for vibe-agent subprocesses.
+    """
+    from orcheo_backend.app.sandbox import ensure_sandbox_configured
+
+    try:
+        ensure_sandbox_configured()
+    except Exception:
+        logger.exception("Failed to configure sandbox runtime for worker process")
+        raise
+
 
 __all__ = ["celery_app"]

--- a/apps/backend/src/orcheo_backend/worker/tasks.py
+++ b/apps/backend/src/orcheo_backend/worker/tasks.py
@@ -207,7 +207,7 @@ async def _mark_run_started(run: Any, run_id: str) -> dict[str, Any] | None:
         return {"status": "skipped", "reason": str(exc)}
 
 
-async def _execute_workflow(run: Any) -> dict[str, Any]:
+async def _execute_workflow(run: Any) -> dict[str, Any]:  # noqa: PLR0915
     """Execute the workflow for the given run.
 
     Args:
@@ -223,18 +223,26 @@ async def _execute_workflow(run: Any) -> dict[str, Any]:
     from orcheo.persistence import create_checkpointer, create_graph_store
     from orcheo.runtime.credentials import CredentialResolver, credential_resolution
     from orcheo.runtime.runnable_config import merge_runnable_configs
+    from orcheo.sandbox.dispatch import use_launcher
     from orcheo_backend.app.dependencies import (
         get_history_store,
         get_repository,
         get_vault,
     )
     from orcheo_backend.app.history import RunHistoryError
+    from orcheo_backend.app.sandbox import (
+        build_workflow_run_spec,
+        ensure_sandbox_configured,
+        get_sandbox_dispatcher,
+        get_sandbox_launcher,
+    )
     from orcheo_backend.app.workflow_execution import _build_initial_state
 
     repository = get_repository()
     history_store = get_history_store()
     run_id = str(run.id)
     workspace_id = getattr(run, "workspace_id", None)
+    ensure_sandbox_configured()
 
     try:
         version = await repository.get_version(run.workflow_version_id)
@@ -264,32 +272,57 @@ async def _execute_workflow(run: Any) -> dict[str, Any]:
             workspace_id=workspace_id,
         )
 
-        external_agent_environ = _external_agent_provider_environment(workspace_id)
-        with _patched_environment(external_agent_environ):
-            with credential_resolution(resolver):
-                async with create_checkpointer(settings) as checkpointer:
-                    async with create_graph_store(settings) as graph_store:
-                        graph = build_graph(graph_config)
-                        compiled = graph.compile(
-                            checkpointer=checkpointer,
-                            store=graph_store,
-                        )
-                        state = _build_initial_state(
-                            graph_config,
-                            inputs,
-                            state_config,
-                            workspace_id,
-                        )
-                        await _stream_run_history_steps(
-                            compiled=compiled,
-                            state=state,
-                            runtime_config=runtime_config,
-                            history_store=history_store,
-                            execution_id=execution_id,
-                            history_error_cls=RunHistoryError,
-                        )
-                        final_state = await compiled.aget_state(runtime_config)
-                        final_state = getattr(final_state, "values", final_state)
+        spec = build_workflow_run_spec(
+            execution_id=execution_id,
+            workspace_id=str(workspace_id) if workspace_id else "",
+            graph_config=graph_config,
+            inputs=inputs,
+            runnable_config=dict(runtime_config),
+            state_config=dict(state_config),
+        )
+        dispatcher = get_sandbox_dispatcher()
+        final_state: Any
+        if dispatcher.should_sandbox(spec):
+            if not workspace_id:
+                msg = "workspace_id is required to dispatch a sandboxed workflow run"
+                raise RuntimeError(msg)
+            final_state = await _execute_sandboxed_run_in_worker(
+                dispatcher=dispatcher,
+                spec=spec,
+                history_store=history_store,
+                execution_id=execution_id,
+                history_error_cls=RunHistoryError,
+            )
+        else:
+            external_agent_environ = _external_agent_provider_environment(workspace_id)
+            with use_launcher(get_sandbox_launcher()):
+                with _patched_environment(external_agent_environ):
+                    with credential_resolution(resolver):
+                        async with create_checkpointer(settings) as checkpointer:
+                            async with create_graph_store(settings) as graph_store:
+                                graph = build_graph(graph_config)
+                                compiled = graph.compile(
+                                    checkpointer=checkpointer,
+                                    store=graph_store,
+                                )
+                                state = _build_initial_state(
+                                    graph_config,
+                                    inputs,
+                                    state_config,
+                                    workspace_id,
+                                )
+                                await _stream_run_history_steps(
+                                    compiled=compiled,
+                                    state=state,
+                                    runtime_config=runtime_config,
+                                    history_store=history_store,
+                                    execution_id=execution_id,
+                                    history_error_cls=RunHistoryError,
+                                )
+                                final_state = await compiled.aget_state(runtime_config)
+                                final_state = getattr(
+                                    final_state, "values", final_state
+                                )
 
         output = _extract_output(final_state)
         await repository.mark_run_succeeded(
@@ -315,6 +348,41 @@ async def _execute_workflow(run: Any) -> dict[str, Any]:
             exc,
             history_store=history_store,
         )
+
+
+async def _execute_sandboxed_run_in_worker(
+    *,
+    dispatcher: Any,
+    spec: Any,
+    history_store: Any,
+    execution_id: str,
+    history_error_cls: type[Exception],
+) -> dict[str, Any]:
+    """Dispatch ``spec`` through the sandbox and persist the aggregated result.
+
+    The sandbox returns a single ``WorkflowRunResult`` rather than a stream of
+    node updates, so we persist one ``sandbox_result`` step (mirroring the
+    WebSocket path) and surface a failure if the run did not succeed.
+    """
+    result = await dispatcher.dispatch(spec)
+    payload: dict[str, Any] = {
+        "event": "sandbox_result",
+        "status": result.status,
+        "outputs": dict(result.outputs),
+    }
+    if result.error:
+        payload["error"] = result.error
+    try:
+        await history_store.append_step(execution_id, payload)
+    except history_error_cls:
+        logger.exception(
+            "Failed to append sandbox result for execution %s",
+            execution_id,
+        )
+    if result.status != "succeeded":
+        msg = result.error or f"sandboxed run finished with {result.status}"
+        raise RuntimeError(msg)
+    return {"sandbox_outputs": dict(result.outputs)}
 
 
 async def _start_history_record(

--- a/apps/canvas/src/App.tsx
+++ b/apps/canvas/src/App.tsx
@@ -18,8 +18,7 @@ import RequireAuth from "@features/auth/components/require-auth";
 import OAuthCallback from "@features/auth/pages/oauth-callback";
 import Profile from "@features/account/pages/profile";
 import Settings from "@features/account/pages/settings";
-import WorkspaceMembers from "@features/account/pages/workspace-members";
-import ServiceTokens from "@features/account/pages/service-tokens";
+import WorkspaceManagement from "@features/account/pages/workspace-management";
 import PublicChatPage from "@features/chatkit/pages/public-chat";
 import {
   getSelectedWorkspaceSlug,
@@ -51,22 +50,13 @@ function WorkspaceGalleryRoute() {
   return <WorkflowGallery />;
 }
 
-function WorkspaceMembersRoute() {
+function WorkspaceManagementRoute() {
   const { workspaceSlug } = useParams<{ workspaceSlug?: string }>();
   useLayoutEffect(() => {
     syncWorkspaceSlug(workspaceSlug);
   }, [workspaceSlug]);
 
-  return <WorkspaceMembers />;
-}
-
-function ServiceTokensRoute() {
-  const { workspaceSlug } = useParams<{ workspaceSlug?: string }>();
-  useLayoutEffect(() => {
-    syncWorkspaceSlug(workspaceSlug);
-  }, [workspaceSlug]);
-
-  return <ServiceTokens />;
+  return <WorkspaceManagement />;
 }
 
 function WorkspaceCanvasRoute() {
@@ -106,12 +96,7 @@ export default function OrcheoCanvasApp() {
 
                 <Route
                   path="/:workspaceSlug/workspace"
-                  element={<WorkspaceMembersRoute />}
-                />
-
-                <Route
-                  path="/:workspaceSlug/tokens"
-                  element={<ServiceTokensRoute />}
+                  element={<WorkspaceManagementRoute />}
                 />
 
                 <Route

--- a/apps/canvas/src/features/MODULES.md
+++ b/apps/canvas/src/features/MODULES.md
@@ -13,7 +13,10 @@ Each row corresponds to one source script (test files excluded).
 | `account/pages/profile/types.ts`                                                     | `ProfileUser` interface (name, email, avatar, role, optional joinDate).                                      |
 | `account/pages/profile.tsx`                                                          | Profile page that composes the general-info tab and any additional settings tabs.                            |
 | `account/pages/settings.tsx`                                                         | Settings page with tabs for agent integrations and appearance preferences.                                   |
-| `account/pages/workspace-members.tsx`                                                | Page for listing and managing workspace members with role-based access control.                              |
+| `account/pages/workspace-members.tsx`                                                | Tab content for listing and managing workspace members with role-based access control.                       |
+| `account/pages/service-tokens.tsx`                                                   | Tab content for creating, rotating, and revoking workspace-scoped API keys used by the Orcheo SDK.           |
+| `account/pages/workspace-management.tsx`                                             | Workspace Management page with tabs for members, external agents, and API keys.                              |
+| `account/components/external-agents-section.tsx`                                     | Section for connecting and managing per-workspace external agent CLIs (Claude Code, Codex, Gemini).          |
 | **auth**                                                                             |                                                                                                              |
 | `auth/components/auto-login.tsx`                                                     | Initiates an OIDC login redirect automatically, forwarding org / invitation / hint query params.             |
 | `auth/components/require-auth.tsx`                                                   | Route guard that verifies auth state and refreshes tokens before rendering protected children.               |

--- a/apps/canvas/src/features/account/pages/service-tokens.tsx
+++ b/apps/canvas/src/features/account/pages/service-tokens.tsx
@@ -37,10 +37,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/design-system/ui/dialog";
-import useCredentialVault from "@/hooks/use-credential-vault";
-import { usePageContext } from "@/hooks/use-page-context";
 import { toast } from "@/hooks/use-toast";
-import TopNavigation from "@features/shared/components/top-navigation";
 import {
   createServiceToken,
   getActiveWorkspace,
@@ -88,20 +85,6 @@ interface RevealedSecret {
 }
 
 export default function ServiceTokens() {
-  const { setPageContext } = usePageContext();
-  useEffect(() => {
-    setPageContext({ page: "workspace" });
-  }, [setPageContext]);
-
-  const {
-    credentials,
-    isLoading: isCredentialsLoading,
-    onAddCredential,
-    onUpdateCredential,
-    onDeleteCredential,
-    onRevealCredentialSecret,
-  } = useCredentialVault();
-
   const [tokens, setTokens] = useState<ServiceToken[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [workspaceName, setWorkspaceName] = useState<string | null>(null);
@@ -264,145 +247,131 @@ export default function ServiceTokens() {
   };
 
   return (
-    <div className="flex h-full min-h-0 flex-col overflow-hidden">
-      <TopNavigation
-        credentials={credentials}
-        isCredentialsLoading={isCredentialsLoading}
-        onAddCredential={onAddCredential}
-        onUpdateCredential={onUpdateCredential}
-        onDeleteCredential={onDeleteCredential}
-        onRevealCredentialSecret={onRevealCredentialSecret}
-      />
-
-      <main className="flex-1 min-h-0 overflow-auto">
-        <div className="mx-auto flex w-full max-w-7xl flex-col space-y-6 p-8 pt-6">
-          <div className="flex items-start justify-between gap-4">
-            <div>
-              <h2 className="text-3xl font-bold tracking-tight">API Keys</h2>
-              <p className="mt-1 text-sm text-muted-foreground">
-                API keys created here are scoped to{" "}
-                <span className="font-medium text-foreground">
-                  {workspaceName ?? "this workspace"}
-                </span>{" "}
-                and cannot access any other workspace.
-              </p>
-            </div>
-            <Button onClick={() => setCreateOpen(true)}>
-              <KeyRound className="mr-2 h-4 w-4" />
-              Create a new key
-            </Button>
-          </div>
-
-          {isLoading ? (
-            <p className="text-sm text-muted-foreground">Loading API keys...</p>
-          ) : tokens.length === 0 ? (
-            <p className="text-sm text-muted-foreground">
-              No API keys for this workspace yet.
-            </p>
-          ) : (
-            <div className="rounded-lg border">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Identifier</TableHead>
-                    <TableHead>Key</TableHead>
-                    <TableHead>Scopes</TableHead>
-                    <TableHead>Issued</TableHead>
-                    <TableHead>Expires</TableHead>
-                    <TableHead>Last used</TableHead>
-                    <TableHead>Status</TableHead>
-                    <TableHead className="text-right">Actions</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {tokens.map((token) => {
-                    const status = tokenStatus(token);
-                    const isActive = status === "Active";
-                    return (
-                      <TableRow key={token.identifier}>
-                        <TableCell className="font-mono text-sm">
-                          {token.identifier}
-                        </TableCell>
-                        <TableCell className="font-mono text-sm text-muted-foreground">
-                          {token.secret_preview
-                            ? `••••••••${token.secret_preview}`
-                            : "—"}
-                        </TableCell>
-                        <TableCell className="text-sm">
-                          {token.scopes.length > 0 ? (
-                            <div className="flex flex-wrap gap-1">
-                              {token.scopes.map((scope) => (
-                                <Badge key={scope} variant="secondary">
-                                  {scope}
-                                </Badge>
-                              ))}
-                            </div>
-                          ) : (
-                            <span className="text-muted-foreground">—</span>
-                          )}
-                        </TableCell>
-                        <TableCell className="text-sm text-muted-foreground">
-                          {formatDate(token.issued_at)}
-                        </TableCell>
-                        <TableCell className="text-sm text-muted-foreground">
-                          {token.expires_at
-                            ? formatDate(token.expires_at)
-                            : "Never"}
-                        </TableCell>
-                        <TableCell className="text-sm text-muted-foreground">
-                          {formatDate(token.last_used_at)}
-                        </TableCell>
-                        <TableCell>
-                          <Badge variant={isActive ? "default" : "outline"}>
-                            {status}
-                          </Badge>
-                        </TableCell>
-                        <TableCell className="text-right">
-                          <div className="flex justify-end gap-1">
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={() =>
-                                void handleRotate(token.identifier)
-                              }
-                              disabled={
-                                !isActive ||
-                                rotatingId === token.identifier ||
-                                revokingId === token.identifier
-                              }
-                            >
-                              <RotateCw className="mr-2 h-4 w-4" />
-                              {rotatingId === token.identifier
-                                ? "Rotating..."
-                                : "Rotate"}
-                            </Button>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              className="text-destructive hover:text-destructive"
-                              onClick={() => setRevokeTarget(token.identifier)}
-                              disabled={
-                                !isActive ||
-                                rotatingId === token.identifier ||
-                                revokingId === token.identifier
-                              }
-                            >
-                              <Trash2 className="mr-2 h-4 w-4" />
-                              {revokingId === token.identifier
-                                ? "Revoking..."
-                                : "Revoke"}
-                            </Button>
-                          </div>
-                        </TableCell>
-                      </TableRow>
-                    );
-                  })}
-                </TableBody>
-              </Table>
-            </div>
-          )}
+    <div className="flex flex-col space-y-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-xl font-bold">API Keys</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            API keys authenticate the Orcheo SDK and CLI when accessing{" "}
+            <span className="font-medium text-foreground">
+              {workspaceName ?? "this workspace"}
+            </span>{" "}
+            programmatically. They are scoped to this workspace and cannot
+            access any other workspace.
+          </p>
         </div>
-      </main>
+        <Button onClick={() => setCreateOpen(true)}>
+          <KeyRound className="mr-2 h-4 w-4" />
+          Create a new key
+        </Button>
+      </div>
+
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading API keys...</p>
+      ) : tokens.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          No API keys for this workspace yet.
+        </p>
+      ) : (
+        <div className="rounded-lg border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Identifier</TableHead>
+                <TableHead>Key</TableHead>
+                <TableHead>Scopes</TableHead>
+                <TableHead>Issued</TableHead>
+                <TableHead>Expires</TableHead>
+                <TableHead>Last used</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {tokens.map((token) => {
+                const status = tokenStatus(token);
+                const isActive = status === "Active";
+                return (
+                  <TableRow key={token.identifier}>
+                    <TableCell className="font-mono text-sm">
+                      {token.identifier}
+                    </TableCell>
+                    <TableCell className="font-mono text-sm text-muted-foreground">
+                      {token.secret_preview
+                        ? `••••••••${token.secret_preview}`
+                        : "—"}
+                    </TableCell>
+                    <TableCell className="text-sm">
+                      {token.scopes.length > 0 ? (
+                        <div className="flex flex-wrap gap-1">
+                          {token.scopes.map((scope) => (
+                            <Badge key={scope} variant="secondary">
+                              {scope}
+                            </Badge>
+                          ))}
+                        </div>
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-sm text-muted-foreground">
+                      {formatDate(token.issued_at)}
+                    </TableCell>
+                    <TableCell className="text-sm text-muted-foreground">
+                      {token.expires_at
+                        ? formatDate(token.expires_at)
+                        : "Never"}
+                    </TableCell>
+                    <TableCell className="text-sm text-muted-foreground">
+                      {formatDate(token.last_used_at)}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={isActive ? "default" : "outline"}>
+                        {status}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex justify-end gap-1">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => void handleRotate(token.identifier)}
+                          disabled={
+                            !isActive ||
+                            rotatingId === token.identifier ||
+                            revokingId === token.identifier
+                          }
+                        >
+                          <RotateCw className="mr-2 h-4 w-4" />
+                          {rotatingId === token.identifier
+                            ? "Rotating..."
+                            : "Rotate"}
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="text-destructive hover:text-destructive"
+                          onClick={() => setRevokeTarget(token.identifier)}
+                          disabled={
+                            !isActive ||
+                            rotatingId === token.identifier ||
+                            revokingId === token.identifier
+                          }
+                        >
+                          <Trash2 className="mr-2 h-4 w-4" />
+                          {revokingId === token.identifier
+                            ? "Revoking..."
+                            : "Revoke"}
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </div>
+      )}
 
       <Dialog
         open={createOpen}

--- a/apps/canvas/src/features/account/pages/workspace-management.test.tsx
+++ b/apps/canvas/src/features/account/pages/workspace-management.test.tsx
@@ -1,0 +1,71 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import WorkspaceManagement from "./workspace-management";
+
+vi.mock("@/hooks/use-credential-vault", () => ({
+  default: () => ({
+    credentials: [],
+    isLoading: false,
+    onAddCredential: vi.fn(),
+    onUpdateCredential: vi.fn(),
+    onDeleteCredential: vi.fn(),
+    onRevealCredentialSecret: vi.fn(),
+  }),
+}));
+
+const setPageContextMock = vi.fn();
+vi.mock("@/hooks/use-page-context", () => ({
+  usePageContext: () => ({
+    setPageContext: setPageContextMock,
+    setVaultOpen: vi.fn(),
+    pageContext: { page: "workspace" },
+  }),
+}));
+
+vi.mock("@features/shared/components/top-navigation", () => ({
+  default: () => <header data-testid="top-nav" />,
+}));
+
+vi.mock("@features/account/pages/workspace-members", () => ({
+  default: () => <div data-testid="members-panel" />,
+}));
+
+vi.mock("@features/account/components/external-agents-section", () => ({
+  default: () => <div data-testid="agents-panel" />,
+}));
+
+vi.mock("@features/account/pages/service-tokens", () => ({
+  default: () => <div data-testid="api-keys-panel" />,
+}));
+
+const renderPage = () =>
+  render(
+    <MemoryRouter>
+      <WorkspaceManagement />
+    </MemoryRouter>,
+  );
+
+describe("WorkspaceManagement", () => {
+  afterEach(() => {
+    cleanup();
+    setPageContextMock.mockReset();
+  });
+
+  it("shows the members tab by default and switches to other tabs", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    expect(setPageContextMock).toHaveBeenCalledWith({ page: "workspace" });
+    expect(screen.getByTestId("members-panel")).toBeInTheDocument();
+    expect(screen.queryByTestId("agents-panel")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "External Agents" }));
+    expect(screen.getByTestId("agents-panel")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "API Keys" }));
+    expect(screen.getByTestId("api-keys-panel")).toBeInTheDocument();
+  });
+});

--- a/apps/canvas/src/features/account/pages/workspace-management.tsx
+++ b/apps/canvas/src/features/account/pages/workspace-management.tsx
@@ -1,0 +1,68 @@
+import { useEffect } from "react";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/design-system/ui/tabs";
+import useCredentialVault from "@/hooks/use-credential-vault";
+import { usePageContext } from "@/hooks/use-page-context";
+import ExternalAgentsSection from "@features/account/components/external-agents-section";
+import ServiceTokens from "@features/account/pages/service-tokens";
+import WorkspaceMembers from "@features/account/pages/workspace-members";
+import TopNavigation from "@features/shared/components/top-navigation";
+
+export default function WorkspaceManagement() {
+  const { setPageContext } = usePageContext();
+  useEffect(() => {
+    setPageContext({ page: "workspace" });
+  }, [setPageContext]);
+
+  const {
+    credentials,
+    isLoading: isCredentialsLoading,
+    onAddCredential,
+    onUpdateCredential,
+    onDeleteCredential,
+    onRevealCredentialSecret,
+  } = useCredentialVault();
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden">
+      <TopNavigation
+        credentials={credentials}
+        isCredentialsLoading={isCredentialsLoading}
+        onAddCredential={onAddCredential}
+        onUpdateCredential={onUpdateCredential}
+        onDeleteCredential={onDeleteCredential}
+        onRevealCredentialSecret={onRevealCredentialSecret}
+      />
+
+      <main className="flex-1 min-h-0 overflow-auto">
+        <div className="mx-auto flex w-full max-w-7xl flex-col space-y-6 p-8 pt-6">
+          <h1 className="text-3xl font-bold tracking-tight">
+            Workspace Management
+          </h1>
+
+          <Tabs defaultValue="members" className="flex flex-col gap-4">
+            <TabsList className="self-start">
+              <TabsTrigger value="members">Workspace Members</TabsTrigger>
+              <TabsTrigger value="agents">External Agents</TabsTrigger>
+              <TabsTrigger value="api-keys">API Keys</TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="members">
+              <WorkspaceMembers />
+            </TabsContent>
+            <TabsContent value="agents">
+              <ExternalAgentsSection />
+            </TabsContent>
+            <TabsContent value="api-keys">
+              <ServiceTokens />
+            </TabsContent>
+          </Tabs>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/canvas/src/features/account/pages/workspace-members.tsx
+++ b/apps/canvas/src/features/account/pages/workspace-members.tsx
@@ -17,11 +17,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/design-system/ui/table";
-import useCredentialVault from "@/hooks/use-credential-vault";
-import { usePageContext } from "@/hooks/use-page-context";
 import { toast } from "@/hooks/use-toast";
-import ExternalAgentsSection from "@features/account/components/external-agents-section";
-import TopNavigation from "@features/shared/components/top-navigation";
 import { getAuthenticatedUserProfile } from "@features/auth/lib/auth-session";
 import {
   getActiveWorkspace,
@@ -44,20 +40,6 @@ const isValidUserId = (userId: string): boolean =>
   USER_ID_PATTERN.test(userId.trim());
 
 export default function WorkspaceMembers() {
-  const { setPageContext } = usePageContext();
-  useEffect(() => {
-    setPageContext({ page: "workspace" });
-  }, [setPageContext]);
-
-  const {
-    credentials,
-    isLoading: isCredentialsLoading,
-    onAddCredential,
-    onUpdateCredential,
-    onDeleteCredential,
-    onRevealCredentialSecret,
-  } = useCredentialVault();
-
   const [members, setMembers] = useState<WorkspaceMember[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [canManage, setCanManage] = useState(false);
@@ -194,184 +176,160 @@ export default function WorkspaceMembers() {
   };
 
   return (
-    <div className="flex h-full min-h-0 flex-col overflow-hidden">
-      <TopNavigation
-        credentials={credentials}
-        isCredentialsLoading={isCredentialsLoading}
-        onAddCredential={onAddCredential}
-        onUpdateCredential={onUpdateCredential}
-        onDeleteCredential={onDeleteCredential}
-        onRevealCredentialSecret={onRevealCredentialSecret}
-      />
+    <div className="flex flex-col space-y-6">
+      {isForbidden && (
+        <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
+          You do not have permission to view workspace members. Ask a workspace
+          admin or owner to grant you access.
+        </div>
+      )}
 
-      <main className="flex-1 min-h-0 overflow-auto">
-        <div className="mx-auto flex w-full max-w-7xl flex-col space-y-6 p-8 pt-6">
-          <ExternalAgentsSection />
-
-          <div className="flex items-center justify-between">
-            <h2 className="text-3xl font-bold tracking-tight">
-              Workspace Members
-            </h2>
+      {canManage && (
+        <div className="rounded-lg border p-4">
+          <h3 className="mb-4 text-lg font-medium">Add Member</h3>
+          <div className="flex items-end gap-3">
+            <div className="flex-1 space-y-1.5">
+              <Label htmlFor="new-user-id">User ID</Label>
+              <Input
+                id="new-user-id"
+                placeholder="Enter user ID"
+                value={newUserId}
+                onChange={(e) => {
+                  setNewUserId(e.target.value);
+                  setNewUserIdError(null);
+                }}
+                disabled={isAdding}
+                aria-invalid={newUserIdError ? true : undefined}
+                aria-describedby={
+                  newUserIdError ? "new-user-id-error" : undefined
+                }
+              />
+              {newUserIdError && (
+                <p id="new-user-id-error" className="text-xs text-destructive">
+                  {newUserIdError}
+                </p>
+              )}
+            </div>
+            <div className="w-36 space-y-1.5">
+              <Label htmlFor="new-role">Role</Label>
+              <Select
+                value={newRole}
+                onValueChange={(v) => setNewRole(v as MemberRole)}
+                disabled={isAdding}
+              >
+                <SelectTrigger id="new-role">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {ROLE_OPTIONS.map((role) => (
+                    <SelectItem key={role} value={role}>
+                      {role}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1.5">
+              <Label className="invisible" aria-hidden>
+                Action
+              </Label>
+              <Button
+                onClick={() => void handleAddMember()}
+                disabled={isAdding || !newUserId.trim()}
+              >
+                {isAdding ? "Adding..." : "Add"}
+              </Button>
+            </div>
           </div>
+        </div>
+      )}
 
-          {isForbidden && (
-            <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
-              You do not have permission to view workspace members. Ask a
-              workspace admin or owner to grant you access.
-            </div>
-          )}
+      {isForbidden ? null : isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading members...</p>
+      ) : members.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No members found.</p>
+      ) : (
+        <div className="rounded-lg border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>User ID</TableHead>
+                <TableHead>Role</TableHead>
+                <TableHead>Joined</TableHead>
+                {canManage && (
+                  <TableHead className="text-right">Actions</TableHead>
+                )}
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {members.map((member) => {
+                const isSelf = member.user_id === currentUserId;
+                const isUpdating = updatingUserId === member.user_id;
+                const isRemoving = removingUserId === member.user_id;
 
-          {canManage && (
-            <div className="rounded-lg border p-4">
-              <h3 className="mb-4 text-lg font-medium">Add Member</h3>
-              <div className="flex items-end gap-3">
-                <div className="flex-1 space-y-1.5">
-                  <Label htmlFor="new-user-id">User ID</Label>
-                  <Input
-                    id="new-user-id"
-                    placeholder="Enter user ID"
-                    value={newUserId}
-                    onChange={(e) => {
-                      setNewUserId(e.target.value);
-                      setNewUserIdError(null);
-                    }}
-                    disabled={isAdding}
-                    aria-invalid={newUserIdError ? true : undefined}
-                    aria-describedby={
-                      newUserIdError ? "new-user-id-error" : undefined
-                    }
-                  />
-                  {newUserIdError && (
-                    <p
-                      id="new-user-id-error"
-                      className="text-xs text-destructive"
-                    >
-                      {newUserIdError}
-                    </p>
-                  )}
-                </div>
-                <div className="w-36 space-y-1.5">
-                  <Label htmlFor="new-role">Role</Label>
-                  <Select
-                    value={newRole}
-                    onValueChange={(v) => setNewRole(v as MemberRole)}
-                    disabled={isAdding}
-                  >
-                    <SelectTrigger id="new-role">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {ROLE_OPTIONS.map((role) => (
-                        <SelectItem key={role} value={role}>
-                          {role}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="space-y-1.5">
-                  <Label className="invisible" aria-hidden>
-                    Action
-                  </Label>
-                  <Button
-                    onClick={() => void handleAddMember()}
-                    disabled={isAdding || !newUserId.trim()}
-                  >
-                    {isAdding ? "Adding..." : "Add"}
-                  </Button>
-                </div>
-              </div>
-            </div>
-          )}
-
-          {isForbidden ? null : isLoading ? (
-            <p className="text-sm text-muted-foreground">Loading members...</p>
-          ) : members.length === 0 ? (
-            <p className="text-sm text-muted-foreground">No members found.</p>
-          ) : (
-            <div className="rounded-lg border">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Name</TableHead>
-                    <TableHead>User ID</TableHead>
-                    <TableHead>Role</TableHead>
-                    <TableHead>Joined</TableHead>
+                return (
+                  <TableRow key={member.id}>
+                    <TableCell className="text-sm">
+                      {member.user_name ?? "—"}
+                    </TableCell>
+                    <TableCell className="font-mono text-sm">
+                      {member.user_id}
+                    </TableCell>
+                    <TableCell>
+                      {canManage && !isSelf ? (
+                        <Select
+                          value={member.role}
+                          onValueChange={(v) =>
+                            void handleRoleChange(
+                              member.user_id,
+                              v as MemberRole,
+                            )
+                          }
+                          disabled={isUpdating}
+                        >
+                          <SelectTrigger className="w-32">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {ROLE_OPTIONS.map((role) => (
+                              <SelectItem key={role} value={role}>
+                                {role}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      ) : (
+                        <span className="capitalize">{member.role}</span>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-sm text-muted-foreground">
+                      {new Date(member.created_at).toLocaleDateString()}
+                    </TableCell>
                     {canManage && (
-                      <TableHead className="text-right">Actions</TableHead>
+                      <TableCell className="text-right">
+                        {!isSelf && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="text-destructive hover:text-destructive"
+                            onClick={() =>
+                              void handleRemoveMember(member.user_id)
+                            }
+                            disabled={isRemoving}
+                          >
+                            {isRemoving ? "Removing..." : "Remove"}
+                          </Button>
+                        )}
+                      </TableCell>
                     )}
                   </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {members.map((member) => {
-                    const isSelf = member.user_id === currentUserId;
-                    const isUpdating = updatingUserId === member.user_id;
-                    const isRemoving = removingUserId === member.user_id;
-
-                    return (
-                      <TableRow key={member.id}>
-                        <TableCell className="text-sm">
-                          {member.user_name ?? "—"}
-                        </TableCell>
-                        <TableCell className="font-mono text-sm">
-                          {member.user_id}
-                        </TableCell>
-                        <TableCell>
-                          {canManage && !isSelf ? (
-                            <Select
-                              value={member.role}
-                              onValueChange={(v) =>
-                                void handleRoleChange(
-                                  member.user_id,
-                                  v as MemberRole,
-                                )
-                              }
-                              disabled={isUpdating}
-                            >
-                              <SelectTrigger className="w-32">
-                                <SelectValue />
-                              </SelectTrigger>
-                              <SelectContent>
-                                {ROLE_OPTIONS.map((role) => (
-                                  <SelectItem key={role} value={role}>
-                                    {role}
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                          ) : (
-                            <span className="capitalize">{member.role}</span>
-                          )}
-                        </TableCell>
-                        <TableCell className="text-sm text-muted-foreground">
-                          {new Date(member.created_at).toLocaleDateString()}
-                        </TableCell>
-                        {canManage && (
-                          <TableCell className="text-right">
-                            {!isSelf && (
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                className="text-destructive hover:text-destructive"
-                                onClick={() =>
-                                  void handleRemoveMember(member.user_id)
-                                }
-                                disabled={isRemoving}
-                              >
-                                {isRemoving ? "Removing..." : "Remove"}
-                              </Button>
-                            )}
-                          </TableCell>
-                        )}
-                      </TableRow>
-                    );
-                  })}
-                </TableBody>
-              </Table>
-            </div>
-          )}
+                );
+              })}
+            </TableBody>
+          </Table>
         </div>
-      </main>
+      )}
     </div>
   );
 }

--- a/apps/canvas/src/features/shared/components/top-navigation/account-menu.tsx
+++ b/apps/canvas/src/features/shared/components/top-navigation/account-menu.tsx
@@ -16,7 +16,7 @@ import {
   DialogDescription,
   DialogTitle,
 } from "@/design-system/ui/dialog";
-import { Key, KeyRound, LogOut, Settings, User, Users } from "lucide-react";
+import { Building2, LogOut, Settings, User, Vault } from "lucide-react";
 import {
   clearAuthSession,
   getAuthenticatedUserProfile,
@@ -118,19 +118,8 @@ export default function AccountMenu({
                 to={`/${workspaceSlug}/workspace`}
                 className="flex w-full items-center gap-0"
               >
-                <Users className="mr-2 h-4 w-4" />
-                <span>Workspace Members</span>
-              </Link>
-            </DropdownMenuItem>
-          )}
-          {workspaceSlug && (
-            <DropdownMenuItem asChild>
-              <Link
-                to={`/${workspaceSlug}/tokens`}
-                className="flex w-full items-center gap-0"
-              >
-                <KeyRound className="mr-2 h-4 w-4" />
-                <span>API Keys</span>
+                <Building2 className="mr-2 h-4 w-4" />
+                <span>Workspace Management</span>
               </Link>
             </DropdownMenuItem>
           )}
@@ -142,7 +131,7 @@ export default function AccountMenu({
                 handleVaultOpenChange(true);
               }}
             >
-              <Key className="mr-2 h-4 w-4" />
+              <Vault className="mr-2 h-4 w-4" />
               <span>Credential Vault</span>
             </button>
           </DropdownMenuItem>

--- a/apps/canvas/src/features/workflow/components/dialogs/credentials-vault.tsx
+++ b/apps/canvas/src/features/workflow/components/dialogs/credentials-vault.tsx
@@ -43,8 +43,15 @@ export default function CredentialsVault({
 
   return (
     <div className={containerClassName}>
-      <div className="flex flex-wrap items-center justify-between gap-3 pr-10">
-        <h2 className="text-xl font-bold">Credential Vault</h2>
+      <div className="flex flex-wrap items-start justify-between gap-3 pr-10">
+        <div className="space-y-1">
+          <h2 className="text-xl font-bold">Credential Vault</h2>
+          <p className="text-sm text-muted-foreground">
+            Credentials stored here are securely injected into your workflows at
+            runtime, so nodes can authenticate to external services without
+            hardcoding secrets.
+          </p>
+        </div>
         <AddCredentialDialog onAddCredential={onAddCredential} />
       </div>
 

--- a/deploy/stack/.env.example
+++ b/deploy/stack/.env.example
@@ -34,7 +34,12 @@ ORCHEO_CREDENTIAL_BROKER_SECRET=replace-with-broker-secret
 # docs/operators/workspace_runtime_isolation.md.
 ORCHEO_SANDBOX_RUNTIME_URL=http://sandbox-runtime:9090
 # Container runtime the sandbox-runtime spawns sandboxes under. `runsc`
-# selects gVisor; switch to `runc` only for local dev when gVisor is absent.
+# selects gVisor and gives the documented isolation guarantees; `runc`
+# is the stock Docker runtime and only suitable for local dev where
+# gVisor is not installed. Production deployments MUST set this to
+# `runsc` (and register the runtime with Docker first — see the operator
+# guide). The local docker-compose stack defaults to `runc` so it boots
+# on a stock Docker host.
 ORCHEO_CONTAINER_RUNTIME=runsc
 # OCI image hosting agent CLIs, the Orcheo CLI, and the workflow runner.
 ORCHEO_SANDBOX_IMAGE=orcheo/workspace-sandbox:latest

--- a/deploy/stack/.env.example
+++ b/deploy/stack/.env.example
@@ -20,6 +20,27 @@ ORCHEO_AUTH_BOOTSTRAP_SERVICE_TOKEN=change-me
 # Public ChatKit domain key consumed by Canvas; required for ChatKit UI features.
 # Security note: this value is shipped to browsers. Scope it per environment.
 VITE_ORCHEO_CHATKIT_DOMAIN_KEY=domain_pk_replace_me
+# HMAC secret used by the Credential Broker to sign run-scoped tokens issued
+# to sandboxes. Backend refuses to start if unset — sandboxing is always on.
+# Generate with: `python -m orcheo.sandbox.broker --gen-secret`
+ORCHEO_CREDENTIAL_BROKER_SECRET=replace-with-broker-secret
+
+# -----------------------------------------------------------------------------
+# Workspace runtime isolation (gVisor sandbox)
+# -----------------------------------------------------------------------------
+# Internal URL of the sandbox-runtime service. Backend and worker call this
+# to acquire per-workspace sandboxes and dispatch tenant workflow runs; they
+# never mount the Docker socket themselves. See
+# docs/operators/workspace_runtime_isolation.md.
+ORCHEO_SANDBOX_RUNTIME_URL=http://sandbox-runtime:9090
+# Container runtime the sandbox-runtime spawns sandboxes under. `runsc`
+# selects gVisor; switch to `runc` only for local dev when gVisor is absent.
+ORCHEO_CONTAINER_RUNTIME=runsc
+# OCI image hosting agent CLIs, the Orcheo CLI, and the workflow runner.
+ORCHEO_SANDBOX_IMAGE=orcheo/workspace-sandbox:latest
+# When `true`, workflows composed only of trusted built-in nodes skip the
+# sandbox (faster cold-start). Vibe agents always run sandboxed regardless.
+ORCHEO_SANDBOX_FAST_PATH_TRUSTED=false
 
 # -----------------------------------------------------------------------------
 # Core service defaults (database, API, and browser-facing URLs)

--- a/deploy/stack/.env.example
+++ b/deploy/stack/.env.example
@@ -38,8 +38,13 @@ ORCHEO_SANDBOX_RUNTIME_URL=http://sandbox-runtime:9090
 # is the stock Docker runtime and only suitable for local dev where
 # gVisor is not installed. Production deployments MUST set this to
 # `runsc` (and register the runtime with Docker first — see the operator
-# guide). The local docker-compose stack defaults to `runc` so it boots
-# on a stock Docker host.
+# guide).
+#
+# Defaults wired into the compose files:
+#   - deploy/stack/docker-compose.yml (this env template)  → `runsc` (prod)
+#   - deploy/stack/docker-compose.staging.yml overlay      → `runc`  (local builds, no gVisor)
+#   - root docker-compose.yml (dev hot-reload stack)       → `runc`
+# Override here only when this env file is used against a non-default host.
 ORCHEO_CONTAINER_RUNTIME=runsc
 # OCI image hosting agent CLIs, the Orcheo CLI, and the workflow runner.
 ORCHEO_SANDBOX_IMAGE=orcheo/workspace-sandbox:latest

--- a/deploy/stack/docker-compose.staging.yml
+++ b/deploy/stack/docker-compose.staging.yml
@@ -6,6 +6,15 @@ services:
   backend:
     image: orcheo-stack:staging-local
     build: *orcheo_staging_build
+    environment:
+      # Must match the workspace-sandbox image built below, since the backend
+      # embeds this tag in every ContainerSpec sent to sandbox-runtime.
+      ORCHEO_SANDBOX_IMAGE: orcheo/workspace-sandbox:staging-local
+      # Staging runs on stock Docker (Docker Desktop / CI). The base compose
+      # defaults to `runsc` for gVisor-equipped prod hosts; override to `runc`
+      # so local stacks work without installing gVisor. Set
+      # ORCHEO_CONTAINER_RUNTIME explicitly if you do have runsc available.
+      ORCHEO_CONTAINER_RUNTIME: ${ORCHEO_CONTAINER_RUNTIME:-runc}
 
   worker:
     image: orcheo-stack:staging-local
@@ -14,6 +23,9 @@ services:
       - orcheo_data:/data
       - ../../workspace/agents:/workspace/agents
       - ./chatkit_widgets:/app/examples/chatkit_widgets/widgets:ro
+    environment:
+      ORCHEO_SANDBOX_IMAGE: orcheo/workspace-sandbox:staging-local
+      ORCHEO_CONTAINER_RUNTIME: ${ORCHEO_CONTAINER_RUNTIME:-runc}
 
   celery-beat:
     image: orcheo-stack:staging-local
@@ -30,3 +42,18 @@ services:
     build:
       context: ../..
       dockerfile: Dockerfile.sandbox-runtime
+    environment:
+      ORCHEO_SANDBOX_IMAGE: orcheo/workspace-sandbox:staging-local
+      ORCHEO_CONTAINER_RUNTIME: ${ORCHEO_CONTAINER_RUNTIME:-runc}
+
+  # The workspace-sandbox image is *not* run as part of the long-lived stack
+  # — it is the image the `sandbox-runtime` service spawns on demand. Declaring
+  # it as a service lets `docker compose up` build it automatically; the no-op
+  # command makes the resulting container exit immediately (default restart
+  # policy `no` keeps it from coming back).
+  workspace-sandbox:
+    image: orcheo/workspace-sandbox:staging-local
+    build:
+      context: ../..
+      dockerfile: Dockerfile.workspace-sandbox
+    command: ["sh", "-c", "echo 'workspace-sandbox image is only consumed by sandbox-runtime at run time; nothing to run here.' && exit 0"]

--- a/deploy/stack/docker-compose.yml
+++ b/deploy/stack/docker-compose.yml
@@ -225,6 +225,10 @@ services:
 
 networks:
   sandbox-egress:
+    # Sandbox child containers are created through the host Docker API with
+    # network_mode=sandbox-egress, so this must be the real Docker network
+    # name rather than Compose's project-prefixed default.
+    name: sandbox-egress
     # nftables rules attached to this bridge enforce the L3/L4 deny policy.
     # See deploy/stack/sandbox-egress.nft.
     driver: bridge

--- a/deploy/stack/docker-compose.yml
+++ b/deploy/stack/docker-compose.yml
@@ -60,12 +60,21 @@ services:
       ORCHEO_CORS_ALLOW_ORIGINS: ${ORCHEO_CORS_ALLOW_ORIGINS:-http://localhost:2026,http://127.0.0.1:2026}
       ORCHEO_PLUGIN_DIR: /data/plugins
       ORCHEO_CACHE_DIR: /data/cache/orcheo
+      ORCHEO_SANDBOX_RUNTIME_URL: ${ORCHEO_SANDBOX_RUNTIME_URL:-http://sandbox-runtime:9090}
+      ORCHEO_CREDENTIAL_BROKER_SECRET: ${ORCHEO_CREDENTIAL_BROKER_SECRET:?set ORCHEO_CREDENTIAL_BROKER_SECRET}
+      # Backend/worker embed this image name in every ContainerSpec they send
+      # to sandbox-runtime, so it must match the image sandbox-runtime is
+      # allowed to spawn.
+      ORCHEO_SANDBOX_IMAGE: ${ORCHEO_SANDBOX_IMAGE:-orcheo/workspace-sandbox:latest}
+      ORCHEO_CONTAINER_RUNTIME: ${ORCHEO_CONTAINER_RUNTIME:-runsc}
       ORCHEO_MCP_STDIO_LOG: /dev/stderr
       PYTHONUNBUFFERED: "1"
     depends_on:
       redis:
         condition: service_healthy
       postgres:
+        condition: service_healthy
+      sandbox-runtime:
         condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://localhost:2025/api/system/health > /dev/null"]
@@ -105,12 +114,21 @@ services:
       ORCHEO_PLUGIN_DIR: /data/plugins
       ORCHEO_CACHE_DIR: /data/cache/orcheo
       ORCHEO_BACKEND_INTERNAL_URL: http://backend:2025
+      ORCHEO_SANDBOX_RUNTIME_URL: ${ORCHEO_SANDBOX_RUNTIME_URL:-http://sandbox-runtime:9090}
+      ORCHEO_CREDENTIAL_BROKER_SECRET: ${ORCHEO_CREDENTIAL_BROKER_SECRET:?set ORCHEO_CREDENTIAL_BROKER_SECRET}
+      # Backend/worker embed this image name in every ContainerSpec they send
+      # to sandbox-runtime, so it must match the image sandbox-runtime is
+      # allowed to spawn.
+      ORCHEO_SANDBOX_IMAGE: ${ORCHEO_SANDBOX_IMAGE:-orcheo/workspace-sandbox:latest}
+      ORCHEO_CONTAINER_RUNTIME: ${ORCHEO_CONTAINER_RUNTIME:-runsc}
       ORCHEO_MCP_STDIO_LOG: /dev/stderr
       PYTHONUNBUFFERED: "1"
     depends_on:
       redis:
         condition: service_healthy
       postgres:
+        condition: service_healthy
+      sandbox-runtime:
         condition: service_healthy
     command: python -m celery -A orcheo_backend.worker.celery_app worker --loglevel=info
 
@@ -199,17 +217,24 @@ services:
   sandbox-runtime:
     # Sole service mounting the container-runtime socket. Treat as
     # root-equivalent on the host; never expose this socket to tenant code.
-    image: ${ORCHEO_SANDBOX_RUNTIME_IMAGE:-alpine:3.20}
+    image: ${ORCHEO_SANDBOX_RUNTIME_IMAGE:-ghcr.io/ai-colleagues/orcheo-sandbox-runtime:latest}
     restart: unless-stopped
-    command: ["sh", "-c", "trap : TERM INT; tail -f /dev/null"]
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+      # Writable: the runtime calls `docker run` / `docker exec` to spawn
+      # per-workspace sandbox children.
+      - /var/run/docker.sock:/var/run/docker.sock
       - sandbox_scratch:/scratch
     environment:
       ORCHEO_CONTAINER_RUNTIME: ${ORCHEO_CONTAINER_RUNTIME:-runsc}
       ORCHEO_SANDBOX_IMAGE: ${ORCHEO_SANDBOX_IMAGE:-orcheo/workspace-sandbox:latest}
       ORCHEO_EGRESS_PROXY_URL: http://egress-proxy:3128
       ORCHEO_CREDENTIAL_BROKER_URL: http://backend:2025/internal/credentials/resolve
+      ORCHEO_CREDENTIAL_BROKER_SECRET: ${ORCHEO_CREDENTIAL_BROKER_SECRET:?set ORCHEO_CREDENTIAL_BROKER_SECRET}
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:9090/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     networks:
       - default
       - sandbox-egress

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -237,22 +237,18 @@ services:
     networks:
       - sandbox-egress
 
-  # Build-only service. The workspace-sandbox image is *not* run as part of
-  # the long-lived stack — it is the image the `sandbox-runtime` service
-  # spawns on demand to host vibe-agent sessions and tenant workflow runs.
-  # Putting it under a profile keeps `docker compose up` from trying to
-  # start it (there is no foreground process to run) while still letting
-  # `docker compose build` produce the image the runtime requires.
+  # The workspace-sandbox image is *not* run as part of the long-lived stack
+  # — it is the image the `sandbox-runtime` service spawns on demand to host
+  # vibe-agent sessions and tenant workflow runs. Declaring it as a service
+  # lets `docker compose up` build it automatically; the no-op command below
+  # makes the resulting container exit immediately so it leaves no long-lived
+  # process behind (default restart policy `no` keeps it from coming back).
   workspace-sandbox:
     build:
       context: .
       dockerfile: Dockerfile.workspace-sandbox
     image: ${ORCHEO_SANDBOX_IMAGE:-orcheo/workspace-sandbox:latest}
-    profiles: ["build-only"]
-    # No-op command; the image is only consumed by sandbox-runtime at run
-    # time. Anyone who accidentally `up`s this profile gets an immediate,
-    # informative exit instead of a long-running container doing nothing.
-    command: ["sh", "-c", "echo 'workspace-sandbox is a build-only image; nothing to run.' && exit 0"]
+    command: ["sh", "-c", "echo 'workspace-sandbox image is only consumed by sandbox-runtime at run time; nothing to run here.' && exit 0"]
 
 networks:
   sandbox-egress:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,8 @@ services:
       ORCHEO_MULTI_WORKSPACE_WORKSPACE_HEADER: ${ORCHEO_MULTI_WORKSPACE_WORKSPACE_HEADER:-X-Orcheo-Workspace}
       ORCHEO_PLUGIN_DIR: /data/plugins
       ORCHEO_CACHE_DIR: /data/cache/orcheo
+      ORCHEO_SANDBOX_RUNTIME_URL: ${ORCHEO_SANDBOX_RUNTIME_URL:-http://sandbox-runtime:9090}
+      ORCHEO_CREDENTIAL_BROKER_SECRET: ${ORCHEO_CREDENTIAL_BROKER_SECRET}
       # Use system Python from base image instead of downloading
       UV_PYTHON_PREFERENCE: system
       ORCHEO_MCP_STDIO_LOG: /dev/stderr
@@ -70,6 +72,8 @@ services:
       redis:
         condition: service_healthy
       postgres:
+        condition: service_healthy
+      sandbox-runtime:
         condition: service_healthy
     command: uv run uvicorn orcheo_backend.app:app --host 0.0.0.0 --port 2025 --reload
 
@@ -103,6 +107,8 @@ services:
       ORCHEO_PLUGIN_DIR: /data/plugins
       ORCHEO_CACHE_DIR: /data/cache/orcheo
       ORCHEO_BACKEND_INTERNAL_URL: http://backend:2025
+      ORCHEO_SANDBOX_RUNTIME_URL: ${ORCHEO_SANDBOX_RUNTIME_URL:-http://sandbox-runtime:9090}
+      ORCHEO_CREDENTIAL_BROKER_SECRET: ${ORCHEO_CREDENTIAL_BROKER_SECRET}
       # Use system Python from base image instead of downloading
       UV_PYTHON_PREFERENCE: system
       ORCHEO_MCP_STDIO_LOG: /dev/stderr
@@ -111,6 +117,8 @@ services:
       redis:
         condition: service_healthy
       postgres:
+        condition: service_healthy
+      sandbox-runtime:
         condition: service_healthy
     command: uv run celery -A orcheo_backend.worker.celery_app worker --loglevel=info
 
@@ -191,14 +199,20 @@ services:
       dockerfile: Dockerfile.sandbox-runtime
     image: ${ORCHEO_SANDBOX_RUNTIME_IMAGE:-orcheo/sandbox-runtime:local}
     restart: unless-stopped
+    # Docker socket must be writable so we can `docker run` and `docker exec`.
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /var/run/docker.sock:/var/run/docker.sock
       - sandbox_scratch:/scratch
     environment:
       ORCHEO_CONTAINER_RUNTIME: ${ORCHEO_CONTAINER_RUNTIME:-runsc}
       ORCHEO_SANDBOX_IMAGE: ${ORCHEO_SANDBOX_IMAGE:-orcheo/workspace-sandbox:latest}
       ORCHEO_EGRESS_PROXY_URL: http://egress-proxy:3128
       ORCHEO_CREDENTIAL_BROKER_URL: http://backend:2025/internal/credentials/resolve
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:9090/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     networks:
       - default
       - sandbox-egress

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,11 @@ services:
       ORCHEO_CACHE_DIR: /data/cache/orcheo
       ORCHEO_SANDBOX_RUNTIME_URL: ${ORCHEO_SANDBOX_RUNTIME_URL:-http://sandbox-runtime:9090}
       ORCHEO_CREDENTIAL_BROKER_SECRET: ${ORCHEO_CREDENTIAL_BROKER_SECRET}
+      # Runtime name embedded in every ContainerSpec the backend sends to
+      # sandbox-runtime. Defaults to `runc` for local dev so the stack works
+      # on stock Docker; production must override to `runsc` (gVisor) for
+      # the documented isolation guarantees.
+      ORCHEO_CONTAINER_RUNTIME: ${ORCHEO_CONTAINER_RUNTIME:-runc}
       # Use system Python from base image instead of downloading
       UV_PYTHON_PREFERENCE: system
       ORCHEO_MCP_STDIO_LOG: /dev/stderr
@@ -109,6 +114,9 @@ services:
       ORCHEO_BACKEND_INTERNAL_URL: http://backend:2025
       ORCHEO_SANDBOX_RUNTIME_URL: ${ORCHEO_SANDBOX_RUNTIME_URL:-http://sandbox-runtime:9090}
       ORCHEO_CREDENTIAL_BROKER_SECRET: ${ORCHEO_CREDENTIAL_BROKER_SECRET}
+      # See note in the `backend` service above; the worker also builds
+      # ContainerSpecs and must agree with the backend on the runtime name.
+      ORCHEO_CONTAINER_RUNTIME: ${ORCHEO_CONTAINER_RUNTIME:-runc}
       # Use system Python from base image instead of downloading
       UV_PYTHON_PREFERENCE: system
       ORCHEO_MCP_STDIO_LOG: /dev/stderr
@@ -204,7 +212,10 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - sandbox_scratch:/scratch
     environment:
-      ORCHEO_CONTAINER_RUNTIME: ${ORCHEO_CONTAINER_RUNTIME:-runsc}
+      # Mirrored from the backend/worker for parity, in case future code in
+      # the runtime service decides to read it. The authoritative value is
+      # still the one the backend embeds in each ContainerSpec.
+      ORCHEO_CONTAINER_RUNTIME: ${ORCHEO_CONTAINER_RUNTIME:-runc}
       ORCHEO_SANDBOX_IMAGE: ${ORCHEO_SANDBOX_IMAGE:-orcheo/workspace-sandbox:latest}
       ORCHEO_EGRESS_PROXY_URL: http://egress-proxy:3128
       ORCHEO_CREDENTIAL_BROKER_URL: http://backend:2025/internal/credentials/resolve
@@ -226,8 +237,29 @@ services:
     networks:
       - sandbox-egress
 
+  # Build-only service. The workspace-sandbox image is *not* run as part of
+  # the long-lived stack — it is the image the `sandbox-runtime` service
+  # spawns on demand to host vibe-agent sessions and tenant workflow runs.
+  # Putting it under a profile keeps `docker compose up` from trying to
+  # start it (there is no foreground process to run) while still letting
+  # `docker compose build` produce the image the runtime requires.
+  workspace-sandbox:
+    build:
+      context: .
+      dockerfile: Dockerfile.workspace-sandbox
+    image: ${ORCHEO_SANDBOX_IMAGE:-orcheo/workspace-sandbox:latest}
+    profiles: ["build-only"]
+    # No-op command; the image is only consumed by sandbox-runtime at run
+    # time. Anyone who accidentally `up`s this profile gets an immediate,
+    # informative exit instead of a long-running container doing nothing.
+    command: ["sh", "-c", "echo 'workspace-sandbox is a build-only image; nothing to run.' && exit 0"]
+
 networks:
   sandbox-egress:
+    # Sandbox child containers are created through the host Docker API with
+    # network_mode=sandbox-egress, so this must be the real Docker network
+    # name rather than Compose's project-prefixed default.
+    name: sandbox-egress
     # nftables rules attached to this bridge enforce the L3/L4 deny policy.
     # See deploy/stack/sandbox-egress.nft.
     driver: bridge

--- a/docs/operators/workspace_runtime_isolation.md
+++ b/docs/operators/workspace_runtime_isolation.md
@@ -14,9 +14,12 @@ For background, see the initiative documents under
 1. A Linux host with the `runsc` (gVisor) Docker runtime registered. On
    standard EC2 (no `/dev/kvm`) gVisor's `systrap` platform is required.
 2. `nftables` available on the host so the L3/L4 deny ruleset can be loaded.
-3. An OCI image registry the host can pull `orcheo/workspace-sandbox` from
-   (`Dockerfile.workspace-sandbox` ships at the repo root). One sandbox image
-   hosts both vibe agent sessions and tenant workflow runs per workspace.
+3. The `orcheo/workspace-sandbox:latest` image must be available to the
+   Docker daemon that `sandbox-runtime` talks to. Either build it locally
+   (`make workspace-sandbox-build` — see the Deploy section) or push a
+   tagged version to a registry the host can pull from and point
+   `ORCHEO_SANDBOX_IMAGE` at it. One sandbox image hosts both vibe agent
+   sessions and tenant workflow runs per workspace.
 
 ## Configuration
 
@@ -30,19 +33,30 @@ override:
 | `ORCHEO_SANDBOX_IMAGE`                | `orcheo/workspace-sandbox:latest`                                      | Image hosting agent CLIs, Orcheo CLI, and workflow runner. |
 | `ORCHEO_SANDBOX_RUNTIME_URL`          | `http://sandbox-runtime:9090`                                          | Internal URL of the sandbox-runtime service. Backend and worker call this to provision sandboxes and dispatch runs — they never mount the Docker socket themselves. |
 | `ORCHEO_EGRESS_PROXY_URL`             | `http://egress-proxy:3128`                                             | Envoy forward proxy for permitted HTTP/HTTPS.            |
-| `ORCHEO_CREDENTIAL_BROKER_URL`        | `http://backend:2025/internal/credentials/resolve`                     | Endpoint sandboxes use to resolve run-scoped credentials.|
+| `ORCHEO_CREDENTIAL_BROKER_URL`        | `http://sandbox-runtime:9090/credentials/resolve`                      | Endpoint workspace sandboxes use to resolve run-scoped credentials. The `sandbox-runtime` service overrides this to the backend broker upstream. |
 | `ORCHEO_CREDENTIAL_BROKER_SECRET`     | _(required — backend refuses to start if unset)_                       | HMAC secret for run-scoped tokens — generate with `python -m orcheo.sandbox.broker --gen-secret`. |
 | `ORCHEO_SANDBOX_FAST_PATH_TRUSTED`    | `false`                                                                | When `true`, workflows composed only of trusted node types skip the sandbox (workflow runs only — vibe agents always sandbox). |
 
 ## Deploy
 
 ```
+make workspace-sandbox-build   # one-shot bootstrap of the per-workspace image
 docker compose up -d
 nft -f deploy/stack/sandbox-egress.nft
 ```
 
 The `sandbox-runtime` and `egress-proxy` services are baked into the base
 `docker-compose.yml`, so no overlay is needed.
+
+The `workspace-sandbox` image is what the `sandbox-runtime` service spawns
+on demand to host vibe-agent sessions and tenant workflow runs — it is *not*
+a long-lived service. It ships as a build-only compose service under the
+`build-only` profile, which is why a plain `docker compose up -d` ignores
+it and the bootstrap step above (or the equivalent
+`docker compose --profile build-only build workspace-sandbox`) is required
+once after cloning and again whenever `Dockerfile.workspace-sandbox` changes.
+Production deployments typically push a tagged version of this image to an
+internal registry and override `ORCHEO_SANDBOX_IMAGE` instead.
 
 The Envoy config at `deploy/stack/envoy-forward-proxy.yaml` can be
 regenerated from per-workspace allowlists with:

--- a/docs/operators/workspace_runtime_isolation.md
+++ b/docs/operators/workspace_runtime_isolation.md
@@ -15,11 +15,13 @@ For background, see the initiative documents under
    standard EC2 (no `/dev/kvm`) gVisor's `systrap` platform is required.
 2. `nftables` available on the host so the L3/L4 deny ruleset can be loaded.
 3. The `orcheo/workspace-sandbox:latest` image must be available to the
-   Docker daemon that `sandbox-runtime` talks to. Either build it locally
-   (`make workspace-sandbox-build` — see the Deploy section) or push a
-   tagged version to a registry the host can pull from and point
-   `ORCHEO_SANDBOX_IMAGE` at it. One sandbox image hosts both vibe agent
-   sessions and tenant workflow runs per workspace.
+   Docker daemon that `sandbox-runtime` talks to. `docker compose up -d`
+   builds it as part of bringing the stack up; you can also rebuild just
+   that image with `make workspace-sandbox-build` after editing
+   `Dockerfile.workspace-sandbox`. Alternatively, push a tagged version
+   to a registry the host can pull from and point `ORCHEO_SANDBOX_IMAGE`
+   at it. One sandbox image hosts both vibe agent sessions and tenant
+   workflow runs per workspace.
 
 ## Configuration
 
@@ -40,8 +42,7 @@ override:
 ## Deploy
 
 ```
-make workspace-sandbox-build   # one-shot bootstrap of the per-workspace image
-docker compose up -d
+docker compose up -d           # builds and starts the stack; workspace-sandbox is built as part of this
 nft -f deploy/stack/sandbox-egress.nft
 ```
 
@@ -50,11 +51,12 @@ The `sandbox-runtime` and `egress-proxy` services are baked into the base
 
 The `workspace-sandbox` image is what the `sandbox-runtime` service spawns
 on demand to host vibe-agent sessions and tenant workflow runs — it is *not*
-a long-lived service. It ships as a build-only compose service under the
-`build-only` profile, which is why a plain `docker compose up -d` ignores
-it and the bootstrap step above (or the equivalent
-`docker compose --profile build-only build workspace-sandbox`) is required
-once after cloning and again whenever `Dockerfile.workspace-sandbox` changes.
+a long-lived service. It's declared as a normal Compose service so
+`docker compose up -d` builds the image automatically; its `command:` is a
+no-op `exit 0`, so the resulting container exits immediately and the image
+is then consumed only by `sandbox-runtime` over the Docker API. After
+editing `Dockerfile.workspace-sandbox`, rebuild with `make
+workspace-sandbox-build` (or `docker compose build workspace-sandbox`).
 Production deployments typically push a tagged version of this image to an
 internal registry and override `ORCHEO_SANDBOX_IMAGE` instead.
 

--- a/docs/operators/workspace_runtime_isolation.md
+++ b/docs/operators/workspace_runtime_isolation.md
@@ -28,10 +28,11 @@ override:
 |---------------------------------------|------------------------------------------------------------------------|----------------------------------------------------------|
 | `ORCHEO_CONTAINER_RUNTIME`            | `runsc`                                                                | Docker runtime name (`runsc` for gVisor).                |
 | `ORCHEO_SANDBOX_IMAGE`                | `orcheo/workspace-sandbox:latest`                                      | Image hosting agent CLIs, Orcheo CLI, and workflow runner. |
+| `ORCHEO_SANDBOX_RUNTIME_URL`          | `http://sandbox-runtime:9090`                                          | Internal URL of the sandbox-runtime service. Backend and worker call this to provision sandboxes and dispatch runs — they never mount the Docker socket themselves. |
 | `ORCHEO_EGRESS_PROXY_URL`             | `http://egress-proxy:3128`                                             | Envoy forward proxy for permitted HTTP/HTTPS.            |
 | `ORCHEO_CREDENTIAL_BROKER_URL`        | `http://backend:2025/internal/credentials/resolve`                     | Endpoint sandboxes use to resolve run-scoped credentials.|
-| `ORCHEO_CREDENTIAL_BROKER_SECRET`     | _(required)_                                                           | HMAC secret for run-scoped tokens — generate with `python -m orcheo.sandbox.broker --gen-secret`. |
-| `ORCHEO_SANDBOX_FAST_PATH_TRUSTED`    | `false`                                                                | When `true`, workflows composed only of trusted node types skip the sandbox. |
+| `ORCHEO_CREDENTIAL_BROKER_SECRET`     | _(required — backend refuses to start if unset)_                       | HMAC secret for run-scoped tokens — generate with `python -m orcheo.sandbox.broker --gen-secret`. |
+| `ORCHEO_SANDBOX_FAST_PATH_TRUSTED`    | `false`                                                                | When `true`, workflows composed only of trusted node types skip the sandbox (workflow runs only — vibe agents always sandbox). |
 
 ## Deploy
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,13 @@ docs = [
 examples = [
   "orcheo-backend"
 ]
+# Extra packages only the sandbox-runtime image needs. The runtime service is
+# the only Orcheo component that talks to the host Docker daemon directly via
+# the `docker` Python SDK; backend / worker reach it over HTTP and do not
+# install this group.
+sandbox-runtime = [
+  "docker>=7.0.0"
+]
 
 [project]
 dependencies = [

--- a/src/orcheo/external_agents/paths.py
+++ b/src/orcheo/external_agents/paths.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 import os
 import subprocess
+from collections.abc import Mapping
 from pathlib import Path
 from orcheo.external_agents.models import WorkingDirectoryValidationError
 
@@ -13,14 +14,30 @@ DEFAULT_RUNTIME_ROOT_UNDER_HOME = Path("~/.orcheo") / DEFAULT_RUNTIME_DIR_NAME
 DEFAULT_WORKSPACE_AGENT_ROOT = Path("/workspace/agents")
 RUNTIMES_DIR_NAME = "runtimes"
 STAGING_DIR_NAME = "staging"
+RUNTIME_ROOT_ENV_VAR = "ORCHEO_AGENT_RUNTIME_ROOT"
 
 
 def default_runtime_root(
     *,
     data_root: Path = Path("/data"),
     home_directory: Path | None = None,
+    env: Mapping[str, str] | None = None,
 ) -> Path:
-    """Return the default managed runtime root for the current host."""
+    """Return the default managed runtime root for the current host.
+
+    The lookup order is:
+
+    1. ``ORCHEO_AGENT_RUNTIME_ROOT`` from the environment — set by the sandbox
+       runtime manager so per-workspace sandboxes write under the writable
+       ``/scratch`` tmpfs instead of the read-only rootfs.
+    2. ``/data/agent-runtimes`` when the data volume is writable.
+    3. ``~/.orcheo/agent-runtimes`` as the final fallback.
+    """
+    environment = env if env is not None else os.environ
+    override = environment.get(RUNTIME_ROOT_ENV_VAR, "").strip()
+    if override:
+        return Path(override)
+
     if data_root.exists() and os.access(data_root, os.W_OK | os.X_OK):
         return data_root / DEFAULT_RUNTIME_DIR_NAME
 

--- a/src/orcheo/nodes/ai/external/base.py
+++ b/src/orcheo/nodes/ai/external/base.py
@@ -11,7 +11,6 @@ from orcheo.external_agents import (
     RuntimeInstallError,
     RuntimeVerificationError,
     WorkingDirectoryValidationError,
-    execute_process,
 )
 from orcheo.graph.state import State
 from orcheo.nodes.base import TaskNode
@@ -19,6 +18,7 @@ from orcheo.runtime.credentials import (
     CredentialReferenceNotFoundError,
     CredentialResolverUnavailableError,
 )
+from orcheo.sandbox.dispatch import run_external_agent_process
 
 
 logger = logging.getLogger(__name__)
@@ -226,8 +226,9 @@ class ExternalAgentNode(TaskNode):
                 "External agent execution requested provider bypass flags.",
                 extra={"node_name": self.name, **audit_metadata},
             )
-        result = await execute_process(
+        result = await run_external_agent_process(
             command,
+            workspace_id=workspace_id,
             cwd=working_directory,
             env=provider.build_environment(provider_environ),
             timeout_seconds=self.timeout_seconds,

--- a/src/orcheo/nodes/external_agent.py
+++ b/src/orcheo/nodes/external_agent.py
@@ -11,7 +11,6 @@ from orcheo.external_agents import (
     RuntimeInstallError,
     RuntimeVerificationError,
     WorkingDirectoryValidationError,
-    execute_process,
 )
 from orcheo.graph.state import State
 from orcheo.nodes.base import TaskNode
@@ -19,7 +18,7 @@ from orcheo.runtime.credentials import (
     CredentialReferenceNotFoundError,
     CredentialResolverUnavailableError,
 )
-from orcheo.sandbox.dispatch import get_active_launcher
+from orcheo.sandbox.dispatch import run_external_agent_process
 
 
 logger = logging.getLogger(__name__)
@@ -227,23 +226,14 @@ class ExternalAgentNode(TaskNode):
                 "External agent execution requested provider bypass flags.",
                 extra={"node_name": self.name, **audit_metadata},
             )
-        launcher = get_active_launcher()
         agent_env = provider.build_environment(provider_environ)
-        if launcher is not None and workspace_id:
-            result = await launcher.run(
-                workspace_id=workspace_id,
-                command=command,
-                cwd=working_directory,
-                env=agent_env,
-                timeout_seconds=self.timeout_seconds,
-            )
-        else:
-            result = await execute_process(
-                command,
-                cwd=working_directory,
-                env=agent_env,
-                timeout_seconds=self.timeout_seconds,
-            )
+        result = await run_external_agent_process(
+            command,
+            workspace_id=workspace_id,
+            cwd=working_directory,
+            env=agent_env,
+            timeout_seconds=self.timeout_seconds,
+        )
         self._set_trace_metadata_for_run(
             {
                 "external_agent": {

--- a/src/orcheo/sandbox/broker.py
+++ b/src/orcheo/sandbox/broker.py
@@ -226,3 +226,26 @@ def _b64decode(value: str) -> bytes:
 def generate_broker_secret() -> str:
     """Return a fresh 256-bit secret encoded as URL-safe base64."""
     return secrets.token_urlsafe(32)
+
+
+def _cli() -> None:  # pragma: no cover - tiny CLI helper
+    """Tiny CLI for ``python -m orcheo.sandbox.broker --gen-secret``."""
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser(description="Credential Broker helpers")
+    parser.add_argument(
+        "--gen-secret",
+        action="store_true",
+        help="Print a fresh URL-safe 256-bit secret suitable for "
+        "ORCHEO_CREDENTIAL_BROKER_SECRET.",
+    )
+    args = parser.parse_args()
+    if args.gen_secret:
+        sys.stdout.write(generate_broker_secret() + "\n")
+        return
+    parser.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    _cli()

--- a/src/orcheo/sandbox/config.py
+++ b/src/orcheo/sandbox/config.py
@@ -7,6 +7,9 @@ flag.
 """
 
 from __future__ import annotations
+import os
+from collections.abc import Mapping
+from typing import Any, ClassVar
 from pydantic import BaseModel, Field, field_validator
 
 
@@ -42,7 +45,16 @@ class SandboxSettings(BaseModel):
         ),
     )
     default_cpu_limit: str = Field(default="1.0")
-    default_memory_limit: str = Field(default="512m")
+    # ``/scratch``, ``/workspace``, and ``/home/orcheo`` are mounted as tmpfs
+    # (see ``DockerContainerRuntime._build_host_config``). On Linux, tmpfs
+    # pages are charged to the container's memory cgroup, so the memory limit
+    # has to cover the resident-set size of the workflow runner PLUS the
+    # working set of all three tmpfs mounts (npm cache in ``~/.npm``, the
+    # managed agent-runtime tree in ``/scratch/agent-runtimes``, anything the
+    # agent writes under ``/workspace``). 512 MiB OOM-killed any run that did
+    # a real ``npm install``; 2 GiB leaves enough headroom for the agent CLIs
+    # plus a fresh provider install.
+    default_memory_limit: str = Field(default="2g")
     default_pid_limit: int = Field(default=256, ge=1)
     default_scratch_disk_limit: str = Field(default="1g")
     default_idle_ttl_seconds: int = Field(default=900, ge=1)
@@ -58,8 +70,8 @@ class SandboxSettings(BaseModel):
         ),
     )
     credential_broker_url: str = Field(
-        default="http://backend:2025/internal/credentials/resolve",
-        description="Backend endpoint the Credential Broker listens on.",
+        default="http://sandbox-runtime:9090/credentials/resolve",
+        description="Credential endpoint reachable from workspace sandboxes.",
     )
     audit_logger_name: str = Field(default="orcheo.sandbox.audit")
 
@@ -71,3 +83,46 @@ class SandboxSettings(BaseModel):
             msg = "default_pool_max must be >= 1"
             raise ValueError(msg)
         return value
+
+    # Mapping of model field → environment variable. Kept explicit so the
+    # documented operator-facing names in
+    # ``docs/operators/workspace_runtime_isolation.md`` stay in sync with
+    # what the code actually reads. Unset env vars fall back to the field
+    # default. Booleans/numbers are coerced by Pydantic's validators.
+    _FIELD_TO_ENV: ClassVar[dict[str, str]] = {
+        "container_runtime": "ORCHEO_CONTAINER_RUNTIME",
+        "image": "ORCHEO_SANDBOX_IMAGE",
+        "default_cpu_limit": "ORCHEO_SANDBOX_DEFAULT_CPU_LIMIT",
+        "default_memory_limit": "ORCHEO_SANDBOX_DEFAULT_MEMORY_LIMIT",
+        "default_pid_limit": "ORCHEO_SANDBOX_DEFAULT_PID_LIMIT",
+        "default_scratch_disk_limit": "ORCHEO_SANDBOX_DEFAULT_SCRATCH_DISK_LIMIT",
+        "default_idle_ttl_seconds": "ORCHEO_SANDBOX_DEFAULT_IDLE_TTL_SECONDS",
+        "default_pool_min": "ORCHEO_SANDBOX_DEFAULT_POOL_MIN",
+        "default_pool_max": "ORCHEO_SANDBOX_DEFAULT_POOL_MAX",
+        "egress_proxy_url": "ORCHEO_EGRESS_PROXY_URL",
+        "credential_broker_url": "ORCHEO_CREDENTIAL_BROKER_URL",
+        "audit_logger_name": "ORCHEO_SANDBOX_AUDIT_LOGGER_NAME",
+    }
+
+    @classmethod
+    def from_mapping(cls, source: Mapping[str, Any]) -> SandboxSettings:
+        """Build settings from a ``Mapping`` (e.g. ``os.environ``).
+
+        Unset / blank values fall back to the field default. This is how the
+        process bootstraps actually pick up operator env-var overrides; the
+        previous ``SandboxSettings()`` call quietly ignored every override.
+        """
+        kwargs: dict[str, Any] = {}
+        for field_name, env_key in cls._FIELD_TO_ENV.items():
+            value = source.get(env_key)
+            if value is None:
+                continue
+            if isinstance(value, str) and not value.strip():
+                continue
+            kwargs[field_name] = value
+        return cls(**kwargs)
+
+    @classmethod
+    def from_env(cls) -> SandboxSettings:
+        """Build settings from the process environment."""
+        return cls.from_mapping(os.environ)

--- a/src/orcheo/sandbox/dispatch.py
+++ b/src/orcheo/sandbox/dispatch.py
@@ -15,21 +15,27 @@ from contextvars import ContextVar
 from pathlib import Path
 from orcheo.external_agents.models import ProcessExecutionResult
 from orcheo.sandbox.errors import SandboxError
-from orcheo.sandbox.launcher import SandboxedProcessLauncher
+from orcheo.sandbox.launcher import ProcessLauncher
 
 
 class SandboxDispatchError(SandboxError):
     """Raised when an agent process is dispatched without an active sandbox."""
 
 
-_active_launcher: ContextVar[SandboxedProcessLauncher | None] = ContextVar(
+_active_launcher: ContextVar[ProcessLauncher | None] = ContextVar(
     "orcheo_sandbox_active_launcher", default=None
 )
 
 
 @contextmanager
-def use_launcher(launcher: SandboxedProcessLauncher) -> Iterator[None]:
-    """Bind ``launcher`` as the active sandbox dispatcher within this context."""
+def use_launcher(launcher: ProcessLauncher) -> Iterator[None]:
+    """Bind ``launcher`` as the active process dispatcher within this context.
+
+    Accepts any object satisfying :class:`ProcessLauncher` — production
+    callers in the backend / worker bind a ``SandboxedProcessLauncher``;
+    ``workflow_runner`` (which runs inside a sandbox) binds a
+    ``LocalProcessLauncher``.
+    """
     token = _active_launcher.set(launcher)
     try:
         yield
@@ -37,7 +43,7 @@ def use_launcher(launcher: SandboxedProcessLauncher) -> Iterator[None]:
         _active_launcher.reset(token)
 
 
-def get_active_launcher() -> SandboxedProcessLauncher | None:
+def get_active_launcher() -> ProcessLauncher | None:
     """Return the launcher bound to the current async context, if any."""
     return _active_launcher.get()
 

--- a/src/orcheo/sandbox/dispatch.py
+++ b/src/orcheo/sandbox/dispatch.py
@@ -1,14 +1,11 @@
 """Context-managed dispatcher for the sandboxed agent-launch path.
 
-Nodes call ``run_external_agent_process(...)`` instead of ``execute_process``
-directly. When a ``SandboxedProcessLauncher`` is installed via
-``use_launcher`` (a context manager), the call routes through the sandbox.
-When no launcher is active — single-tenant deploys, unit tests, or self-
-hosted setups with the feature flag off — the call falls straight through to
-``execute_process`` so the legacy behavior is unchanged.
-
-This keeps the change footprint on existing nodes tiny: one import + one
-call swap.
+Nodes call ``run_external_agent_process(...)`` instead of spawning processes
+directly. A ``SandboxedProcessLauncher`` must be bound via ``use_launcher``
+before any agent CLI runs — workspace runtime isolation is always on, and
+there is no host-fallback path. Calling without an active launcher or
+without a workspace id is a programmer error and raises
+``SandboxDispatchError``.
 """
 
 from __future__ import annotations
@@ -17,8 +14,12 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from pathlib import Path
 from orcheo.external_agents.models import ProcessExecutionResult
-from orcheo.external_agents.process import execute_process
+from orcheo.sandbox.errors import SandboxError
 from orcheo.sandbox.launcher import SandboxedProcessLauncher
+
+
+class SandboxDispatchError(SandboxError):
+    """Raised when an agent process is dispatched without an active sandbox."""
 
 
 _active_launcher: ContextVar[SandboxedProcessLauncher | None] = ContextVar(
@@ -27,9 +28,7 @@ _active_launcher: ContextVar[SandboxedProcessLauncher | None] = ContextVar(
 
 
 @contextmanager
-def use_launcher(
-    launcher: SandboxedProcessLauncher | None,
-) -> Iterator[None]:
+def use_launcher(launcher: SandboxedProcessLauncher) -> Iterator[None]:
     """Bind ``launcher`` as the active sandbox dispatcher within this context."""
     token = _active_launcher.set(launcher)
     try:
@@ -51,19 +50,21 @@ async def run_external_agent_process(
     env: Mapping[str, str] | None,
     timeout_seconds: float | int | None,
 ) -> ProcessExecutionResult:
-    """Run an external agent's CLI through the sandbox launcher if active.
+    """Run an external agent's CLI through the active sandbox launcher.
 
-    Falls back to ``execute_process`` when no launcher is bound or
-    ``workspace_id`` is missing (cannot scope a sandbox without it).
+    Raises ``SandboxDispatchError`` if no launcher is bound or
+    ``workspace_id`` is missing — there is no host fallback.
     """
     launcher = get_active_launcher()
-    if launcher is None or not workspace_id:
-        return await execute_process(
-            command,
-            cwd=cwd,
-            env=env,
-            timeout_seconds=timeout_seconds,
+    if launcher is None:
+        msg = (
+            "No sandbox launcher bound for agent process dispatch. "
+            "Wrap the call site in `with use_launcher(...)`."
         )
+        raise SandboxDispatchError(msg)
+    if not workspace_id:
+        msg = "workspace_id is required to dispatch an agent process to a sandbox"
+        raise SandboxDispatchError(msg)
     return await launcher.run(
         workspace_id=workspace_id,
         command=command,

--- a/src/orcheo/sandbox/launcher.py
+++ b/src/orcheo/sandbox/launcher.py
@@ -1,28 +1,25 @@
 """Launcher that runs agent processes inside a sandbox lease.
 
-``SandboxedProcessLauncher`` is the integration point between the existing
-``ExternalAgentNode`` (which currently spawns CLI processes directly via
-``execute_process``) and the Sandbox Runtime Manager. The launcher:
+``SandboxedProcessLauncher`` is the integration point between
+``ExternalAgentNode`` and the Sandbox Runtime Manager. The launcher:
 
-1. Acquires an agent sandbox for the workspace.
+1. Acquires a workspace sandbox via the manager.
 2. Runs the CLI inside the sandbox via the runtime's exec primitive
-   (``docker exec`` under the hood, or a fake in tests).
-3. Destroys the sandbox on completion (agent sandboxes are single-use).
+   (``docker exec`` under the hood, or an HTTP call to the sandbox-runtime
+   service via ``RemoteSandboxExec``).
+3. Releases the sandbox to the warm pool when done.
 
-This module intentionally keeps the ``execute_process`` fallback intact:
-when the feature flag is off, callers pass through directly to the legacy
-path. Wiring in ``ExternalAgentNode`` lives in
-``orcheo.nodes.external_agent``.
+There is no host fallback. Workspace runtime isolation is always on — any
+caller that fails to provide a real ``_SandboxExec`` backend gets a
+construction-time error so silently-unsandboxed execution is impossible.
 """
 
 from __future__ import annotations
 import asyncio
 from collections.abc import Mapping
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
 from orcheo.external_agents.models import ProcessExecutionResult
-from orcheo.external_agents.process import execute_process
 from orcheo.sandbox.manager import SandboxRuntimeManager
 
 
@@ -41,47 +38,24 @@ class _SandboxExec(Protocol):
         """Execute ``command`` inside ``sandbox_id`` and return the result."""
 
 
-@dataclass
-class HostFallbackExec:
-    """Default exec that just runs the process on the host (legacy path)."""
-
-    async def exec(
-        self,
-        sandbox_id: str,
-        command: list[str],
-        *,
-        cwd: Path | None,
-        env: Mapping[str, str] | None,
-        timeout_seconds: float | int | None,
-    ) -> ProcessExecutionResult:
-        """Forward to the legacy ``execute_process`` helper."""
-        del sandbox_id
-        return await execute_process(
-            command,
-            cwd=cwd,
-            env=env,
-            timeout_seconds=timeout_seconds,
-        )
-
-
 class SandboxedProcessLauncher:
-    """Run a one-shot process inside a freshly-provisioned agent sandbox."""
+    """Run a one-shot process inside a per-workspace sandbox lease."""
 
     def __init__(
         self,
         manager: SandboxRuntimeManager,
-        exec_backend: _SandboxExec | None = None,
+        exec_backend: _SandboxExec,
     ) -> None:
         """Initialize the launcher.
 
         Args:
             manager: Sandbox Runtime Manager that owns lifecycles.
-            exec_backend: How to run the command inside the sandbox. Defaults
-                to ``HostFallbackExec`` for environments where the sandbox is
-                a no-op (tests, single-tenant).
+            exec_backend: How to run the command inside the sandbox. Required —
+                there is no host fallback. Pass a ``RemoteSandboxExec`` for
+                production or a test double for unit tests.
         """
         self._manager = manager
-        self._exec = exec_backend or HostFallbackExec()
+        self._exec = exec_backend
 
     async def run(
         self,

--- a/src/orcheo/sandbox/launcher.py
+++ b/src/orcheo/sandbox/launcher.py
@@ -20,7 +20,32 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Protocol
 from orcheo.external_agents.models import ProcessExecutionResult
+from orcheo.external_agents.process import execute_process
 from orcheo.sandbox.manager import SandboxRuntimeManager
+
+
+class ProcessLauncher(Protocol):
+    """Protocol satisfied by both the remote and in-sandbox launchers.
+
+    Outside the sandbox (backend / worker) the bound launcher is a
+    :class:`SandboxedProcessLauncher` that ``docker exec``s into a per-workspace
+    sandbox container. Inside the sandbox (when ``WorkflowSandboxDispatcher``
+    routes the entire workflow into a sandbox, and ``workflow_runner``
+    spawns the graph), the bound launcher is a :class:`LocalProcessLauncher`
+    that runs the CLI in-process — we are already isolated, so dispatching
+    to *another* sandbox would be a recursion with no benefit.
+    """
+
+    async def run(
+        self,
+        *,
+        workspace_id: str,
+        command: list[str],
+        cwd: Path | None,
+        env: Mapping[str, str] | None,
+        timeout_seconds: float | int | None,
+    ) -> ProcessExecutionResult:
+        """Run ``command`` on behalf of ``workspace_id``."""
 
 
 class _SandboxExec(Protocol):
@@ -78,3 +103,32 @@ class SandboxedProcessLauncher:
             )
         finally:
             await asyncio.to_thread(self._manager.release, lease)
+
+
+class LocalProcessLauncher:
+    """Launcher that runs commands directly in the current process tree.
+
+    Used by ``workflow_runner`` inside a sandbox container, where the workflow
+    is already isolated and dispatching each CLI to *another* sandbox would
+    add no isolation and a network hop. ``workspace_id`` is accepted (and
+    ignored) so the launcher is interchangeable with
+    :class:`SandboxedProcessLauncher`.
+    """
+
+    async def run(
+        self,
+        *,
+        workspace_id: str,
+        command: list[str],
+        cwd: Path | None,
+        env: Mapping[str, str] | None,
+        timeout_seconds: float | int | None,
+    ) -> ProcessExecutionResult:
+        """Run ``command`` in this process tree via ``execute_process``."""
+        del workspace_id
+        return await execute_process(
+            command,
+            cwd=cwd,
+            env=env,
+            timeout_seconds=timeout_seconds,
+        )

--- a/src/orcheo/sandbox/manager.py
+++ b/src/orcheo/sandbox/manager.py
@@ -38,6 +38,13 @@ from orcheo.sandbox.runtime import (
 
 _DEFAULT_NETWORK: Final[str] = "sandbox-egress"
 
+# Sandbox containers run with a read-only rootfs (see ContainerSpec defaults)
+# and only mount /scratch as writable tmpfs. Pinning the managed external-agent
+# runtime root under /scratch lets ExternalAgentRuntimeManager mkdir its tree
+# from inside the sandbox; without it the default ~/.orcheo path fails with
+# EACCES against the read-only rootfs.
+_SANDBOX_AGENT_RUNTIME_ROOT: Final[str] = "/scratch/agent-runtimes"
+
 
 class SandboxRuntimeManager:
     """Provision, lease, and destroy per-workspace sandbox containers."""
@@ -299,6 +306,10 @@ class SandboxRuntimeManager:
             image=self._settings.image,
             workspace_id=workspace_id,
             runtime=self._settings.container_runtime,
+            environment={
+                "ORCHEO_CREDENTIAL_BROKER_URL": self._settings.credential_broker_url,
+                "ORCHEO_AGENT_RUNTIME_ROOT": _SANDBOX_AGENT_RUNTIME_ROOT,
+            },
             cpu_limit=pool.cpu_limit,
             memory_limit=pool.memory_limit,
             pid_limit=pool.pid_limit,

--- a/src/orcheo/sandbox/remote.py
+++ b/src/orcheo/sandbox/remote.py
@@ -1,0 +1,298 @@
+"""HTTP clients that proxy sandbox operations to the sandbox-runtime service.
+
+The Docker socket is root-equivalent on the host (design §Security
+Considerations). The backend and Celery worker therefore never touch it
+directly — they call the dedicated ``sandbox-runtime`` container over HTTP,
+and that container is the only process with the socket mount.
+
+This module provides three clients:
+
+- ``RemoteContainerRuntime`` implements ``ContainerRuntime`` by POSTing to
+  ``/containers``. The :class:`SandboxRuntimeManager` uses it for
+  acquire/destroy.
+- ``RemoteSandboxExec`` implements ``_SandboxExec`` for
+  :class:`SandboxedProcessLauncher`, dispatching a one-shot ``docker exec``
+  via ``/sandboxes/{sandbox_id}/exec``.
+- ``RemoteSandboxRunner`` satisfies the
+  :class:`orcheo.sandbox.workflow.SandboxRunner` protocol so the workflow
+  dispatcher can stream a ``WorkflowRunSpec`` into a lease via
+  ``/sandboxes/{sandbox_id}/dispatch_workflow``.
+"""
+
+from __future__ import annotations
+from collections.abc import Mapping
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+from typing import Any, cast
+import httpx
+from orcheo.external_agents.models import ProcessExecutionResult
+from orcheo.sandbox.errors import SandboxAcquireError, SandboxLifecycleError
+from orcheo.sandbox.models import SandboxLease
+from orcheo.sandbox.runtime import ContainerHandle, ContainerSpec
+from orcheo.sandbox.workflow import WorkflowRunResult, WorkflowRunSpec
+
+
+class RemoteRuntimeError(SandboxLifecycleError):
+    """Raised when the sandbox-runtime service returns an error response."""
+
+
+def _spec_to_payload(spec: ContainerSpec) -> dict[str, Any]:
+    """Serialize a ``ContainerSpec`` for the runtime-service API."""
+    return {
+        "image": spec.image,
+        "workspace_id": spec.workspace_id,
+        "runtime": spec.runtime,
+        "command": list(spec.command),
+        "environment": dict(spec.environment),
+        "cpu_limit": spec.cpu_limit,
+        "memory_limit": spec.memory_limit,
+        "pid_limit": spec.pid_limit,
+        "scratch_size": spec.scratch_size,
+        "user": spec.user,
+        "network_mode": spec.network_mode,
+        "read_only_root": spec.read_only_root,
+        "cap_drop": list(spec.cap_drop),
+        "no_new_privileges": spec.no_new_privileges,
+        "labels": dict(spec.labels),
+    }
+
+
+def _handle_from_payload(payload: Mapping[str, Any]) -> ContainerHandle:
+    """Build a ``ContainerHandle`` from a runtime-service response."""
+    return ContainerHandle(
+        container_id=str(payload["container_id"]),
+        image=str(payload["image"]),
+        workspace_id=str(payload["workspace_id"]),
+        runtime=str(payload["runtime"]),
+    )
+
+
+class RemoteContainerRuntime:
+    """Container runtime backed by the sandbox-runtime HTTP service."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        client: httpx.Client | None = None,
+        timeout: float = 30.0,
+    ) -> None:
+        """Initialize the runtime.
+
+        Args:
+            base_url: Base URL of the sandbox-runtime service
+                (e.g. ``http://sandbox-runtime:9090``).
+            client: Optional pre-configured ``httpx.Client``; one is created
+                if omitted.
+            timeout: Request timeout in seconds.
+        """
+        self._base_url = base_url.rstrip("/")
+        self._owns_client = client is None
+        self._client = client or httpx.Client(timeout=timeout)
+
+    def close(self) -> None:
+        """Close the underlying HTTP client if we own it."""
+        if self._owns_client:
+            self._client.close()
+
+    def start(self, spec: ContainerSpec) -> ContainerHandle:
+        """Provision a container via the runtime service."""
+        response = self._client.post(
+            f"{self._base_url}/containers",
+            json=_spec_to_payload(spec),
+        )
+        self._raise_for_status(response, action="provision container")
+        return _handle_from_payload(response.json())
+
+    def stop(self, handle: ContainerHandle) -> None:
+        """Stop and remove the container via the runtime service."""
+        response = self._client.delete(
+            f"{self._base_url}/containers/{handle.container_id}",
+        )
+        if response.status_code == httpx.codes.NOT_FOUND:
+            return
+        self._raise_for_status(response, action="stop container")
+
+    def is_running(self, handle: ContainerHandle) -> bool:
+        """Return True if the runtime service still reports the container alive."""
+        response = self._client.get(
+            f"{self._base_url}/containers/{handle.container_id}",
+        )
+        if response.status_code == httpx.codes.NOT_FOUND:
+            return False
+        self._raise_for_status(response, action="inspect container")
+        return bool(response.json().get("running", False))
+
+    @staticmethod
+    def _raise_for_status(response: httpx.Response, *, action: str) -> None:
+        """Translate non-2xx responses into ``RemoteRuntimeError``."""
+        if response.is_success:
+            return
+        try:
+            detail = response.json().get("detail", response.text)
+        except ValueError:
+            detail = response.text
+        msg = f"sandbox-runtime {action} failed: {response.status_code} {detail}"
+        if response.status_code == httpx.codes.CONFLICT:
+            raise SandboxAcquireError(msg)
+        raise RemoteRuntimeError(msg)
+
+
+class RemoteSandboxExec:
+    """Sandbox exec backend that proxies ``docker exec`` to the runtime service."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        client: httpx.AsyncClient | None = None,
+        timeout: float = 60.0,
+    ) -> None:
+        """Initialize the exec backend.
+
+        Args:
+            base_url: Base URL of the sandbox-runtime service.
+            client: Optional pre-configured ``httpx.AsyncClient``.
+            timeout: Default request timeout in seconds.
+        """
+        self._base_url = base_url.rstrip("/")
+        self._owns_client = client is None
+        self._client = client or httpx.AsyncClient(timeout=timeout)
+        self._default_timeout = timeout
+
+    async def aclose(self) -> None:
+        """Close the underlying HTTP client if we own it."""
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def exec(
+        self,
+        sandbox_id: str,
+        command: list[str],
+        *,
+        cwd: Path | None,
+        env: Mapping[str, str] | None,
+        timeout_seconds: float | int | None,
+    ) -> ProcessExecutionResult:
+        """Execute ``command`` inside ``sandbox_id`` via the runtime service."""
+        payload: dict[str, Any] = {
+            "command": list(command),
+            "cwd": str(cwd) if cwd is not None else None,
+            "env": dict(env) if env is not None else None,
+            "timeout_seconds": (
+                float(timeout_seconds) if timeout_seconds is not None else None
+            ),
+        }
+        # Add a small wall-clock margin so the proxy can return a timeout
+        # result instead of being cut off by the HTTP timeout.
+        request_timeout = (
+            float(timeout_seconds) + 30.0
+            if timeout_seconds is not None
+            else self._default_timeout
+        )
+        response = await self._client.post(
+            f"{self._base_url}/sandboxes/{sandbox_id}/exec",
+            json=payload,
+            timeout=request_timeout,
+        )
+        if not response.is_success:
+            try:
+                detail = response.json().get("detail", response.text)
+            except ValueError:
+                detail = response.text
+            msg = f"sandbox-runtime exec failed: {response.status_code} {detail}"
+            raise RemoteRuntimeError(msg)
+        data = response.json()
+        return ProcessExecutionResult(
+            command=list(data.get("command", command)),
+            stdout=data.get("stdout", ""),
+            stderr=data.get("stderr", ""),
+            exit_code=data.get("exit_code"),
+            timed_out=bool(data.get("timed_out", False)),
+            duration_seconds=float(data.get("duration_seconds", 0.0)),
+        )
+
+
+def _workflow_spec_payload(spec: WorkflowRunSpec) -> dict[str, Any]:
+    """Serialize a ``WorkflowRunSpec`` for transport."""
+    return {
+        "run_id": spec.run_id,
+        "workspace_id": spec.workspace_id,
+        "workflow_definition": dict(spec.workflow_definition),
+        "inputs": dict(spec.inputs),
+        "node_types": list(spec.node_types),
+    }
+
+
+class RemoteSandboxRunner:
+    """Workflow ``SandboxRunner`` that proxies to the runtime service."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        client: httpx.AsyncClient | None = None,
+        timeout: float = 300.0,
+    ) -> None:
+        """Initialize the runner.
+
+        Args:
+            base_url: Base URL of the sandbox-runtime service.
+            client: Optional pre-configured ``httpx.AsyncClient``.
+            timeout: Default request timeout in seconds.
+        """
+        self._base_url = base_url.rstrip("/")
+        self._owns_client = client is None
+        self._client = client or httpx.AsyncClient(timeout=timeout)
+        self._default_timeout = timeout
+
+    async def aclose(self) -> None:
+        """Close the underlying HTTP client if we own it."""
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def execute(
+        self,
+        lease: SandboxLease,
+        spec: WorkflowRunSpec,
+        broker_token: str,
+    ) -> WorkflowRunResult:
+        """Send the run to the sandbox identified by ``lease`` and await its result."""
+        payload = {
+            "spec": _workflow_spec_payload(spec),
+            "broker_token": broker_token,
+        }
+        response = await self._client.post(
+            f"{self._base_url}/sandboxes/{lease.sandbox_id}/dispatch_workflow",
+            json=payload,
+            timeout=self._default_timeout,
+        )
+        if not response.is_success:
+            try:
+                detail = response.json().get("detail", response.text)
+            except ValueError:
+                detail = response.text
+            msg = (
+                "sandbox-runtime dispatch_workflow failed: "
+                f"{response.status_code} {detail}"
+            )
+            raise RemoteRuntimeError(msg)
+        data = response.json()
+        return WorkflowRunResult(
+            run_id=str(data.get("run_id", spec.run_id)),
+            status=str(data.get("status", "failed")),
+            outputs=cast(Mapping[str, Any], dict(data.get("outputs") or {})),
+            error=data.get("error"),
+        )
+
+
+def serialize_workflow_run_result(result: WorkflowRunResult) -> dict[str, Any]:
+    """Serialize a ``WorkflowRunResult`` for the runtime service to return."""
+    if is_dataclass(result) and not isinstance(result, type):
+        return asdict(result)
+    return {
+        "run_id": result.run_id,
+        "status": result.status,
+        "outputs": dict(result.outputs),
+        "error": result.error,
+    }

--- a/src/orcheo/sandbox/remote.py
+++ b/src/orcheo/sandbox/remote.py
@@ -221,7 +221,16 @@ def _workflow_spec_payload(spec: WorkflowRunSpec) -> dict[str, Any]:
         "workflow_definition": dict(spec.workflow_definition),
         "inputs": dict(spec.inputs),
         "node_types": list(spec.node_types),
+        "runnable_config": dict(spec.runnable_config),
+        "state_config": dict(spec.state_config),
     }
+
+
+# Default HTTP wait for ``dispatch_workflow``. Set above the agent CLI's own
+# timeout (``ExternalAgentNode.timeout_seconds`` defaults to 1800s) so the
+# HTTP client doesn't give up *before* the in-sandbox work has a chance to
+# either finish or report its own timeout.
+DEFAULT_WORKFLOW_DISPATCH_TIMEOUT_SECONDS: float = 1860.0
 
 
 class RemoteSandboxRunner:
@@ -232,14 +241,18 @@ class RemoteSandboxRunner:
         base_url: str,
         *,
         client: httpx.AsyncClient | None = None,
-        timeout: float = 300.0,
+        timeout: float = DEFAULT_WORKFLOW_DISPATCH_TIMEOUT_SECONDS,
     ) -> None:
         """Initialize the runner.
 
         Args:
             base_url: Base URL of the sandbox-runtime service.
             client: Optional pre-configured ``httpx.AsyncClient``.
-            timeout: Default request timeout in seconds.
+            timeout: Default request timeout in seconds. Must exceed the
+                longest agent timeout the operator expects to dispatch
+                through this runner; otherwise the HTTP wait will time out
+                before the in-sandbox workflow can return a result and the
+                run will surface as ``failed`` with no useful error.
         """
         self._base_url = base_url.rstrip("/")
         self._owns_client = client is None

--- a/src/orcheo/sandbox/runtime.py
+++ b/src/orcheo/sandbox/runtime.py
@@ -175,10 +175,10 @@ class DockerContainerRuntime:
 
         ``client.containers.run`` quietly attempts a registry pull when the
         image is missing — but ``orcheo/workspace-sandbox`` is a local-only
-        image (built via ``make docker-build`` / the Compose ``build-only``
-        profile), so the implicit pull always fails with a confusing
-        "pull access denied" message. Catching the absence here turns that
-        into an actionable error pointing the operator at the build target.
+        image (built via ``make docker-build``), so the implicit pull always
+        fails with a confusing "pull access denied" message. Catching the
+        absence here turns that into an actionable error pointing the
+        operator at the build target.
         """
         try:
             client.images.get(image)  # type: ignore[attr-defined]
@@ -192,11 +192,9 @@ class DockerContainerRuntime:
                 return
             msg = (
                 f"Workspace sandbox image {image!r} is not present on the "
-                "Docker daemon. The image is local-only (declared under the "
-                "Compose 'build-only' profile) and cannot be pulled from a "
-                "registry. Run `make docker-build` (or "
-                "`docker compose --profile build-only build workspace-sandbox`) "
-                "and try again."
+                "Docker daemon. The image is local-only and cannot be pulled "
+                "from a registry. Run `make docker-build` (or "
+                "`docker compose build workspace-sandbox`) and try again."
             )
             raise RuntimeError(msg) from exc
 

--- a/src/orcheo/sandbox/runtime.py
+++ b/src/orcheo/sandbox/runtime.py
@@ -138,31 +138,105 @@ class DockerContainerRuntime:
     def start(self, spec: ContainerSpec) -> ContainerHandle:
         """Spawn a Docker container that satisfies ``spec``."""
         client = self._ensure_client()
+        self._require_local_image(client, spec.image)
         host_config = self._build_host_config(spec)
         cmd = list(spec.command) if spec.command else None
-        container = client.containers.run(  # type: ignore[attr-defined]
-            image=spec.image,
-            command=cmd,
-            detach=True,
-            runtime=spec.runtime,
-            environment=dict(spec.environment),
-            user=spec.user,
-            read_only=spec.read_only_root,
-            cap_drop=list(spec.cap_drop),
-            security_opt=self._build_security_opt(spec),
-            network_mode=spec.network_mode,
-            labels={
-                "orcheo.workspace_id": spec.workspace_id,
-                **dict(spec.labels),
-            },
-            **host_config,
-        )
+        try:
+            container = client.containers.run(  # type: ignore[attr-defined]
+                image=spec.image,
+                command=cmd,
+                detach=True,
+                runtime=spec.runtime,
+                environment=dict(spec.environment),
+                user=spec.user,
+                read_only=spec.read_only_root,
+                cap_drop=list(spec.cap_drop),
+                security_opt=self._build_security_opt(spec),
+                network_mode=spec.network_mode,
+                labels={
+                    "orcheo.workspace_id": spec.workspace_id,
+                    **dict(spec.labels),
+                },
+                **host_config,
+            )
+        except Exception as exc:
+            self._reraise_with_helpful_runtime_error(exc, spec, client)
+            raise
         return ContainerHandle(
             container_id=container.id,
             image=spec.image,
             workspace_id=spec.workspace_id,
             runtime=spec.runtime,
         )
+
+    @staticmethod
+    def _require_local_image(client: object, image: str) -> None:
+        """Fail fast if ``image`` isn't built locally.
+
+        ``client.containers.run`` quietly attempts a registry pull when the
+        image is missing — but ``orcheo/workspace-sandbox`` is a local-only
+        image (built via ``make docker-build`` / the Compose ``build-only``
+        profile), so the implicit pull always fails with a confusing
+        "pull access denied" message. Catching the absence here turns that
+        into an actionable error pointing the operator at the build target.
+        """
+        try:
+            client.images.get(image)  # type: ignore[attr-defined]
+        except Exception as exc:  # noqa: BLE001 — translate any docker SDK error
+            message = str(exc).lower()
+            if "not found" not in message and "no such image" not in message:
+                # Not a missing-image error (could be a daemon-connectivity
+                # problem). Let the original exception bubble; ``start()``'s
+                # outer try/except already routes it through the daemon-runtime
+                # diagnostic helper.
+                return
+            msg = (
+                f"Workspace sandbox image {image!r} is not present on the "
+                "Docker daemon. The image is local-only (declared under the "
+                "Compose 'build-only' profile) and cannot be pulled from a "
+                "registry. Run `make docker-build` (or "
+                "`docker compose --profile build-only build workspace-sandbox`) "
+                "and try again."
+            )
+            raise RuntimeError(msg) from exc
+
+    @staticmethod
+    def _reraise_with_helpful_runtime_error(
+        exc: Exception, spec: ContainerSpec, client: object
+    ) -> None:
+        """Translate Docker's cryptic 'unknown runtime' error.
+
+        The Docker daemon returns ``400 Bad Request ("unknown or invalid
+        runtime name: <name>")`` when the requested runtime is not registered.
+        That message doesn't tell the operator what their options are. We
+        intercept it, list the runtimes the daemon actually has, and explain
+        how to fix the configuration. Any other exception is left untouched
+        so the original stack trace propagates.
+        """
+        message = str(exc)
+        if "unknown or invalid runtime name" not in message:
+            return
+        available: list[str] = []
+        try:
+            info = client.info()  # type: ignore[attr-defined]
+            runtimes = info.get("Runtimes") if isinstance(info, dict) else None
+            if isinstance(runtimes, dict):
+                available = sorted(runtimes.keys())
+        except Exception:  # pragma: no cover - best-effort probe
+            available = []
+        hint = (
+            f"Docker daemon does not have the container runtime "
+            f"{spec.runtime!r} registered. "
+        )
+        if available:
+            hint += f"Available runtimes on this host: {', '.join(available)}. "
+        hint += (
+            "Either install/register the runtime (e.g. install gVisor and add "
+            "it to /etc/docker/daemon.json for `runsc`), or set the env var "
+            "ORCHEO_CONTAINER_RUNTIME to one of the available names "
+            "(typically `runc` for local development)."
+        )
+        raise RuntimeError(hint) from exc
 
     def stop(self, handle: ContainerHandle) -> None:
         """Stop and remove the container behind ``handle``."""
@@ -192,14 +266,44 @@ class DockerContainerRuntime:
 
     @staticmethod
     def _build_host_config(spec: ContainerSpec) -> dict[str, object]:
-        """Translate ``spec`` resource limits into Docker host-config kwargs."""
+        """Translate ``spec`` resource limits into Docker host-config kwargs.
+
+        ``/scratch``, ``/workspace``, and ``/home/orcheo`` are mounted as
+        tmpfs with mode 1777 so that the per-workspace UID can write into
+        them despite the read-only rootfs:
+
+        - ``/scratch`` hosts the managed external-agent runtime tree (see
+          ``ORCHEO_AGENT_RUNTIME_ROOT`` in the manager).
+        - ``/workspace`` is the agent's working directory tree
+          (``DEFAULT_WORKSPACE_AGENT_ROOT``).
+        - ``/home/orcheo`` is the container's ``HOME`` (baked in the image);
+          ``npm``, ``git``, and provider CLIs all expect a writable home for
+          caches and config (``~/.npm``, ``~/.config``, ``~/.cache``, etc.).
+
+        The home path is intentionally hardcoded to match
+        ``Dockerfile.workspace-sandbox``; both must change together if the
+        image's HOME ever moves.
+
+        ``exec`` is explicitly enabled on every mount because Docker's
+        default tmpfs options are ``rw,nosuid,nodev,noexec`` — and the
+        managed provider CLIs (``/scratch/agent-runtimes/<provider>/bin/...``)
+        plus git hooks and any helper scripts the agent drops in
+        ``/workspace`` need to be runnable from these paths. ``nosuid`` and
+        ``nodev`` are kept (we don't want setuid binaries or device nodes in
+        a sandbox); only ``noexec`` is dropped.
+        """
         cpu_quota = int(float(spec.cpu_limit) * 100_000)
+        tmpfs_options = f"size={spec.scratch_size},mode=1777,exec"
         return {
             "mem_limit": spec.memory_limit,
             "pids_limit": spec.pid_limit,
             "cpu_period": 100_000,
             "cpu_quota": cpu_quota,
-            "tmpfs": {"/scratch": f"size={spec.scratch_size},mode=1777"},
+            "tmpfs": {
+                "/scratch": tmpfs_options,
+                "/workspace": tmpfs_options,
+                "/home/orcheo": tmpfs_options,
+            },
         }
 
 

--- a/src/orcheo/sandbox/runtime.py
+++ b/src/orcheo/sandbox/runtime.py
@@ -266,9 +266,9 @@ class DockerContainerRuntime:
     def _build_host_config(spec: ContainerSpec) -> dict[str, object]:
         """Translate ``spec`` resource limits into Docker host-config kwargs.
 
-        ``/scratch``, ``/workspace``, and ``/home/orcheo`` are mounted as
-        tmpfs with mode 1777 so that the per-workspace UID can write into
-        them despite the read-only rootfs:
+        ``/scratch``, ``/workspace``, ``/home/orcheo``, and ``/tmp`` are
+        mounted as tmpfs with mode 1777 so that the per-workspace UID can
+        write into them despite the read-only rootfs:
 
         - ``/scratch`` hosts the managed external-agent runtime tree (see
           ``ORCHEO_AGENT_RUNTIME_ROOT`` in the manager).
@@ -277,6 +277,10 @@ class DockerContainerRuntime:
         - ``/home/orcheo`` is the container's ``HOME`` (baked in the image);
           ``npm``, ``git``, and provider CLIs all expect a writable home for
           caches and config (``~/.npm``, ``~/.config``, ``~/.cache``, etc.).
+        - ``/tmp`` is required by the Claude Code native binary, which
+          writes scratch files there during ``--print`` runs and hangs
+          silently (after policy-limits init, before any API request) when
+          the path is on a read-only rootfs.
 
         The home path is intentionally hardcoded to match
         ``Dockerfile.workspace-sandbox``; both must change together if the
@@ -301,6 +305,7 @@ class DockerContainerRuntime:
                 "/scratch": tmpfs_options,
                 "/workspace": tmpfs_options,
                 "/home/orcheo": tmpfs_options,
+                "/tmp": tmpfs_options,
             },
         }
 

--- a/src/orcheo/sandbox/service.py
+++ b/src/orcheo/sandbox/service.py
@@ -1,0 +1,403 @@
+"""HTTP service exposing the Sandbox Runtime Manager to backend / worker.
+
+The Docker socket is root-equivalent on the host (design §Security
+Considerations). To keep the socket off the backend and worker containers,
+this service runs inside the dedicated ``sandbox-runtime`` container — the
+only process that mounts ``/var/run/docker.sock`` — and exposes an HTTP API
+that other Orcheo services call.
+
+Endpoints
+---------
+- ``POST /containers``: provision a new sandbox container from a
+  ``ContainerSpec`` payload. Returns the ``ContainerHandle``.
+- ``DELETE /containers/{container_id}``: stop and remove a sandbox.
+- ``GET /containers/{container_id}``: report whether the sandbox is running.
+- ``POST /sandboxes/{sandbox_id}/exec``: run a one-shot command inside an
+  existing sandbox (used by ``RemoteSandboxExec``).
+- ``POST /sandboxes/{sandbox_id}/dispatch_workflow``: run a
+  ``WorkflowRunSpec`` inside the sandbox and return its
+  ``WorkflowRunResult``.
+
+The service has no opinion on workspace pooling — that lives in the
+:class:`SandboxRuntimeManager` on the caller side. The runtime service is a
+thin wrapper around the container engine plus a ``docker exec`` shim.
+"""
+
+from __future__ import annotations
+import asyncio
+import json
+import logging
+import os
+import shlex
+import time
+from collections.abc import Mapping
+from typing import Any, Final
+from fastapi import FastAPI, HTTPException, status
+from pydantic import BaseModel, Field
+from orcheo.external_agents.models import ProcessExecutionResult
+from orcheo.sandbox.runtime import (
+    ContainerHandle,
+    ContainerRuntime,
+    ContainerSpec,
+    DockerContainerRuntime,
+)
+from orcheo.sandbox.workflow import WorkflowRunResult, WorkflowRunSpec
+
+
+logger = logging.getLogger(__name__)
+
+
+_WORKFLOW_RUNNER_MODULE: Final[str] = "orcheo.sandbox.workflow_runner"
+
+
+class ContainerSpecPayload(BaseModel):
+    """Wire-format ``ContainerSpec`` accepted by ``POST /containers``."""
+
+    image: str
+    workspace_id: str
+    runtime: str = "runsc"
+    command: list[str] = Field(default_factory=list)
+    environment: dict[str, str] = Field(default_factory=dict)
+    cpu_limit: str = "1.0"
+    memory_limit: str = "512m"
+    pid_limit: int = 256
+    scratch_size: str = "1g"
+    user: str = "10001:10001"
+    network_mode: str = "sandbox-egress"
+    read_only_root: bool = True
+    cap_drop: list[str] = Field(default_factory=lambda: ["ALL"])
+    no_new_privileges: bool = True
+    labels: dict[str, str] = Field(default_factory=dict)
+
+    def to_spec(self) -> ContainerSpec:
+        """Build a frozen ``ContainerSpec`` from the wire payload."""
+        return ContainerSpec(
+            image=self.image,
+            workspace_id=self.workspace_id,
+            runtime=self.runtime,
+            command=tuple(self.command),
+            environment=self.environment,
+            cpu_limit=self.cpu_limit,
+            memory_limit=self.memory_limit,
+            pid_limit=self.pid_limit,
+            scratch_size=self.scratch_size,
+            user=self.user,
+            network_mode=self.network_mode,
+            read_only_root=self.read_only_root,
+            cap_drop=tuple(self.cap_drop),
+            no_new_privileges=self.no_new_privileges,
+            labels=self.labels,
+        )
+
+
+class ExecRequest(BaseModel):
+    """Wire-format ``docker exec`` request."""
+
+    command: list[str]
+    cwd: str | None = None
+    env: dict[str, str] | None = None
+    timeout_seconds: float | None = None
+
+
+class WorkflowDispatchPayload(BaseModel):
+    """Wire-format payload for ``POST /sandboxes/{id}/dispatch_workflow``."""
+
+    spec: dict[str, Any]
+    broker_token: str = ""
+
+
+class ContainerExecutor:
+    """Run ``docker exec`` commands inside an existing sandbox container.
+
+    The default implementation shells out to ``docker exec`` because the
+    Docker SDK's ``exec_run`` does not give us a stable way to enforce a
+    wall-clock timeout. Tests inject a fake.
+    """
+
+    async def exec(
+        self,
+        sandbox_id: str,
+        request: ExecRequest,
+    ) -> ProcessExecutionResult:
+        """Run ``request.command`` inside ``sandbox_id`` via ``docker exec``."""
+        argv: list[str] = ["docker", "exec"]
+        if request.cwd is not None:
+            argv.extend(["-w", request.cwd])
+        if request.env:
+            for key, value in request.env.items():
+                argv.extend(["-e", f"{key}={value}"])
+        argv.append(sandbox_id)
+        argv.extend(request.command)
+
+        started = time.monotonic()
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *argv,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except FileNotFoundError as exc:  # pragma: no cover - dev environment
+            msg = f"docker CLI is not available in the sandbox-runtime container: {exc}"
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=msg,
+            ) from exc
+
+        timed_out = False
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                process.communicate(),
+                timeout=request.timeout_seconds,
+            )
+            exit_code: int | None = process.returncode
+        except TimeoutError:
+            timed_out = True
+            process.kill()
+            stdout, stderr = await process.communicate()
+            exit_code = None
+
+        return ProcessExecutionResult(
+            command=request.command,
+            stdout=stdout.decode("utf-8", errors="replace"),
+            stderr=stderr.decode("utf-8", errors="replace"),
+            exit_code=exit_code,
+            timed_out=timed_out,
+            duration_seconds=time.monotonic() - started,
+        )
+
+
+class WorkflowSandboxInvoker:
+    """Invoke the workflow runner inside a sandbox container and parse its result.
+
+    The invoker pipes a single newline-delimited ``WorkflowRunSpec`` payload
+    to ``python -m orcheo.sandbox.workflow_runner`` running in the sandbox
+    and reads the response from stdout. The broker token is passed as the
+    ``ORCHEO_BROKER_TOKEN`` env var so tenant code in the sandbox cannot see
+    it on the command line via ``ps``.
+    """
+
+    def __init__(self, executor: ContainerExecutor) -> None:
+        """Initialize the invoker."""
+        self._executor = executor
+
+    async def invoke(
+        self,
+        sandbox_id: str,
+        spec: WorkflowRunSpec,
+        broker_token: str,
+        *,
+        timeout_seconds: float | None = None,
+    ) -> WorkflowRunResult:
+        """Send ``spec`` into the sandbox and parse its ``WorkflowRunResult``."""
+        payload = json.dumps(
+            {
+                "workflow_definition": dict(spec.workflow_definition),
+                "inputs": dict(spec.inputs),
+                "run_id": spec.run_id,
+                "workspace_id": spec.workspace_id,
+            },
+            separators=(",", ":"),
+        )
+        argv = [
+            "sh",
+            "-c",
+            (
+                "printf '%s\\n' "
+                + shlex.quote(payload)
+                + " | python -m "
+                + _WORKFLOW_RUNNER_MODULE
+            ),
+        ]
+        result = await self._executor.exec(
+            sandbox_id,
+            ExecRequest(
+                command=argv,
+                cwd=None,
+                env={"ORCHEO_BROKER_TOKEN": broker_token} if broker_token else None,
+                timeout_seconds=timeout_seconds,
+            ),
+        )
+        if result.timed_out:
+            return WorkflowRunResult(
+                run_id=spec.run_id,
+                status="failed",
+                outputs={},
+                error="workflow run timed out inside sandbox",
+            )
+        if result.exit_code not in (0, None):
+            return WorkflowRunResult(
+                run_id=spec.run_id,
+                status="failed",
+                outputs={},
+                error=(
+                    f"workflow runner exited with {result.exit_code}: "
+                    f"{result.stderr.strip() or result.stdout.strip()}"
+                ),
+            )
+        last_line = _last_json_line(result.stdout)
+        if last_line is None:
+            return WorkflowRunResult(
+                run_id=spec.run_id,
+                status="failed",
+                outputs={},
+                error="workflow runner produced no JSON output",
+            )
+        try:
+            parsed: Mapping[str, Any] = json.loads(last_line)
+        except json.JSONDecodeError as exc:
+            return WorkflowRunResult(
+                run_id=spec.run_id,
+                status="failed",
+                outputs={},
+                error=f"could not parse workflow runner output: {exc}",
+            )
+        return WorkflowRunResult(
+            run_id=spec.run_id,
+            status=str(parsed.get("status", "failed")),
+            outputs=dict(parsed.get("outputs") or {}),
+            error=parsed.get("error"),
+        )
+
+
+def _last_json_line(blob: str) -> str | None:
+    """Return the last non-empty line in ``blob`` that parses as JSON."""
+    for line in reversed(blob.splitlines()):
+        candidate = line.strip()
+        if not candidate:
+            continue
+        if candidate.startswith("{") and candidate.endswith("}"):
+            return candidate
+    return None
+
+
+def _parse_workflow_spec(payload: WorkflowDispatchPayload) -> WorkflowRunSpec:
+    """Parse a dispatch payload into a ``WorkflowRunSpec`` or raise 400."""
+    try:
+        return WorkflowRunSpec(
+            run_id=str(payload.spec["run_id"]),
+            workspace_id=str(payload.spec["workspace_id"]),
+            workflow_definition=dict(payload.spec.get("workflow_definition") or {}),
+            inputs=dict(payload.spec.get("inputs") or {}),
+            node_types=tuple(payload.spec.get("node_types") or ()),
+        )
+    except KeyError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"missing field in spec: {exc}",
+        ) from exc
+
+
+def _register_container_routes(
+    app: FastAPI,
+    runtime: ContainerRuntime,
+    handles: dict[str, ContainerHandle],
+) -> None:
+    """Register the container-lifecycle routes on ``app``."""
+
+    @app.post("/containers", status_code=status.HTTP_201_CREATED)
+    def provision(payload: ContainerSpecPayload) -> dict[str, str]:
+        spec = payload.to_spec()
+        try:
+            handle = runtime.start(spec)
+        except Exception as exc:  # noqa: BLE001 — surface runtime failures as 500
+            logger.exception("Failed to provision sandbox for %s", spec.workspace_id)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"provision failed: {exc}",
+            ) from exc
+        handles[handle.container_id] = handle
+        return handle.as_dict()
+
+    @app.delete("/containers/{container_id}", status_code=status.HTTP_204_NO_CONTENT)
+    def stop(container_id: str) -> None:
+        handle = handles.pop(container_id, None)
+        if handle is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"unknown container {container_id}",
+            )
+        try:
+            runtime.stop(handle)
+        except Exception as exc:  # noqa: BLE001 — surface runtime failures as 500
+            logger.exception("Failed to stop sandbox %s", container_id)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"stop failed: {exc}",
+            ) from exc
+
+    @app.get("/containers/{container_id}")
+    def inspect(container_id: str) -> dict[str, Any]:
+        handle = handles.get(container_id)
+        if handle is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"unknown container {container_id}",
+            )
+        return {**handle.as_dict(), "running": runtime.is_running(handle)}
+
+
+def _register_sandbox_routes(
+    app: FastAPI,
+    executor: ContainerExecutor,
+    invoker: WorkflowSandboxInvoker,
+) -> None:
+    """Register the in-sandbox exec / workflow routes on ``app``."""
+
+    @app.post("/sandboxes/{sandbox_id}/exec")
+    async def exec_in_sandbox(sandbox_id: str, payload: ExecRequest) -> dict[str, Any]:
+        result = await executor.exec(sandbox_id, payload)
+        return result.model_dump()
+
+    @app.post("/sandboxes/{sandbox_id}/dispatch_workflow")
+    async def dispatch_workflow(
+        sandbox_id: str, payload: WorkflowDispatchPayload
+    ) -> dict[str, Any]:
+        spec = _parse_workflow_spec(payload)
+        result = await invoker.invoke(sandbox_id, spec, payload.broker_token)
+        return {
+            "run_id": result.run_id,
+            "status": result.status,
+            "outputs": dict(result.outputs),
+            "error": result.error,
+        }
+
+
+def build_service_app(
+    runtime: ContainerRuntime | None = None,
+    executor: ContainerExecutor | None = None,
+    invoker: WorkflowSandboxInvoker | None = None,
+) -> FastAPI:
+    """Build the FastAPI app for the sandbox-runtime service."""
+    runtime = runtime or DockerContainerRuntime()
+    executor = executor or ContainerExecutor()
+    invoker = invoker or WorkflowSandboxInvoker(executor)
+    handles: dict[str, ContainerHandle] = {}
+
+    app = FastAPI(
+        title="Orcheo Sandbox Runtime",
+        description=(
+            "Internal service that brokers Docker/gVisor sandbox operations. "
+            "Mounts the container-runtime socket; never expose publicly."
+        ),
+    )
+    _register_container_routes(app, runtime, handles)
+    _register_sandbox_routes(app, executor, invoker)
+
+    @app.get("/healthz")
+    def healthz() -> dict[str, str]:
+        return {"status": "ok"}
+
+    return app
+
+
+def main() -> None:  # pragma: no cover - CLI entrypoint
+    """Run the sandbox-runtime service with uvicorn."""
+    import uvicorn
+
+    host = os.getenv("ORCHEO_SANDBOX_RUNTIME_HOST", "0.0.0.0")  # noqa: S104
+    port = int(os.getenv("ORCHEO_SANDBOX_RUNTIME_PORT", "9090"))
+    uvicorn.run(build_service_app(), host=host, port=port)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    main()

--- a/src/orcheo/sandbox/service.py
+++ b/src/orcheo/sandbox/service.py
@@ -31,8 +31,10 @@ import os
 import shlex
 import time
 from collections.abc import Mapping
-from typing import Any, Final
-from fastapi import FastAPI, HTTPException, status
+from typing import Annotated, Any, Final
+import httpx
+from fastapi import FastAPI, Header, HTTPException, status
+from fastapi.responses import Response
 from pydantic import BaseModel, Field
 from orcheo.external_agents.models import ProcessExecutionResult
 from orcheo.sandbox.runtime import (
@@ -195,6 +197,8 @@ class WorkflowSandboxInvoker:
                 "inputs": dict(spec.inputs),
                 "run_id": spec.run_id,
                 "workspace_id": spec.workspace_id,
+                "runnable_config": dict(spec.runnable_config),
+                "state_config": dict(spec.state_config),
             },
             separators=(",", ":"),
         )
@@ -279,6 +283,8 @@ def _parse_workflow_spec(payload: WorkflowDispatchPayload) -> WorkflowRunSpec:
             workflow_definition=dict(payload.spec.get("workflow_definition") or {}),
             inputs=dict(payload.spec.get("inputs") or {}),
             node_types=tuple(payload.spec.get("node_types") or ()),
+            runnable_config=dict(payload.spec.get("runnable_config") or {}),
+            state_config=dict(payload.spec.get("state_config") or {}),
         )
     except KeyError as exc:
         raise HTTPException(
@@ -362,6 +368,33 @@ def _register_sandbox_routes(
         }
 
 
+def _register_credential_relay_route(app: FastAPI) -> None:
+    """Relay credential requests from sandboxes to the backend broker."""
+
+    @app.post("/credentials/resolve")
+    async def relay_credential_request(
+        payload: dict[str, Any],
+        authorization: Annotated[str | None, Header()] = None,
+        x_orcheo_workspace: Annotated[str | None, Header()] = None,
+    ) -> Response:
+        broker_url = os.getenv(
+            "ORCHEO_CREDENTIAL_BROKER_URL",
+            "http://backend:2025/internal/credentials/resolve",
+        )
+        headers: dict[str, str] = {}
+        if authorization is not None:
+            headers["Authorization"] = authorization
+        if x_orcheo_workspace is not None:
+            headers["X-Orcheo-Workspace"] = x_orcheo_workspace
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(broker_url, json=payload, headers=headers)
+        return Response(
+            content=response.content,
+            status_code=response.status_code,
+            media_type=response.headers.get("content-type"),
+        )
+
+
 def build_service_app(
     runtime: ContainerRuntime | None = None,
     executor: ContainerExecutor | None = None,
@@ -382,6 +415,7 @@ def build_service_app(
     )
     _register_container_routes(app, runtime, handles)
     _register_sandbox_routes(app, executor, invoker)
+    _register_credential_relay_route(app)
 
     @app.get("/healthz")
     def healthz() -> dict[str, str]:

--- a/src/orcheo/sandbox/service.py
+++ b/src/orcheo/sandbox/service.py
@@ -316,8 +316,13 @@ def _register_container_routes(
 
     @app.delete("/containers/{container_id}", status_code=status.HTTP_204_NO_CONTENT)
     def stop(container_id: str) -> None:
-        handle = handles.pop(container_id, None)
-        if handle is None:
+        handle = handles.pop(container_id, None) or ContainerHandle(
+            container_id=container_id,
+            image="",
+            workspace_id="",
+            runtime="",
+        )
+        if not runtime.is_running(handle):
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"unknown container {container_id}",

--- a/src/orcheo/sandbox/workflow.py
+++ b/src/orcheo/sandbox/workflow.py
@@ -16,7 +16,7 @@ of trusted nodes may take the in-worker fast path when the operator allows it
 from __future__ import annotations
 import asyncio
 from collections.abc import Iterable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Protocol
 from orcheo.sandbox.broker import CredentialBroker
 from orcheo.sandbox.manager import SandboxRuntimeManager
@@ -27,17 +27,29 @@ from orcheo.sandbox.models import SandboxLease
 # Everything not in this set is treated as tenant-authored and forced into a
 # Workflow Sandbox. The list is intentionally minimal and grown by operator
 # review.
+#
+# IMPORTANT: Do not add base classes (e.g. ``TaskNode``, ``BaseNode``) or
+# node types that accept tenant-authored code / scripts. Only concrete
+# first-party integration nodes whose behavior is fully defined by Orcheo
+# source belong here. When in doubt, leave it out — the dispatcher will route
+# it through the sandbox, which is the safe default.
 TRUSTED_NODE_TYPES: frozenset[str] = frozenset(
     {
+        # First-party AI / chat integrations.
         "AINode",
         "ChatModelNode",
+        # First-party integration nodes — behavior fully defined in Orcheo
+        # source, no tenant-authored code paths.
         "RSSNode",
         "MongoDBNode",
         "SlackNode",
         "TelegramNode",
-        "TaskNode",
-        "DataTransformNode",
-        "IntegrationNode",
+        # First-party declarative utility nodes — variables / delays /
+        # iteration / debug. These accept data only, never tenant code.
+        "SetVariableNode",
+        "DelayNode",
+        "ForLoopNode",
+        "DebugNode",
     }
 )
 
@@ -51,6 +63,8 @@ class WorkflowRunSpec:
     workflow_definition: Mapping[str, Any]
     inputs: Mapping[str, Any]
     node_types: tuple[str, ...] = ()
+    runnable_config: Mapping[str, Any] = field(default_factory=dict)
+    state_config: Mapping[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -76,8 +90,16 @@ class SandboxRunner(Protocol):
 
 
 def requires_sandbox(node_types: Iterable[str]) -> bool:
-    """Return True if any node type is not in the trusted set."""
-    return any(node_type not in TRUSTED_NODE_TYPES for node_type in node_types)
+    """Return True if any node type is not in the trusted set.
+
+    Fails closed: an empty iterable (no node types parsed) is treated as
+    untrusted. A graph the dispatcher cannot classify must not silently take
+    the in-worker fast path.
+    """
+    types = list(node_types)
+    if not types:
+        return True
+    return any(node_type not in TRUSTED_NODE_TYPES for node_type in types)
 
 
 class WorkflowSandboxDispatcher:
@@ -136,11 +158,22 @@ class WorkflowSandboxDispatcher:
         try:
             return await self._runner.execute(lease, spec, token)
         except Exception as exc:  # noqa: BLE001 — surface any runner failure
+            # Some exceptions (notably ``httpx.ReadTimeout`` wrapping an
+            # ``asyncio.TimeoutError``) stringify to ``""``, which would
+            # collapse into a useless "sandboxed run finished with failed"
+            # message downstream. Always include the type so the failure
+            # mode is identifiable in the chatkit logs.
+            detail = str(exc).strip()
+            error_message = (
+                f"{type(exc).__name__}: {detail}"
+                if detail
+                else f"{type(exc).__name__} (no message)"
+            )
             return WorkflowRunResult(
                 run_id=spec.run_id,
                 status="failed",
                 outputs={},
-                error=str(exc),
+                error=error_message,
             )
         finally:
             self._broker.revoke(spec.run_id)

--- a/src/orcheo/sandbox/workflow_runner.py
+++ b/src/orcheo/sandbox/workflow_runner.py
@@ -1,10 +1,11 @@
-"""Workflow Sandbox entrypoint — the long-lived process inside a sandbox.
+"""Workflow Sandbox runner invoked inside a leased sandbox.
 
-The Workflow Sandbox image runs ``python -m orcheo.sandbox.workflow_runner``.
-This module listens on stdin for ``WorkflowRunSpec`` payloads, forks a fresh
-child process per run, executes the workflow, and writes the result back to
-stdout. The fresh child is mandatory: it gives fault isolation between runs
-even when the sandbox is being reused via the warm pool.
+The sandbox runtime invokes ``python -m orcheo.sandbox.workflow_runner`` via
+``docker exec`` for each workflow dispatch. This module listens on stdin for
+``WorkflowRunSpec`` payloads, forks a fresh child process per run, executes the
+workflow, and writes the result back to stdout. The fresh child is mandatory:
+it gives fault isolation between runs even when the sandbox is being reused
+via the warm pool.
 
 The runner intentionally has no Celery, Redis, or Postgres dependencies — it
 only knows how to execute a workflow graph for the workspace pinned by its
@@ -16,32 +17,154 @@ which bypasses the stdin loop for simpler testability.
 """
 
 from __future__ import annotations
+import asyncio
 import json
 import multiprocessing as mp
+import os
 import sys
+import traceback
 from collections.abc import Mapping
+from contextlib import AbstractContextManager, nullcontext
 from dataclasses import asdict, is_dataclass
+from queue import Empty
 from typing import Any, cast
+import httpx
+from orcheo.runtime.credentials import (
+    UnknownCredentialPayloadError,
+    credential_resolution,
+)
+from orcheo.runtime.credentials.references import CredentialReference
+from orcheo.sandbox.dispatch import use_launcher
+from orcheo.sandbox.launcher import LocalProcessLauncher
+
+
+class _BrokerCredentialResolver:
+    """Resolve sandbox credential references through the backend broker."""
+
+    def __init__(
+        self,
+        *,
+        broker_url: str,
+        broker_token: str,
+        run_id: str,
+        workspace_id: str | None,
+    ) -> None:
+        self._broker_url = broker_url
+        self._broker_token = broker_token
+        self._run_id = run_id
+        self._workspace_id = workspace_id
+
+    def resolve(self, reference: CredentialReference) -> str:
+        """Resolve secret credential references through the broker HTTP API."""
+        if reference.payload_path not in ((), ("secret",)):
+            path = ".".join(reference.payload_path)
+            msg = (
+                "Sandbox credential broker only supports secret payloads; "
+                f"got {path!r} for {reference.identifier!r}"
+            )
+            raise UnknownCredentialPayloadError(msg)
+        headers = {"Authorization": f"Bearer {self._broker_token}"}
+        if self._workspace_id:
+            headers["X-Orcheo-Workspace"] = self._workspace_id
+        response = httpx.post(
+            self._broker_url,
+            json={
+                "run_id": self._run_id,
+                "credential_name": reference.identifier,
+            },
+            headers=headers,
+            timeout=30.0,
+        )
+        if not response.is_success:
+            msg = (
+                f"Credential broker resolve failed for {reference.identifier!r}: "
+                f"{response.status_code} {response.text}"
+            )
+            raise RuntimeError(msg)
+        value = response.json().get("value")
+        if not isinstance(value, str):
+            msg = (
+                "Credential broker returned an invalid value for "
+                f"{reference.identifier!r}"
+            )
+            raise RuntimeError(msg)
+        return value
+
+
+def _credential_context(
+    *,
+    run_id: str,
+    workspace_id: str | None,
+) -> AbstractContextManager[Any]:
+    """Bind the broker credential resolver when this run has a broker token."""
+    broker_token = os.getenv("ORCHEO_BROKER_TOKEN", "").strip()
+    if not broker_token:
+        return nullcontext()
+    broker_url = os.getenv("ORCHEO_CREDENTIAL_BROKER_URL", "").strip()
+    if not broker_url:
+        msg = "ORCHEO_CREDENTIAL_BROKER_URL is required for sandbox credentials"
+        raise RuntimeError(msg)
+    return credential_resolution(
+        cast(
+            Any,
+            _BrokerCredentialResolver(
+                broker_url=broker_url,
+                broker_token=broker_token,
+                run_id=run_id,
+                workspace_id=workspace_id,
+            ),
+        )
+    )
 
 
 def _execute_workflow_in_child(
     queue: mp.Queue[Mapping[str, Any]],
     workflow_definition: Mapping[str, Any],
     inputs: Mapping[str, Any],
+    runnable_config: Mapping[str, Any],
+    state_config: Mapping[str, Any],
+    run_id: str,
+    workspace_id: str | None,
 ) -> None:
     """Execute the workflow in a forked child and send the result back."""
     try:
         # In a real deployment this calls the graph builder + runner.
         # The runner module ships with the workflow-sandbox image, so the
         # heavy imports stay out of the worker.
-        outputs = _run_graph(workflow_definition, inputs)
+        outputs = _run_graph(
+            workflow_definition,
+            inputs,
+            runnable_config=runnable_config,
+            state_config=state_config,
+            run_id=run_id,
+            workspace_id=workspace_id,
+        )
         queue.put({"status": "succeeded", "outputs": dict(outputs), "error": None})
     except Exception as exc:  # noqa: BLE001 — propagate failure to parent
-        queue.put({"status": "failed", "outputs": {}, "error": str(exc)})
+        # Include the exception type AND the traceback so an empty
+        # ``str(exc)`` (e.g. exceptions raised with no args) still tells the
+        # caller what actually broke. Also echo to stderr so the traceback
+        # appears in the sandbox-runtime container logs alongside the
+        # serialized failure payload.
+        tb = traceback.format_exc()
+        print(tb, file=sys.stderr, flush=True)
+        detail = str(exc).strip()
+        error_message = (
+            f"{type(exc).__name__}: {detail}\n{tb}"
+            if detail
+            else f"{type(exc).__name__} (no message)\n{tb}"
+        )
+        queue.put({"status": "failed", "outputs": {}, "error": error_message})
 
 
 def _run_graph(
-    workflow_definition: Mapping[str, Any], inputs: Mapping[str, Any]
+    workflow_definition: Mapping[str, Any],
+    inputs: Mapping[str, Any],
+    *,
+    runnable_config: Mapping[str, Any] | None = None,
+    state_config: Mapping[str, Any] | None = None,
+    run_id: str = "",
+    workspace_id: str | None = None,
 ) -> Mapping[str, Any]:
     """Execute the workflow graph and return its outputs.
 
@@ -51,10 +174,34 @@ def _run_graph(
     # Imported lazily so unit tests of the runner can stub _run_graph without
     # paying the langgraph import cost.
     from orcheo.graph.builder import build_graph
+    from orcheo.runtime.state_builder import build_initial_state
 
     graph = build_graph(dict(workflow_definition))
     compiled = graph.compile()
-    result = compiled.invoke(cast(Any, dict(inputs)))
+    state = build_initial_state(
+        workflow_definition,
+        inputs,
+        state_config,
+        workspace_id,
+    )
+    # Bind a local launcher so any ``ExternalAgentNode`` invoked by the graph
+    # runs the CLI in this process tree instead of trying to dispatch into
+    # *another* sandbox. The whole workflow is already running inside the
+    # per-workspace sandbox the dispatcher acquired; recursing through the
+    # remote sandbox-runtime here would deadlock at best, and at worst fail
+    # with "no launcher bound" (the bound launcher only lives in the parent
+    # backend / worker process, not the child mp.Process that the runner
+    # spawns).
+    with (
+        _credential_context(run_id=run_id, workspace_id=workspace_id),
+        use_launcher(LocalProcessLauncher()),
+    ):
+        result = asyncio.run(
+            compiled.ainvoke(
+                cast(Any, state),
+                config=cast(Any, dict(runnable_config or {})),
+            )
+        )
     return cast("Mapping[str, Any]", result)
 
 
@@ -62,6 +209,10 @@ def run_in_subprocess(
     workflow_definition: Mapping[str, Any],
     inputs: Mapping[str, Any],
     *,
+    runnable_config: Mapping[str, Any] | None = None,
+    state_config: Mapping[str, Any] | None = None,
+    run_id: str = "",
+    workspace_id: str | None = None,
     spawn: bool = True,
 ) -> Mapping[str, Any]:
     """Run a workflow definition in a fresh child process and return its result.
@@ -69,6 +220,11 @@ def run_in_subprocess(
     Args:
         workflow_definition: Serialized workflow graph.
         inputs: Workflow inputs.
+        runnable_config: LangChain runtime config passed into graph invocation.
+        state_config: Runtime config copied into the initial workflow state.
+        run_id: Run identifier used by the run-scoped credential broker.
+        workspace_id: Workspace identifier injected into the initial state and
+            credential broker calls.
         spawn: When True (default), use ``multiprocessing`` to fork a fresh
             child. Set to False in unit tests to execute in-process.
 
@@ -82,30 +238,94 @@ def run_in_subprocess(
             def put(self, item: Mapping[str, Any]) -> None:
                 queue.append(item)
 
-        _execute_workflow_in_child(_ListQueue(), workflow_definition, inputs)  # type: ignore[arg-type]
+        _execute_workflow_in_child(
+            _ListQueue(),  # type: ignore[arg-type]
+            workflow_definition,
+            inputs,
+            runnable_config or {},
+            state_config or {},
+            run_id,
+            workspace_id,
+        )
         return queue[0]
     ctx = mp.get_context("spawn")
     q: mp.Queue[Mapping[str, Any]] = ctx.Queue()
     process = ctx.Process(
         target=_execute_workflow_in_child,
-        args=(q, workflow_definition, inputs),
+        args=(
+            q,
+            workflow_definition,
+            inputs,
+            runnable_config or {},
+            state_config or {},
+            run_id,
+            workspace_id,
+        ),
         daemon=True,
     )
     process.start()
     process.join()
-    return q.get_nowait()
+    try:
+        return q.get_nowait()
+    except Empty:
+        # The child exited without putting a result on the queue: either it
+        # was killed (signal / OOM) or it died before reaching the try/except
+        # in ``_execute_workflow_in_child`` (e.g. import-time crash during
+        # spawn). Surface the exit status so the failure is debuggable from
+        # the dispatcher logs instead of just ``_queue.Empty``.
+        exitcode = process.exitcode
+        if exitcode is None:
+            detail = "child process is still running after join()"
+        elif exitcode < 0:
+            detail = f"killed by signal {-exitcode}"
+        elif exitcode == 0:
+            detail = "exited cleanly without producing a result"
+        else:
+            detail = f"exited with status {exitcode}"
+        return {
+            "status": "failed",
+            "outputs": {},
+            "error": f"sandbox child process produced no result ({detail})",
+        }
+
+
+def _json_default(value: Any) -> Any:
+    """Convert workflow-state objects into JSON-safe sandbox result values."""
+    if is_dataclass(value) and not isinstance(value, type):
+        return asdict(cast(Any, value))
+
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        try:
+            return model_dump(mode="json")
+        except TypeError:
+            return model_dump()
+
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    if isinstance(value, set | frozenset):
+        return list(value)
+
+    return str(value)
 
 
 def serve_stdin_loop() -> None:  # pragma: no cover - long-running entrypoint
     """Read newline-delimited JSON specs from stdin until EOF."""
     for line in sys.stdin:
         payload = json.loads(line)
-        result = run_in_subprocess(payload["workflow_definition"], payload["inputs"])
+        result = run_in_subprocess(
+            payload["workflow_definition"],
+            payload["inputs"],
+            runnable_config=payload.get("runnable_config") or {},
+            state_config=payload.get("state_config") or {},
+            run_id=str(payload.get("run_id") or ""),
+            workspace_id=payload.get("workspace_id"),
+        )
         if is_dataclass(result) and not isinstance(result, type):
             serialized: Mapping[str, Any] = asdict(cast(Any, result))
         else:
             serialized = dict(result)
-        sys.stdout.write(json.dumps(serialized) + "\n")
+        sys.stdout.write(json.dumps(serialized, default=_json_default) + "\n")
         sys.stdout.flush()
 
 

--- a/tests/backend/test_app_sandbox_helpers.py
+++ b/tests/backend/test_app_sandbox_helpers.py
@@ -1,0 +1,96 @@
+"""Tests for the backend-shared sandbox bootstrap helpers."""
+
+from __future__ import annotations
+from types import SimpleNamespace
+from typing import Any
+import pytest
+from orcheo_backend.app import sandbox as sandbox_module
+from orcheo_backend.app.sandbox import (
+    build_credential_broker,
+    build_workflow_run_spec,
+    collect_node_types,
+    ensure_sandbox_configured,
+    run_uses_trusted_nodes_only,
+)
+
+
+def test_run_uses_trusted_nodes_only_returns_true_for_trusted_only() -> None:
+    assert run_uses_trusted_nodes_only(("AINode", "ChatModelNode"))
+
+
+def test_run_uses_trusted_nodes_only_returns_false_for_unknown_type() -> None:
+    assert not run_uses_trusted_nodes_only(("AINode", "TenantPythonNode"))
+
+
+def test_run_uses_trusted_nodes_only_fails_closed_on_empty() -> None:
+    """A graph with no parseable node types must not take the in-worker fast path."""
+    assert not run_uses_trusted_nodes_only(())
+
+
+def test_collect_node_types_returns_empty_for_non_dict() -> None:
+    assert collect_node_types("not a dict") == ()
+
+
+def test_collect_node_types_extracts_unique_types() -> None:
+    config = {
+        "nodes": [
+            {"type": "AINode"},
+            {"kind": "RSSNode"},
+            {"type": "AINode"},  # duplicate filtered
+            "not-a-dict",
+            {"name": "no-type-here"},
+        ]
+    }
+    assert collect_node_types(config) == ("AINode", "RSSNode")
+
+
+def test_build_workflow_run_spec_carries_node_types() -> None:
+    spec = build_workflow_run_spec(
+        execution_id="exec-1",
+        workspace_id="ws-1",
+        graph_config={"nodes": [{"type": "TenantPythonNode"}]},
+        inputs={"x": 1},
+        runnable_config={"configurable": {"thread_id": "exec-1"}},
+        state_config={"configurable": {"ai_model": "openai:test"}},
+    )
+    assert spec.run_id == "exec-1"
+    assert spec.workspace_id == "ws-1"
+    assert spec.node_types == ("TenantPythonNode",)
+    assert spec.runnable_config == {"configurable": {"thread_id": "exec-1"}}
+    assert spec.state_config == {"configurable": {"ai_model": "openai:test"}}
+
+
+def test_ensure_sandbox_configured_is_idempotent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated calls must not raise and must not rebind an existing broker."""
+    calls: list[Any] = []
+
+    class _StubBootstrap:
+        def __init__(self) -> None:
+            self._broker: Any = None
+
+        def configure(self, broker: Any) -> None:
+            calls.append(broker)
+            self._broker = broker
+
+    stub = _StubBootstrap()
+    monkeypatch.setattr(sandbox_module, "_bootstrap", stub)
+
+    # Provide a fake vault so build_credential_broker doesn't blow up.
+    monkeypatch.setattr(sandbox_module, "get_vault", lambda: SimpleNamespace())
+    monkeypatch.setenv("ORCHEO_CREDENTIAL_BROKER_SECRET", "abc")
+
+    ensure_sandbox_configured()
+    ensure_sandbox_configured()  # idempotent — must not rebind
+
+    assert len(calls) == 1
+
+
+def test_build_credential_broker_requires_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The broker refuses to build without ORCHEO_CREDENTIAL_BROKER_SECRET."""
+    monkeypatch.delenv("ORCHEO_CREDENTIAL_BROKER_SECRET", raising=False)
+    with pytest.raises(RuntimeError, match="ORCHEO_CREDENTIAL_BROKER_SECRET"):
+        build_credential_broker()

--- a/tests/backend/test_app_sandbox_helpers.py
+++ b/tests/backend/test_app_sandbox_helpers.py
@@ -6,11 +6,16 @@ from typing import Any
 import pytest
 from orcheo_backend.app import sandbox as sandbox_module
 from orcheo_backend.app.sandbox import (
+    SandboxRuntimeNotConfiguredError,
+    _SandboxBootstrap,
     build_credential_broker,
     build_workflow_run_spec,
     collect_node_types,
     ensure_sandbox_configured,
+    install_sandbox_bootstrap,
+    reset_sandbox_bootstrap,
     run_uses_trusted_nodes_only,
+    _fast_path_enabled,
 )
 
 
@@ -94,3 +99,206 @@ def test_build_credential_broker_requires_secret(
     monkeypatch.delenv("ORCHEO_CREDENTIAL_BROKER_SECRET", raising=False)
     with pytest.raises(RuntimeError, match="ORCHEO_CREDENTIAL_BROKER_SECRET"):
         build_credential_broker()
+
+
+# ---------------------------------------------------------------------------
+# _SandboxBootstrap unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_bootstrap_runtime_url_raises_when_env_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_runtime_url raises SandboxRuntimeNotConfiguredError when env var is unset."""
+    monkeypatch.delenv("ORCHEO_SANDBOX_RUNTIME_URL", raising=False)
+    bootstrap = _SandboxBootstrap()
+    with pytest.raises(
+        SandboxRuntimeNotConfiguredError, match="ORCHEO_SANDBOX_RUNTIME_URL"
+    ):
+        bootstrap._runtime_url()
+
+
+def test_bootstrap_runtime_url_returns_env_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_runtime_url returns the configured env var when set."""
+    monkeypatch.setenv("ORCHEO_SANDBOX_RUNTIME_URL", "http://sandbox-runtime:9090")
+    bootstrap = _SandboxBootstrap()
+    assert bootstrap._runtime_url() == "http://sandbox-runtime:9090"
+
+
+def test_bootstrap_ensure_manager_creates_manager(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_ensure_manager lazily creates runtime and manager."""
+    monkeypatch.setenv("ORCHEO_SANDBOX_RUNTIME_URL", "http://sandbox-runtime:9090")
+
+    created_runtimes: list[Any] = []
+    created_managers: list[Any] = []
+
+    class _FakeRuntime:
+        def __init__(self, url: str) -> None:
+            self.url = url
+            created_runtimes.append(self)
+
+    class _FakeManager:
+        def __init__(self, *, runtime: Any, settings: Any) -> None:
+            self.runtime = runtime
+            created_managers.append(self)
+
+    monkeypatch.setattr(sandbox_module, "RemoteContainerRuntime", _FakeRuntime)
+    monkeypatch.setattr(sandbox_module, "SandboxRuntimeManager", _FakeManager)
+    monkeypatch.setattr(
+        sandbox_module, "SandboxSettings", SimpleNamespace(from_env=lambda: {})
+    )
+
+    bootstrap = _SandboxBootstrap()
+    manager = bootstrap._ensure_manager()
+    assert len(created_managers) == 1
+    assert manager is created_managers[0]
+
+    # Second call must return cached manager without creating a new one.
+    manager2 = bootstrap._ensure_manager()
+    assert manager2 is manager
+    assert len(created_managers) == 1
+
+
+def test_bootstrap_launcher_creates_and_caches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """launcher() creates a SandboxedProcessLauncher on first call and caches it."""
+    monkeypatch.setenv("ORCHEO_SANDBOX_RUNTIME_URL", "http://sandbox-runtime:9090")
+
+    class _FakeRuntime:
+        def __init__(self, url: str) -> None:
+            pass
+
+    class _FakeManager:
+        def __init__(self, *, runtime: Any, settings: Any) -> None:
+            pass
+
+    class _FakeExec:
+        def __init__(self, url: str) -> None:
+            self.url = url
+
+    class _FakeLauncher:
+        def __init__(self, manager: Any, *, exec_backend: Any) -> None:
+            self.exec_backend = exec_backend
+
+    monkeypatch.setattr(sandbox_module, "RemoteContainerRuntime", _FakeRuntime)
+    monkeypatch.setattr(sandbox_module, "SandboxRuntimeManager", _FakeManager)
+    monkeypatch.setattr(
+        sandbox_module, "SandboxSettings", SimpleNamespace(from_env=lambda: {})
+    )
+    monkeypatch.setattr(sandbox_module, "RemoteSandboxExec", _FakeExec)
+    monkeypatch.setattr(sandbox_module, "SandboxedProcessLauncher", _FakeLauncher)
+
+    bootstrap = _SandboxBootstrap()
+    launcher = bootstrap.launcher()
+    assert isinstance(launcher, _FakeLauncher)
+
+    # Second call returns the same instance.
+    launcher2 = bootstrap.launcher()
+    assert launcher2 is launcher
+
+
+def test_bootstrap_dispatcher_raises_without_broker() -> None:
+    """dispatcher() raises SandboxRuntimeNotConfiguredError when broker not set."""
+    bootstrap = _SandboxBootstrap()
+    with pytest.raises(SandboxRuntimeNotConfiguredError, match="broker"):
+        bootstrap.dispatcher()
+
+
+def test_bootstrap_dispatcher_creates_dispatcher(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """dispatcher() creates a WorkflowSandboxDispatcher after configure() is called."""
+    monkeypatch.setenv("ORCHEO_SANDBOX_RUNTIME_URL", "http://sandbox-runtime:9090")
+
+    class _FakeRuntime:
+        def __init__(self, url: str) -> None:
+            pass
+
+    class _FakeManager:
+        def __init__(self, *, runtime: Any, settings: Any) -> None:
+            pass
+
+    class _FakeRunner:
+        def __init__(self, url: str) -> None:
+            pass
+
+    dispatchers_created: list[Any] = []
+
+    class _FakeDispatcher:
+        def __init__(
+            self,
+            manager: Any,
+            runner: Any,
+            broker: Any,
+            *,
+            allow_in_worker_fast_path: bool,
+        ) -> None:
+            self.broker = broker
+            dispatchers_created.append(self)
+
+    monkeypatch.setattr(sandbox_module, "RemoteContainerRuntime", _FakeRuntime)
+    monkeypatch.setattr(sandbox_module, "SandboxRuntimeManager", _FakeManager)
+    monkeypatch.setattr(
+        sandbox_module, "SandboxSettings", SimpleNamespace(from_env=lambda: {})
+    )
+    monkeypatch.setattr(sandbox_module, "RemoteSandboxRunner", _FakeRunner)
+    monkeypatch.setattr(sandbox_module, "WorkflowSandboxDispatcher", _FakeDispatcher)
+
+    broker = SimpleNamespace()
+    bootstrap = _SandboxBootstrap()
+    bootstrap.configure(broker)
+    dispatcher = bootstrap.dispatcher()
+    assert isinstance(dispatcher, _FakeDispatcher)
+    assert dispatcher.broker is broker
+
+    # Second call returns cached instance.
+    dispatcher2 = bootstrap.dispatcher()
+    assert dispatcher2 is dispatcher
+    assert len(dispatchers_created) == 1
+
+
+def test_reset_sandbox_bootstrap_replaces_global(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """reset_sandbox_bootstrap() replaces _bootstrap with a fresh instance."""
+    original = sandbox_module._bootstrap
+    try:
+        reset_sandbox_bootstrap()
+        assert sandbox_module._bootstrap is not original
+        assert sandbox_module._bootstrap._broker is None
+    finally:
+        sandbox_module._bootstrap = original
+
+
+def test_install_sandbox_bootstrap_replaces_global(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """install_sandbox_bootstrap() installs the given instance as _bootstrap."""
+    original = sandbox_module._bootstrap
+    try:
+        new_bootstrap = _SandboxBootstrap()
+        install_sandbox_bootstrap(new_bootstrap)
+        assert sandbox_module._bootstrap is new_bootstrap
+    finally:
+        sandbox_module._bootstrap = original
+
+
+def test_fast_path_enabled_with_various_env_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_fast_path_enabled returns True for truthy env values only."""
+    for truthy in ("1", "true", "True", "TRUE", "yes", "YES"):
+        monkeypatch.setenv("ORCHEO_SANDBOX_FAST_PATH_TRUSTED", truthy)
+        assert _fast_path_enabled() is True, f"expected True for {truthy!r}"
+
+    for falsy in ("0", "false", "no", "", "maybe"):
+        monkeypatch.setenv("ORCHEO_SANDBOX_FAST_PATH_TRUSTED", falsy)
+        assert _fast_path_enabled() is False, f"expected False for {falsy!r}"
+
+    monkeypatch.delenv("ORCHEO_SANDBOX_FAST_PATH_TRUSTED", raising=False)
+    assert _fast_path_enabled() is False

--- a/tests/backend/test_chatkit_workflow_executor.py
+++ b/tests/backend/test_chatkit_workflow_executor.py
@@ -653,3 +653,128 @@ async def test_execute_graph_passes_workspace_id_to_initial_state(
         "inputs": {"message": "hello"},
         "workspace_id": str(UUID(int=1)),
     }
+
+
+@pytest.mark.asyncio
+async def test_execute_graph_dispatches_to_sandbox_when_untrusted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Untrusted graphs hit the sandbox dispatcher and emit a sandbox_result."""
+    from orcheo.sandbox.workflow import WorkflowRunResult
+
+    dispatched: list[object] = []
+    callbacks: list[Mapping[str, object]] = []
+
+    class _SandboxingDispatcher:
+        def should_sandbox(self, spec):  # noqa: ARG002
+            return True
+
+        async def dispatch(self, spec):
+            dispatched.append(spec)
+            return WorkflowRunResult(
+                run_id=spec.run_id,
+                status="succeeded",
+                outputs={"answer": 42},
+            )
+
+    monkeypatch.setattr(
+        workflow_executor_module,
+        "get_sandbox_dispatcher",
+        lambda: _SandboxingDispatcher(),
+    )
+    # ensure_sandbox_configured is a no-op when the stub bootstrap is already
+    # wired by conftest; calling it must not blow up.
+    executor = WorkflowExecutor(repository=object(), vault_provider=lambda: object())
+
+    async def _step_callback(step: Mapping[str, object]) -> None:
+        callbacks.append(step)
+
+    result = await executor._execute_graph(
+        workflow_id=UUID(int=0),
+        graph_config={"nodes": [{"type": "TenantPythonNode"}]},
+        inputs={"x": 1},
+        config={"configurable": {"thread_id": "thread"}},
+        state_config={"configurable": {"thread_id": "thread"}},
+        step_callback=_step_callback,
+        workspace_id="ws-1",
+    )
+
+    assert dispatched and dispatched[0].workspace_id == "ws-1"
+    assert result == {"answer": 42}
+    assert callbacks == [
+        {
+            "event": "sandbox_result",
+            "status": "succeeded",
+            "outputs": {"answer": 42},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_execute_graph_raises_without_workspace_for_sandbox_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sandboxed dispatch requires a workspace id; absence is a hard error."""
+
+    class _SandboxingDispatcher:
+        def should_sandbox(self, spec):  # noqa: ARG002
+            return True
+
+        async def dispatch(self, spec):  # pragma: no cover - never reached
+            raise AssertionError("should not dispatch")
+
+    monkeypatch.setattr(
+        workflow_executor_module,
+        "get_sandbox_dispatcher",
+        lambda: _SandboxingDispatcher(),
+    )
+    executor = WorkflowExecutor(repository=object(), vault_provider=lambda: object())
+
+    with pytest.raises(RuntimeError, match="workspace_id is required"):
+        await executor._execute_graph(
+            workflow_id=UUID(int=0),
+            graph_config={"nodes": [{"type": "TenantPythonNode"}]},
+            inputs={},
+            config={"configurable": {"thread_id": "thread"}},
+            state_config={"configurable": {"thread_id": "thread"}},
+            step_callback=None,
+            workspace_id=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_execute_graph_surfaces_sandbox_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-succeeded sandbox result must be raised so the caller fails."""
+    from orcheo.sandbox.workflow import WorkflowRunResult
+
+    class _SandboxingDispatcher:
+        def should_sandbox(self, spec):  # noqa: ARG002
+            return True
+
+        async def dispatch(self, spec):
+            return WorkflowRunResult(
+                run_id=spec.run_id,
+                status="failed",
+                outputs={},
+                error="kaboom",
+            )
+
+    monkeypatch.setattr(
+        workflow_executor_module,
+        "get_sandbox_dispatcher",
+        lambda: _SandboxingDispatcher(),
+    )
+    executor = WorkflowExecutor(repository=object(), vault_provider=lambda: object())
+
+    with pytest.raises(RuntimeError, match="kaboom"):
+        await executor._execute_graph(
+            workflow_id=UUID(int=0),
+            graph_config={"nodes": [{"type": "TenantPythonNode"}]},
+            inputs={},
+            config={"configurable": {"thread_id": "thread"}},
+            state_config={"configurable": {"thread_id": "thread"}},
+            step_callback=None,
+            workspace_id="ws-1",
+        )

--- a/tests/backend/test_workflow_execution_unit.py
+++ b/tests/backend/test_workflow_execution_unit.py
@@ -1048,7 +1048,7 @@ async def test_execute_node_runs_node_with_prepared_state(
         lambda stored, candidate: DummyMergedConfig(),
     )
 
-    class NodeStub:
+    class AINode:  # name must be in TRUSTED_NODE_TYPES so execute_node accepts it
         def __init__(self, **kwargs: Any) -> None:
             self.kwargs = kwargs
 
@@ -1061,7 +1061,7 @@ async def test_execute_node_runs_node_with_prepared_state(
             }
 
     result = await workflow_execution.execute_node(
-        NodeStub,
+        AINode,
         {"name": "node"},
         {"message": "hello"},
         workflow_id=UUID(int=7),
@@ -1753,7 +1753,7 @@ async def test_execute_workflow_evaluation_completes(
     websocket = object()
     await execute_workflow_evaluation(
         workflow_id="workflow",
-        graph_config={},
+        graph_config={"nodes": [{"type": "AINode"}]},
         inputs={},
         execution_id="exec-eval",
         websocket=websocket,
@@ -1811,7 +1811,7 @@ async def test_execute_workflow_training_completes(
     websocket = object()
     await execute_workflow_training(
         workflow_id="workflow",
-        graph_config={},
+        graph_config={"nodes": [{"type": "AINode"}]},
         inputs={},
         execution_id="exec-train",
         websocket=websocket,
@@ -1822,3 +1822,70 @@ async def test_execute_workflow_training_completes(
     history_store.start_run.assert_awaited_once()
     safe_send.assert_any_await(websocket, {"status": "completed"})
     assert emit_update.await_args_list[-1][1]["complete"] is True
+
+
+@pytest.mark.asyncio
+async def test_execute_workflow_evaluation_rejects_untrusted_node_types(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Evaluation runs cannot host tenant Python — it must be refused."""
+    safe_send = AsyncMock()
+    monkeypatch.setattr(workflow_execution, "_safe_send_json", safe_send)
+
+    await execute_workflow_evaluation(
+        workflow_id="workflow",
+        graph_config={"nodes": [{"type": "TenantPythonNode"}]},
+        inputs={},
+        execution_id="exec-eval",
+        websocket=object(),
+        evaluation={"dataset": {"cases": [{"inputs": {"foo": "bar"}}]}},
+    )
+
+    assert safe_send.await_args is not None
+    sent_payload = safe_send.await_args.args[1]
+    assert sent_payload["status"] == "error"
+    assert "untrusted node" in sent_payload["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_execute_workflow_training_rejects_untrusted_node_types(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Training runs cannot host tenant Python — it must be refused."""
+    safe_send = AsyncMock()
+    monkeypatch.setattr(workflow_execution, "_safe_send_json", safe_send)
+
+    await execute_workflow_training(
+        workflow_id="workflow",
+        graph_config={"nodes": [{"type": "TenantPythonNode"}]},
+        inputs={},
+        execution_id="exec-train",
+        websocket=object(),
+        training={"dataset": {"cases": [{"inputs": {"foo": "bar"}}]}},
+    )
+
+    assert safe_send.await_args is not None
+    sent_payload = safe_send.await_args.args[1]
+    assert sent_payload["status"] == "error"
+    assert "untrusted node" in sent_payload["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_execute_node_rejects_untrusted_node_class() -> None:
+    """execute_node refuses to run a node class outside the trusted set."""
+
+    class TenantPythonNode:  # name is not in TRUSTED_NODE_TYPES
+        def __init__(self, **_: object) -> None:
+            pass
+
+        async def __call__(
+            self, state: object, runtime_config: object
+        ) -> dict[str, object]:
+            return {}
+
+    with pytest.raises(workflow_execution.UntrustedNodeNotAllowedError):
+        await workflow_execution.execute_node(
+            TenantPythonNode,
+            {},
+            {},
+        )

--- a/tests/backend/test_workflow_execution_unit.py
+++ b/tests/backend/test_workflow_execution_unit.py
@@ -1889,3 +1889,439 @@ async def test_execute_node_rejects_untrusted_node_class() -> None:
             {},
             {},
         )
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_sandboxed_run tests (lines 184-220)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dispatch_sandboxed_run_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_dispatch_sandboxed_run persists a sandbox_result step on success."""
+    from orcheo.sandbox.workflow import WorkflowRunResult
+    from orcheo_backend.app.workflow_execution import _dispatch_sandboxed_run
+
+    history_store = AsyncMock()
+    history_step = SimpleNamespace()
+    history_store.append_step = AsyncMock(return_value=history_step)
+    websocket = AsyncMock()
+    tracer = object()
+    span = SimpleNamespace()
+    safe_send = AsyncMock(return_value=True)
+    emit_update = AsyncMock()
+    record_step_calls: list[Any] = []
+
+    monkeypatch.setattr(workflow_execution, "_safe_send_json", safe_send)
+    monkeypatch.setattr(workflow_execution, "_emit_trace_update", emit_update)
+    monkeypatch.setattr(
+        workflow_execution,
+        "record_workflow_step",
+        lambda tracer_arg, payload: record_step_calls.append(payload),
+    )
+    monkeypatch.setattr(
+        workflow_execution, "record_workflow_failure", lambda span_arg, exc: None
+    )
+    persist_failure = AsyncMock()
+    monkeypatch.setattr(workflow_execution, "_persist_failure_history", persist_failure)
+
+    succeeded_result = WorkflowRunResult(
+        run_id="exec-s",
+        status="succeeded",
+        outputs={"reply": "done"},
+        error=None,
+    )
+
+    class _FakeDispatcher:
+        async def dispatch(self, spec: Any) -> WorkflowRunResult:
+            return succeeded_result
+
+    monkeypatch.setattr(
+        workflow_execution, "get_sandbox_dispatcher", lambda: _FakeDispatcher()
+    )
+    monkeypatch.setattr(
+        workflow_execution,
+        "build_workflow_run_spec",
+        lambda **kwargs: SimpleNamespace(),
+    )
+
+    result = await _dispatch_sandboxed_run(
+        workspace_id="ws-1",
+        execution_id="exec-s",
+        graph_config={"nodes": []},
+        inputs={},
+        runtime_config={},
+        state_config={},
+        history_store=history_store,
+        websocket=websocket,
+        tracer=tracer,
+        span=span,
+    )
+
+    assert result.status == "succeeded"
+    history_store.append_step.assert_awaited_once()
+    args = history_store.append_step.await_args.args
+    assert args[0] == "exec-s"
+    assert args[1]["event"] == "sandbox_result"
+    assert args[1]["status"] == "succeeded"
+    safe_send.assert_awaited_once()
+    emit_update.assert_awaited_once()
+    persist_failure.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_sandboxed_run_includes_error_in_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_dispatch_sandboxed_run includes error field and persists failure on non-succeeded."""
+    from orcheo.sandbox.workflow import WorkflowRunResult
+    from orcheo_backend.app.workflow_execution import _dispatch_sandboxed_run
+
+    history_store = AsyncMock()
+    history_store.append_step = AsyncMock(return_value=SimpleNamespace())
+    websocket = AsyncMock()
+    span = SimpleNamespace()
+    failure_calls: list[Any] = []
+    monkeypatch.setattr(
+        workflow_execution, "_safe_send_json", AsyncMock(return_value=True)
+    )
+    monkeypatch.setattr(workflow_execution, "_emit_trace_update", AsyncMock())
+    monkeypatch.setattr(workflow_execution, "record_workflow_step", lambda t, p: None)
+    monkeypatch.setattr(
+        workflow_execution,
+        "record_workflow_failure",
+        lambda span_arg, exc: failure_calls.append(exc),
+    )
+    persist_failure = AsyncMock()
+    monkeypatch.setattr(workflow_execution, "_persist_failure_history", persist_failure)
+
+    failed_result = WorkflowRunResult(
+        run_id="exec-f",
+        status="failed",
+        outputs={},
+        error="something went wrong",
+    )
+
+    class _FakeDispatcher:
+        async def dispatch(self, spec: Any) -> WorkflowRunResult:
+            return failed_result
+
+    monkeypatch.setattr(
+        workflow_execution, "get_sandbox_dispatcher", lambda: _FakeDispatcher()
+    )
+    monkeypatch.setattr(
+        workflow_execution,
+        "build_workflow_run_spec",
+        lambda **kwargs: SimpleNamespace(),
+    )
+
+    result = await _dispatch_sandboxed_run(
+        workspace_id="ws-1",
+        execution_id="exec-f",
+        graph_config={},
+        inputs={},
+        runtime_config={},
+        state_config={},
+        history_store=history_store,
+        websocket=websocket,
+        tracer=object(),
+        span=span,
+    )
+
+    assert result.status == "failed"
+    step_payload = history_store.append_step.await_args.args[1]
+    assert step_payload.get("error") == "something went wrong"
+    persist_failure.assert_awaited_once()
+    assert len(failure_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# _execute_sandboxed_workflow tests (lines 524-542)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_sandboxed_workflow_marks_completed_on_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_execute_sandboxed_workflow marks run as completed when sandbox succeeds."""
+    from orcheo.sandbox.workflow import WorkflowRunResult
+    from orcheo_backend.app.workflow_execution import _execute_sandboxed_workflow
+
+    history_store = AsyncMock()
+    history_store.append_step = AsyncMock(return_value=SimpleNamespace())
+    history_store.mark_completed = AsyncMock()
+    websocket = AsyncMock()
+    emit_update = AsyncMock()
+    completion_calls: list[Any] = []
+
+    monkeypatch.setattr(workflow_execution, "_emit_trace_update", emit_update)
+    monkeypatch.setattr(
+        workflow_execution,
+        "record_workflow_completion",
+        lambda span_arg: completion_calls.append(span_arg),
+    )
+
+    succeeded_result = WorkflowRunResult(
+        run_id="exec-1",
+        status="succeeded",
+        outputs={"out": "val"},
+        error=None,
+    )
+    dispatch_mock = AsyncMock(return_value=succeeded_result)
+    monkeypatch.setattr(workflow_execution, "_dispatch_sandboxed_run", dispatch_mock)
+
+    await _execute_sandboxed_workflow(
+        workspace_id="ws-1",
+        execution_id="exec-1",
+        graph_config={},
+        inputs={},
+        runtime_config={},
+        state_config={},
+        history_store=history_store,
+        websocket=websocket,
+        tracer=object(),
+        span=SimpleNamespace(),
+    )
+
+    history_store.mark_completed.assert_awaited_once_with("exec-1")
+    assert len(completion_calls) == 1
+    emit_update.assert_awaited()
+    final_call = emit_update.await_args_list[-1]
+    assert final_call.kwargs.get("complete") is True
+
+
+@pytest.mark.asyncio
+async def test_execute_sandboxed_workflow_emits_trace_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_execute_sandboxed_workflow still emits trace update when sandbox fails."""
+    from orcheo.sandbox.workflow import WorkflowRunResult
+    from orcheo_backend.app.workflow_execution import _execute_sandboxed_workflow
+
+    history_store = AsyncMock()
+    history_store.append_step = AsyncMock(return_value=SimpleNamespace())
+    history_store.mark_completed = AsyncMock()
+    emit_update = AsyncMock()
+    monkeypatch.setattr(workflow_execution, "_emit_trace_update", emit_update)
+    monkeypatch.setattr(
+        workflow_execution, "record_workflow_completion", lambda span_arg: None
+    )
+
+    failed_result = WorkflowRunResult(
+        run_id="exec-fail",
+        status="failed",
+        outputs={},
+        error="sandbox error",
+    )
+    dispatch_mock = AsyncMock(return_value=failed_result)
+    monkeypatch.setattr(workflow_execution, "_dispatch_sandboxed_run", dispatch_mock)
+
+    await _execute_sandboxed_workflow(
+        workspace_id="ws-1",
+        execution_id="exec-fail",
+        graph_config={},
+        inputs={},
+        runtime_config={},
+        state_config={},
+        history_store=history_store,
+        websocket=AsyncMock(),
+        tracer=object(),
+        span=SimpleNamespace(),
+    )
+
+    history_store.mark_completed.assert_not_awaited()
+    final_call = emit_update.await_args_list[-1]
+    assert final_call.kwargs.get("complete") is True
+
+
+# ---------------------------------------------------------------------------
+# execute_workflow sandboxed path tests (lines 688-703)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_workflow_dispatches_to_sandbox_when_should_sandbox(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """execute_workflow takes the sandboxed path when dispatcher.should_sandbox is True."""
+    history_store = AsyncMock()
+    history_store.start_run = AsyncMock()
+    history_store.append_step = AsyncMock(return_value=SimpleNamespace())
+    history_store.mark_completed = AsyncMock()
+
+    span_context = SimpleNamespace(
+        span=object(),
+        trace_id="trace-id",
+        started_at=datetime.now(tz=UTC),
+    )
+
+    @contextlib.contextmanager
+    def fake_span(*args: Any, **kwargs: Any) -> Any:
+        yield span_context
+
+    monkeypatch.setattr(workflow_execution, "get_settings", lambda: {})
+    monkeypatch.setattr(workflow_execution, "get_history_store", lambda: history_store)
+    monkeypatch.setattr(workflow_execution, "get_repository", lambda: object())
+    monkeypatch.setattr(
+        workflow_execution, "resolve_workflow_workspace_id", _echo_workspace_id
+    )
+    monkeypatch.setattr(workflow_execution, "get_vault", lambda: object())
+    monkeypatch.setattr(
+        workflow_execution,
+        "credential_context_from_workflow",
+        lambda workflow_id, workspace_id=None: {},
+    )
+    monkeypatch.setattr(
+        workflow_execution, "CredentialResolver", lambda vault, context=None: object()
+    )
+    monkeypatch.setattr(workflow_execution, "get_tracer", lambda name: object())
+    monkeypatch.setattr(workflow_execution, "workflow_span", fake_span)
+    monkeypatch.setattr(
+        workflow_execution,
+        "_resolve_stored_runnable_config",
+        AsyncMock(return_value=None),
+    )
+
+    class DummyMergedConfig:
+        tags: list[object] = []
+        callbacks: list[object] = []
+        metadata: dict[str, object] = {}
+        run_name = None
+
+        def to_runnable_config(self, execution_id: str) -> dict[str, object]:
+            return {"configurable": {"thread_id": execution_id}}
+
+        def to_state_config(self, execution_id: str) -> dict[str, object]:
+            return {}
+
+        def to_json_config(self, execution_id: str) -> dict[str, object]:
+            return {}
+
+    monkeypatch.setattr(
+        workflow_execution, "merge_runnable_configs", lambda s, c: DummyMergedConfig()
+    )
+
+    class _FakeDispatcher:
+        def should_sandbox(self, spec: Any) -> bool:
+            return True
+
+    monkeypatch.setattr(
+        workflow_execution, "get_sandbox_dispatcher", lambda: _FakeDispatcher()
+    )
+    monkeypatch.setattr(
+        workflow_execution,
+        "build_workflow_run_spec",
+        lambda **kwargs: SimpleNamespace(),
+    )
+
+    sandboxed_calls: list[Any] = []
+    sandboxed_mock = AsyncMock(
+        side_effect=lambda **kwargs: sandboxed_calls.append(kwargs)
+    )
+    monkeypatch.setattr(
+        workflow_execution, "_execute_sandboxed_workflow", sandboxed_mock
+    )
+    monkeypatch.setattr(workflow_execution, "_emit_trace_update", AsyncMock())
+
+    await execute_workflow(
+        workflow_id="ws-workflow",
+        graph_config={"nodes": []},
+        inputs={},
+        execution_id="exec-sandbox",
+        websocket=AsyncMock(),
+        workspace_id="ws-1",
+    )
+
+    sandboxed_mock.assert_awaited_once()
+    assert sandboxed_mock.await_args.kwargs["workspace_id"] == "ws-1"
+
+
+@pytest.mark.asyncio
+async def test_execute_workflow_raises_when_sandbox_path_missing_workspace_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """execute_workflow raises RuntimeError when sandbox path has no workspace_id."""
+    history_store = AsyncMock()
+    history_store.start_run = AsyncMock()
+
+    span_context = SimpleNamespace(
+        span=object(),
+        trace_id="trace-id",
+        started_at=datetime.now(tz=UTC),
+    )
+
+    @contextlib.contextmanager
+    def fake_span(*args: Any, **kwargs: Any) -> Any:
+        yield span_context
+
+    async def echo_none(
+        repository: Any, workflow_id: Any, workspace_id: Any = None
+    ) -> None:
+        return None
+
+    monkeypatch.setattr(workflow_execution, "get_settings", lambda: {})
+    monkeypatch.setattr(workflow_execution, "get_history_store", lambda: history_store)
+    monkeypatch.setattr(workflow_execution, "get_repository", lambda: object())
+    monkeypatch.setattr(workflow_execution, "resolve_workflow_workspace_id", echo_none)
+    monkeypatch.setattr(workflow_execution, "get_vault", lambda: object())
+    monkeypatch.setattr(
+        workflow_execution,
+        "credential_context_from_workflow",
+        lambda workflow_id, workspace_id=None: {},
+    )
+    monkeypatch.setattr(
+        workflow_execution, "CredentialResolver", lambda vault, context=None: object()
+    )
+    monkeypatch.setattr(workflow_execution, "get_tracer", lambda name: object())
+    monkeypatch.setattr(workflow_execution, "workflow_span", fake_span)
+    monkeypatch.setattr(
+        workflow_execution,
+        "_resolve_stored_runnable_config",
+        AsyncMock(return_value=None),
+    )
+
+    class DummyMergedConfig:
+        tags: list[object] = []
+        callbacks: list[object] = []
+        metadata: dict[str, object] = {}
+        run_name = None
+
+        def to_runnable_config(self, execution_id: str) -> dict[str, object]:
+            return {"configurable": {"thread_id": execution_id}}
+
+        def to_state_config(self, execution_id: str) -> dict[str, object]:
+            return {}
+
+        def to_json_config(self, execution_id: str) -> dict[str, object]:
+            return {}
+
+    monkeypatch.setattr(
+        workflow_execution, "merge_runnable_configs", lambda s, c: DummyMergedConfig()
+    )
+
+    class _FakeDispatcher:
+        def should_sandbox(self, spec: Any) -> bool:
+            return True
+
+    monkeypatch.setattr(
+        workflow_execution, "get_sandbox_dispatcher", lambda: _FakeDispatcher()
+    )
+    monkeypatch.setattr(
+        workflow_execution,
+        "build_workflow_run_spec",
+        lambda **kwargs: SimpleNamespace(),
+    )
+    monkeypatch.setattr(workflow_execution, "_emit_trace_update", AsyncMock())
+
+    with pytest.raises(RuntimeError, match="workspace_id is required"):
+        await execute_workflow(
+            workflow_id="ws-workflow",
+            graph_config={"nodes": []},
+            inputs={},
+            execution_id="exec-no-ws",
+            websocket=AsyncMock(),
+            workspace_id=None,
+        )

--- a/tests/backend/worker/test_celery_app.py
+++ b/tests/backend/worker/test_celery_app.py
@@ -1,0 +1,75 @@
+"""Tests for the Celery app configuration and worker process init signal."""
+
+from __future__ import annotations
+import importlib
+import sys
+import types
+from typing import Any
+import pytest
+
+
+def _get_celery_app_module() -> Any:
+    """Return the orcheo_backend.worker.celery_app *module* (not the Celery instance)."""
+    return importlib.import_module("orcheo_backend.worker.celery_app")
+
+
+def test_configure_sandbox_for_worker_calls_ensure_sandbox_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_configure_sandbox_for_worker calls ensure_sandbox_configured on success."""
+    celery_module = _get_celery_app_module()
+
+    calls: list[str] = []
+
+    def _fake_ensure() -> None:
+        calls.append("called")
+
+    fake_sandbox = types.ModuleType("orcheo_backend.app.sandbox")
+    fake_sandbox.ensure_sandbox_configured = _fake_ensure  # type: ignore[attr-defined]
+
+    old = sys.modules.get("orcheo_backend.app.sandbox")
+    sys.modules["orcheo_backend.app.sandbox"] = fake_sandbox
+    try:
+        celery_module._configure_sandbox_for_worker()
+    finally:
+        if old is None:
+            sys.modules.pop("orcheo_backend.app.sandbox", None)
+        else:
+            sys.modules["orcheo_backend.app.sandbox"] = old
+
+    assert calls == ["called"]
+
+
+def test_configure_sandbox_for_worker_reraises_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_configure_sandbox_for_worker re-raises exceptions after logging."""
+    celery_module = _get_celery_app_module()
+
+    logged: list[str] = []
+
+    def _fail_ensure() -> None:
+        raise RuntimeError("sandbox config failed")
+
+    class _StubLogger:
+        def exception(self, *args: Any, **kwargs: Any) -> None:
+            logged.append(args[0] if args else "")
+
+    fake_sandbox = types.ModuleType("orcheo_backend.app.sandbox")
+    fake_sandbox.ensure_sandbox_configured = _fail_ensure  # type: ignore[attr-defined]
+
+    old = sys.modules.get("orcheo_backend.app.sandbox")
+    sys.modules["orcheo_backend.app.sandbox"] = fake_sandbox
+    original_logger = celery_module.logger
+    celery_module.logger = _StubLogger()
+    try:
+        with pytest.raises(RuntimeError, match="sandbox config failed"):
+            celery_module._configure_sandbox_for_worker()
+    finally:
+        celery_module.logger = original_logger
+        if old is None:
+            sys.modules.pop("orcheo_backend.app.sandbox", None)
+        else:
+            sys.modules["orcheo_backend.app.sandbox"] = old
+
+    assert logged  # the exception was logged before re-raising

--- a/tests/backend/worker/test_tasks_workflow_execution.py
+++ b/tests/backend/worker/test_tasks_workflow_execution.py
@@ -820,3 +820,71 @@ class TestExecuteWorkflowSandboxDispatch:
 
         assert result["status"] == "failed"
         assert "workspace_id" in result["error"]
+
+
+class TestExecuteSandboxedRunInWorker:
+    """Tests for _execute_sandboxed_run_in_worker function."""
+
+    @pytest.mark.asyncio
+    async def test_logs_history_error_on_append_failure(self) -> None:
+        """The except handler logs when append_step raises history_error_cls (lines 377-378)."""
+        from unittest.mock import patch
+        from orcheo_backend.worker.tasks import _execute_sandboxed_run_in_worker
+
+        history_error_cls = type("HistoryError", (Exception,), {})
+        mock_history = AsyncMock()
+        mock_history.append_step = AsyncMock(
+            side_effect=history_error_cls("store down")
+        )
+
+        from orcheo.sandbox.workflow import WorkflowRunResult
+
+        class _FakeDispatcher:
+            async def dispatch(self, spec: object) -> WorkflowRunResult:
+                return WorkflowRunResult(
+                    run_id="exec",
+                    status="succeeded",
+                    outputs={"out": "val"},
+                    error=None,
+                )
+
+        with patch("orcheo_backend.worker.tasks.logger") as mock_logger:
+            result = await _execute_sandboxed_run_in_worker(
+                dispatcher=_FakeDispatcher(),
+                spec=object(),
+                history_store=mock_history,
+                execution_id="exec-err",
+                history_error_cls=history_error_cls,
+            )
+
+        mock_logger.exception.assert_called_once()
+        assert "exec-err" in str(mock_logger.exception.call_args)
+        assert result == {"sandbox_outputs": {"out": "val"}}
+
+    @pytest.mark.asyncio
+    async def test_raises_runtime_error_on_non_succeeded_status(self) -> None:
+        """_execute_sandboxed_run_in_worker raises RuntimeError when status != 'succeeded'."""
+        from orcheo_backend.worker.tasks import _execute_sandboxed_run_in_worker
+        from orcheo.sandbox.workflow import WorkflowRunResult
+
+        history_error_cls = type("HistoryError", (Exception,), {})
+        mock_history = AsyncMock()
+        mock_history.append_step = AsyncMock(return_value=None)
+
+        class _FakeDispatcher:
+            async def dispatch(self, spec: object) -> WorkflowRunResult:
+                return WorkflowRunResult(
+                    run_id="exec",
+                    status="failed",
+                    outputs={},
+                    error="something exploded",
+                )
+
+        with pytest.raises(RuntimeError, match="something exploded"):
+            await _execute_sandboxed_run_in_worker(
+                dispatcher=_FakeDispatcher(),
+                spec=object(),
+                history_store=mock_history,
+                execution_id="exec-fail",
+                history_error_cls=history_error_cls,
+            )

--- a/tests/backend/worker/test_tasks_workflow_execution.py
+++ b/tests/backend/worker/test_tasks_workflow_execution.py
@@ -602,3 +602,221 @@ class TestDispatchCronTriggersAsync:
             result = await _dispatch_cron_triggers_async()
 
         assert result == [str(mock_run.id)]
+
+
+class TestExecuteWorkflowSandboxDispatch:
+    """Sandbox-routing behavior introduced by workspace runtime isolation."""
+
+    @pytest.mark.asyncio
+    async def test_sandbox_dispatch_persists_sandbox_result_and_succeeds(
+        self, mock_run: MagicMock, mock_version: MagicMock
+    ) -> None:
+        """Untrusted graphs are dispatched and surfaced via sandbox_result."""
+        from orcheo.sandbox.workflow import WorkflowRunResult
+        from orcheo_backend.worker.tasks import _execute_workflow
+
+        # Untrusted node type → dispatcher must sandbox.
+        mock_version.graph = {"nodes": [{"type": "TenantPythonNode"}]}
+
+        mock_repo = AsyncMock()
+        mock_repo.get_version = AsyncMock(return_value=mock_version)
+        mock_repo.mark_run_succeeded = AsyncMock()
+        mock_history = AsyncMock()
+        mock_history.append_step = AsyncMock()
+
+        class _SandboxingDispatcher:
+            def __init__(self) -> None:
+                self.dispatched: list[Any] = []
+
+            def should_sandbox(self, spec: Any) -> bool:  # noqa: ARG002
+                return True
+
+            async def dispatch(self, spec: Any) -> WorkflowRunResult:
+                self.dispatched.append(spec)
+                return WorkflowRunResult(
+                    run_id=spec.run_id,
+                    status="succeeded",
+                    outputs={"value": 1},
+                )
+
+        dispatcher = _SandboxingDispatcher()
+
+        with (
+            patch(
+                "orcheo_backend.app.dependencies.get_repository",
+                return_value=mock_repo,
+            ),
+            patch(
+                "orcheo_backend.app.dependencies.get_vault",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "orcheo_backend.app.dependencies.get_history_store",
+                return_value=mock_history,
+            ),
+            patch(
+                "orcheo_backend.app.sandbox.get_sandbox_dispatcher",
+                return_value=dispatcher,
+            ),
+            patch("orcheo.config.get_settings"),
+            patch(
+                "orcheo.runtime.runnable_config.merge_runnable_configs"
+            ) as mock_merge,
+        ):
+            mock_config = MagicMock()
+            mock_config.to_runnable_config = MagicMock(return_value={})
+            mock_config.to_state_config = MagicMock(return_value={})
+            mock_config.to_json_config = MagicMock(return_value={})
+            mock_config.tags = []
+            mock_config.callbacks = []
+            mock_config.metadata = {}
+            mock_config.run_name = None
+            mock_merge.return_value = mock_config
+
+            result = await _execute_workflow(mock_run)
+
+        assert result["status"] == "succeeded"
+        assert dispatcher.dispatched and dispatcher.dispatched[0].workspace_id == str(
+            mock_run.workspace_id
+        )
+        sandbox_calls = [
+            call
+            for call in mock_history.append_step.await_args_list
+            if call.args[1].get("event") == "sandbox_result"
+        ]
+        assert sandbox_calls, "sandbox_result step must be persisted"
+        mock_repo.mark_run_succeeded.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_sandbox_dispatch_failure_marks_run_failed(
+        self, mock_run: MagicMock, mock_version: MagicMock
+    ) -> None:
+        """A failed sandbox result raises so the worker records the failure."""
+        from orcheo.sandbox.workflow import WorkflowRunResult
+        from orcheo_backend.worker.tasks import _execute_workflow
+
+        mock_version.graph = {"nodes": [{"type": "TenantPythonNode"}]}
+
+        mock_repo = AsyncMock()
+        mock_repo.get_version = AsyncMock(return_value=mock_version)
+        mock_repo.mark_run_succeeded = AsyncMock()
+        mock_repo.mark_run_failed = AsyncMock()
+        mock_history = AsyncMock()
+        mock_history.append_step = AsyncMock()
+
+        class _FailingDispatcher:
+            def should_sandbox(self, spec: Any) -> bool:  # noqa: ARG002
+                return True
+
+            async def dispatch(self, spec: Any) -> WorkflowRunResult:
+                return WorkflowRunResult(
+                    run_id=spec.run_id,
+                    status="failed",
+                    outputs={},
+                    error="sandbox kaput",
+                )
+
+        with (
+            patch(
+                "orcheo_backend.app.dependencies.get_repository",
+                return_value=mock_repo,
+            ),
+            patch(
+                "orcheo_backend.app.dependencies.get_vault",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "orcheo_backend.app.dependencies.get_history_store",
+                return_value=mock_history,
+            ),
+            patch(
+                "orcheo_backend.app.sandbox.get_sandbox_dispatcher",
+                return_value=_FailingDispatcher(),
+            ),
+            patch("orcheo.config.get_settings"),
+            patch(
+                "orcheo.runtime.runnable_config.merge_runnable_configs"
+            ) as mock_merge,
+        ):
+            mock_config = MagicMock()
+            mock_config.to_runnable_config = MagicMock(return_value={})
+            mock_config.to_state_config = MagicMock(return_value={})
+            mock_config.to_json_config = MagicMock(return_value={})
+            mock_config.tags = []
+            mock_config.callbacks = []
+            mock_config.metadata = {}
+            mock_config.run_name = None
+            mock_merge.return_value = mock_config
+
+            result = await _execute_workflow(mock_run)
+
+        assert result["status"] == "failed"
+        assert "sandbox kaput" in result["error"]
+        mock_repo.mark_run_failed.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_sandbox_dispatch_requires_workspace_id(
+        self, mock_version: MagicMock
+    ) -> None:
+        """Sandboxed dispatch must refuse to run when no workspace_id is set."""
+        from orcheo_backend.worker.tasks import _execute_workflow
+
+        run = MagicMock()
+        run.id = uuid4()
+        run.workflow_version_id = uuid4()
+        run.status = WorkflowRunStatus.PENDING
+        run.input_payload = {}
+        run.runnable_config = None
+        run.workspace_id = None
+
+        mock_version.graph = {"nodes": [{"type": "TenantPythonNode"}]}
+
+        mock_repo = AsyncMock()
+        mock_repo.get_version = AsyncMock(return_value=mock_version)
+        mock_repo.mark_run_failed = AsyncMock()
+        mock_history = AsyncMock()
+        mock_history.append_step = AsyncMock()
+
+        class _AlwaysSandboxDispatcher:
+            def should_sandbox(self, spec: Any) -> bool:  # noqa: ARG002
+                return True
+
+            async def dispatch(self, spec: Any) -> Any:  # pragma: no cover
+                raise AssertionError("should never dispatch")
+
+        with (
+            patch(
+                "orcheo_backend.app.dependencies.get_repository",
+                return_value=mock_repo,
+            ),
+            patch(
+                "orcheo_backend.app.dependencies.get_vault",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "orcheo_backend.app.dependencies.get_history_store",
+                return_value=mock_history,
+            ),
+            patch(
+                "orcheo_backend.app.sandbox.get_sandbox_dispatcher",
+                return_value=_AlwaysSandboxDispatcher(),
+            ),
+            patch("orcheo.config.get_settings"),
+            patch(
+                "orcheo.runtime.runnable_config.merge_runnable_configs"
+            ) as mock_merge,
+        ):
+            mock_config = MagicMock()
+            mock_config.to_runnable_config = MagicMock(return_value={})
+            mock_config.to_state_config = MagicMock(return_value={})
+            mock_config.to_json_config = MagicMock(return_value={})
+            mock_config.tags = []
+            mock_config.callbacks = []
+            mock_config.metadata = {}
+            mock_config.run_name = None
+            mock_merge.return_value = mock_config
+
+            result = await _execute_workflow(run)
+
+        assert result["status"] == "failed"
+        assert "workspace_id" in result["error"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,12 @@ for key, value in (
     ("OPENAI_API_KEY", "sk-test-orcheo"),
     ("ORCHEO_POSTGRES_DSN", "postgresql://test:test@localhost/test"),
     ("ORCHEO_VAULT_ENCRYPTION_KEY", "test-vault-encryption-key"),
+    # The backend refuses to start without a broker secret in non-test runs.
+    # Tests supply a deterministic value so the FastAPI app builds at import.
+    ("ORCHEO_CREDENTIAL_BROKER_SECRET", "test-broker-secret"),
+    # The sandbox bootstrap requires a runtime URL; tests inject their own
+    # primitives and never actually hit this URL.
+    ("ORCHEO_SANDBOX_RUNTIME_URL", "http://sandbox-runtime.test:9090"),
 ):
     os.environ.setdefault(key, value)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,10 +21,18 @@ for key, value in (
     os.environ.setdefault(key, value)
 
 from orcheo.models import AesGcmCredentialCipher
+from orcheo.sandbox.broker import CredentialBroker
+from orcheo.sandbox.launcher import SandboxedProcessLauncher
+from orcheo.sandbox.workflow import (
+    WorkflowRunResult,
+    WorkflowRunSpec,
+    WorkflowSandboxDispatcher,
+)
 from orcheo.vault import InMemoryCredentialVault
 from orcheo.workspace import InMemoryWorkspaceRepository
 from orcheo_backend.app import chatkit_runtime
 from orcheo_backend.app import dependencies as backend_dependencies
+from orcheo_backend.app import sandbox as backend_sandbox
 from orcheo_backend.app.workspace import dependencies as workspace_dependencies
 
 
@@ -88,6 +96,68 @@ def _ensure_vault_encryption_key(monkeypatch):
 
     if not os.environ.get("ORCHEO_VAULT_ENCRYPTION_KEY"):
         monkeypatch.setenv("ORCHEO_VAULT_ENCRYPTION_KEY", "test-vault-encryption-key")
+
+
+class _StubSandboxDispatcher:
+    """Test dispatcher that never sandboxes and never touches the runtime.
+
+    Real workflow execution in unit tests runs in-process: the goal is to
+    verify the worker / executor wiring, not the gVisor stack. The shared
+    bootstrap normally insists on a configured broker before exposing the
+    dispatcher, so we install this stub so the production callers
+    (``dispatcher.should_sandbox(...)`` / ``dispatcher.dispatch(...)``)
+    keep working without standing up a real sandbox runtime.
+    """
+
+    def __init__(self) -> None:
+        self.dispatched: list[WorkflowRunSpec] = []
+        self.next_result: WorkflowRunResult | None = None
+
+    def should_sandbox(self, spec: WorkflowRunSpec) -> bool:  # noqa: ARG002
+        return False
+
+    async def dispatch(self, spec: WorkflowRunSpec) -> WorkflowRunResult:
+        self.dispatched.append(spec)
+        return self.next_result or WorkflowRunResult(
+            run_id=spec.run_id,
+            status="succeeded",
+            outputs={},
+        )
+
+
+class _StubSandboxLauncher:
+    """Test launcher returned by ``get_sandbox_launcher`` during unit tests."""
+
+    async def run(self, **_: object) -> object:  # pragma: no cover - defensive
+        msg = "Stub sandbox launcher cannot execute commands in unit tests"
+        raise RuntimeError(msg)
+
+
+class _StubSandboxBootstrap:
+    """Replacement bootstrap that yields the stub dispatcher / launcher."""
+
+    def __init__(self) -> None:
+        self._dispatcher = _StubSandboxDispatcher()
+        self._launcher = _StubSandboxLauncher()
+        self._broker: CredentialBroker | None = CredentialBroker(
+            secret="test-broker-secret",
+            resolver=lambda **_: "",
+        )
+
+    def configure(self, broker: CredentialBroker) -> None:
+        self._broker = broker
+
+    def launcher(self) -> SandboxedProcessLauncher:  # type: ignore[override]
+        return self._launcher  # type: ignore[return-value]
+
+    def dispatcher(self) -> WorkflowSandboxDispatcher:  # type: ignore[override]
+        return self._dispatcher  # type: ignore[return-value]
+
+
+@pytest.fixture(autouse=True)
+def _install_stub_sandbox_bootstrap(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Swap the real sandbox bootstrap for a stub during every unit test."""
+    monkeypatch.setattr(backend_sandbox, "_bootstrap", _StubSandboxBootstrap())
 
 
 @pytest.fixture(autouse=True)

--- a/tests/external_agents/test_runtime.py
+++ b/tests/external_agents/test_runtime.py
@@ -167,6 +167,39 @@ def test_default_runtime_root_falls_back_to_home(tmp_path: Path) -> None:
     assert resolved == home_directory / ".orcheo" / "agent-runtimes"
 
 
+def test_default_runtime_root_honors_env_override(tmp_path: Path) -> None:
+    """An ORCHEO_AGENT_RUNTIME_ROOT override wins over /data and home defaults.
+
+    The sandbox runtime manager sets this env var so per-workspace sandboxes —
+    which run with a read-only rootfs — direct the managed runtime tree onto
+    the writable /scratch tmpfs instead of ~/.orcheo.
+    """
+    data_root = tmp_path / "data"
+    data_root.mkdir()
+    override = tmp_path / "scratch" / "agent-runtimes"
+
+    resolved = default_runtime_root(
+        data_root=data_root,
+        home_directory=tmp_path / "home",
+        env={"ORCHEO_AGENT_RUNTIME_ROOT": str(override)},
+    )
+
+    assert resolved == override
+
+
+def test_default_runtime_root_ignores_blank_env_override(tmp_path: Path) -> None:
+    """A blank override is treated as unset so the fallback chain runs."""
+    home_directory = tmp_path / "home"
+
+    resolved = default_runtime_root(
+        data_root=tmp_path / "missing-data",
+        home_directory=home_directory,
+        env={"ORCHEO_AGENT_RUNTIME_ROOT": "   "},
+    )
+
+    assert resolved == home_directory / ".orcheo" / "agent-runtimes"
+
+
 def test_runtime_path_helpers_return_expected_locations(tmp_path: Path) -> None:
     """Path helpers resolve provider-specific runtime storage locations."""
     runtime_root = external_agent_paths.ensure_runtime_root(tmp_path / "managed")

--- a/tests/nodes/test_external_agent_legacy_node.py
+++ b/tests/nodes/test_external_agent_legacy_node.py
@@ -20,8 +20,37 @@ from orcheo.external_agents.models import (
 from orcheo.graph.state import State
 from orcheo.nodes.external_agent import ExternalAgentNode
 from orcheo.runtime.credentials import CredentialReferenceNotFoundError
+from orcheo.sandbox.dispatch import use_launcher
 
 from tests.nodes.test_external_agent_node import DummyProvider, FakeRuntimeManager
+
+
+class _CannedLauncher:
+    """Test-only launcher that returns a canned ``ProcessExecutionResult``."""
+
+    def __init__(self, result: ProcessExecutionResult) -> None:
+        self.result = result
+        self.calls: list[dict[str, Any]] = []
+
+    async def run(
+        self,
+        *,
+        workspace_id: str,
+        command: list[str],
+        cwd: Any,
+        env: Any,
+        timeout_seconds: Any,
+    ) -> ProcessExecutionResult:
+        self.calls.append(
+            {
+                "workspace_id": workspace_id,
+                "command": command,
+                "cwd": cwd,
+                "env": env,
+                "timeout_seconds": timeout_seconds,
+            }
+        )
+        return self.result
 
 
 class LegacyDummyExternalAgentNode(ExternalAgentNode):
@@ -182,9 +211,9 @@ async def test_run_reports_timeout_non_zero_exit_and_success(
     manager = FakeRuntimeManager(provider=DummyProvider(), resolution=resolution)
     node = _make_node(manager)
 
-    async def fake_timeout(*args: object, **kwargs: object) -> ProcessExecutionResult:
-        del args, kwargs
-        return ProcessExecutionResult(
+    del monkeypatch
+    timeout_launcher = _CannedLauncher(
+        ProcessExecutionResult(
             command=["dummy"],
             stdout="",
             stderr="",
@@ -192,15 +221,16 @@ async def test_run_reports_timeout_non_zero_exit_and_success(
             timed_out=True,
             duration_seconds=0,
         )
-
-    monkeypatch.setattr("orcheo.nodes.external_agent.execute_process", fake_timeout)
-    result = await node.run(_make_state({"prompt": "run"}), RunnableConfig())
+    )
+    with use_launcher(timeout_launcher):  # type: ignore[arg-type]
+        state = _make_state({"prompt": "run"})
+        state["workspace_id"] = "ws-timeout"
+        result = await node.run(state, RunnableConfig())
     assert result["reason"] == "timeout"
     assert result["status"] == "failed"
 
-    async def fake_exit(*args: object, **kwargs: object) -> ProcessExecutionResult:
-        del args, kwargs
-        return ProcessExecutionResult(
+    exit_launcher = _CannedLauncher(
+        ProcessExecutionResult(
             command=["dummy"],
             stdout="",
             stderr="",
@@ -208,9 +238,11 @@ async def test_run_reports_timeout_non_zero_exit_and_success(
             timed_out=False,
             duration_seconds=0,
         )
-
-    monkeypatch.setattr("orcheo.nodes.external_agent.execute_process", fake_exit)
-    result = await node.run(_make_state({"prompt": "run"}), RunnableConfig())
+    )
+    with use_launcher(exit_launcher):  # type: ignore[arg-type]
+        state = _make_state({"prompt": "run"})
+        state["workspace_id"] = "ws-exit"
+        result = await node.run(state, RunnableConfig())
     assert result["reason"] == "non_zero_exit"
     assert "exited with code 5" in result["message"]
 
@@ -224,9 +256,8 @@ async def test_run_reports_timeout_non_zero_exit_and_success(
     manager = FakeRuntimeManager(provider=provider, resolution=resolution)
     node = _make_node(manager)
 
-    async def fake_success(*args: object, **kwargs: object) -> ProcessExecutionResult:
-        del args, kwargs
-        return ProcessExecutionResult(
+    success_launcher = _CannedLauncher(
+        ProcessExecutionResult(
             command=["dummy"],
             stdout="ok",
             stderr="",
@@ -234,11 +265,11 @@ async def test_run_reports_timeout_non_zero_exit_and_success(
             timed_out=False,
             duration_seconds=0,
         )
-
-    monkeypatch.setattr("orcheo.nodes.external_agent.execute_process", fake_success)
+    )
     state = _make_state({"prompt": "run"})
     state["workspace_id"] = "workspace-1"
-    result = await node.run(state, RunnableConfig())
+    with use_launcher(success_launcher):  # type: ignore[arg-type]
+        result = await node.run(state, RunnableConfig())
     assert result["status"] == "succeeded"
     assert result["stdout"] == "ok"
     assert manager.workspace_id == "workspace-1"
@@ -261,9 +292,9 @@ async def test_run_logs_bypass_flag_audit_event(
     manager = FakeRuntimeManager(provider=provider, resolution=resolution)
     node = _make_node(manager)
 
-    async def fake_execute(*args: object, **kwargs: object) -> ProcessExecutionResult:
-        del args, kwargs
-        return ProcessExecutionResult(
+    del monkeypatch
+    bypass_launcher = _CannedLauncher(
+        ProcessExecutionResult(
             command=["dummy"],
             stdout="ok",
             stderr="",
@@ -271,11 +302,13 @@ async def test_run_logs_bypass_flag_audit_event(
             timed_out=False,
             duration_seconds=0,
         )
-
-    monkeypatch.setattr("orcheo.nodes.external_agent.execute_process", fake_execute)
+    )
 
     with caplog.at_level(logging.INFO, logger="orcheo.nodes.external_agent"):
-        result = await node.run(_make_state({"prompt": "run"}), RunnableConfig())
+        state = _make_state({"prompt": "run"})
+        state["workspace_id"] = "ws-bypass"
+        with use_launcher(bypass_launcher):  # type: ignore[arg-type]
+            result = await node.run(state, RunnableConfig())
 
     assert result["status"] == "succeeded"
     record = next(
@@ -315,12 +348,9 @@ async def test_run_uses_launcher_when_active_launcher_is_set(
         async def run(self, **kwargs: object) -> ProcessExecutionResult:
             return fake_result
 
-    monkeypatch.setattr(
-        "orcheo.nodes.external_agent.get_active_launcher",
-        lambda: _FakeLauncher(),
-    )
-
-    result = await node.run(state, RunnableConfig())
+    del monkeypatch
+    with use_launcher(_FakeLauncher()):  # type: ignore[arg-type]
+        result = await node.run(state, RunnableConfig())
 
     assert result["status"] == "succeeded"
     assert result["stdout"] == "launched-via-sandbox"

--- a/tests/nodes/test_external_agent_node.py
+++ b/tests/nodes/test_external_agent_node.py
@@ -20,6 +20,41 @@ from orcheo.external_agents.models import (
 from orcheo.graph.state import State
 from orcheo.nodes.ai.external.base import ExternalAgentNode
 from orcheo.runtime.credentials import CredentialReferenceNotFoundError
+from orcheo.sandbox.dispatch import use_launcher
+
+
+class _SwappableLauncher:
+    """Test launcher whose canned result is mutable mid-test."""
+
+    def __init__(self) -> None:
+        self.result = ProcessExecutionResult(
+            command=["dummy"],
+            stdout="ok",
+            stderr="",
+            exit_code=0,
+            timed_out=False,
+            duration_seconds=0,
+        )
+
+    async def run(
+        self,
+        *,
+        workspace_id: str,
+        command: list[str],
+        cwd: Any,
+        env: Any,
+        timeout_seconds: Any,
+    ) -> ProcessExecutionResult:
+        del workspace_id, command, cwd, env, timeout_seconds
+        return self.result
+
+
+@pytest.fixture(autouse=True)
+def fake_launcher() -> Any:
+    """Bind a swappable fake launcher for every ExternalAgentNode test."""
+    launcher = _SwappableLauncher()
+    with use_launcher(launcher):  # type: ignore[arg-type]
+        yield launcher
 
 
 class DummyProvider:
@@ -156,7 +191,13 @@ def _make_runtime_resolution(tmp_path: Path) -> RuntimeResolution:
 
 
 def _make_state(inputs: dict[str, Any] | None = None) -> State:
-    return State(inputs=inputs or {}, results={}, structured_response=None, config={})
+    return State(
+        inputs=inputs or {},
+        results={},
+        structured_response=None,
+        config={},
+        workspace_id="ws-test",
+    )
 
 
 def _make_node(manager: FakeRuntimeManager) -> DummyExternalAgentNode:
@@ -340,10 +381,7 @@ async def test_run_invalid_configuration_when_working_directory_invalid(
 
 
 @pytest.mark.asyncio
-async def test_run_auto_initializes_git_worktree_by_default(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
+async def test_run_auto_initializes_git_worktree_by_default(tmp_path: Path) -> None:
     resolution = _make_runtime_resolution(tmp_path)
     manager = FakeRuntimeManager(
         provider=DummyProvider(),
@@ -352,31 +390,13 @@ async def test_run_auto_initializes_git_worktree_by_default(
     node = _make_node(manager)
     state = _make_state({"prompt": "run"})
 
-    async def fake_execute(*args: object, **kwargs: object) -> ProcessExecutionResult:
-        return ProcessExecutionResult(
-            command=["dummy"],
-            stdout="ok",
-            stderr="",
-            exit_code=0,
-            timed_out=False,
-            duration_seconds=0,
-        )
-
-    monkeypatch.setattr(
-        "orcheo.nodes.ai.external.base.execute_process",
-        fake_execute,
-    )
-
     await node.run(state, RunnableConfig())
 
     assert manager.auto_init_git_worktree is True
 
 
 @pytest.mark.asyncio
-async def test_run_can_disable_auto_init_git_worktree(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
+async def test_run_can_disable_auto_init_git_worktree(tmp_path: Path) -> None:
     resolution = _make_runtime_resolution(tmp_path)
     manager = FakeRuntimeManager(
         provider=DummyProvider(),
@@ -385,21 +405,6 @@ async def test_run_can_disable_auto_init_git_worktree(
     node = _make_node(manager)
     node.auto_init_git_worktree = False
     state = _make_state({"prompt": "run"})
-
-    async def fake_execute(*args: object, **kwargs: object) -> ProcessExecutionResult:
-        return ProcessExecutionResult(
-            command=["dummy"],
-            stdout="ok",
-            stderr="",
-            exit_code=0,
-            timed_out=False,
-            duration_seconds=0,
-        )
-
-    monkeypatch.setattr(
-        "orcheo.nodes.ai.external.base.execute_process",
-        fake_execute,
-    )
 
     await node.run(state, RunnableConfig())
 
@@ -459,26 +464,20 @@ async def test_run_requires_auth_before_execution(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_run_reports_timeout(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    fake_launcher: _SwappableLauncher, tmp_path: Path
 ) -> None:
     resolution = _make_runtime_resolution(tmp_path)
     manager = FakeRuntimeManager(provider=DummyProvider(), resolution=resolution)
     node = _make_node(manager)
     state = _make_state({"prompt": "run"})
 
-    async def fake_execute(*args: object, **kwargs: object) -> ProcessExecutionResult:
-        return ProcessExecutionResult(
-            command=["dummy"],
-            stdout="",
-            stderr="",
-            exit_code=None,
-            timed_out=True,
-            duration_seconds=0,
-        )
-
-    monkeypatch.setattr(
-        "orcheo.nodes.ai.external.base.execute_process",
-        fake_execute,
+    fake_launcher.result = ProcessExecutionResult(
+        command=["dummy"],
+        stdout="",
+        stderr="",
+        exit_code=None,
+        timed_out=True,
+        duration_seconds=0,
     )
 
     result = await node.run(state, RunnableConfig())
@@ -489,26 +488,20 @@ async def test_run_reports_timeout(
 
 @pytest.mark.asyncio
 async def test_run_reports_non_zero_exit(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    fake_launcher: _SwappableLauncher, tmp_path: Path
 ) -> None:
     resolution = _make_runtime_resolution(tmp_path)
     manager = FakeRuntimeManager(provider=DummyProvider(), resolution=resolution)
     node = _make_node(manager)
     state = _make_state({"prompt": "run"})
 
-    async def fake_execute(*args: object, **kwargs: object) -> ProcessExecutionResult:
-        return ProcessExecutionResult(
-            command=["dummy"],
-            stdout="",
-            stderr="",
-            exit_code=5,
-            timed_out=False,
-            duration_seconds=0,
-        )
-
-    monkeypatch.setattr(
-        "orcheo.nodes.ai.external.base.execute_process",
-        fake_execute,
+    fake_launcher.result = ProcessExecutionResult(
+        command=["dummy"],
+        stdout="",
+        stderr="",
+        exit_code=5,
+        timed_out=False,
+        duration_seconds=0,
     )
 
     result = await node.run(state, RunnableConfig())
@@ -518,28 +511,11 @@ async def test_run_reports_non_zero_exit(
 
 
 @pytest.mark.asyncio
-async def test_run_succeeds_with_zero_exit(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+async def test_run_succeeds_with_zero_exit(tmp_path: Path) -> None:
     resolution = _make_runtime_resolution(tmp_path)
     manager = FakeRuntimeManager(provider=DummyProvider(), resolution=resolution)
     node = _make_node(manager)
     state = _make_state({"prompt": "run"})
-
-    async def fake_execute(*args: object, **kwargs: object) -> ProcessExecutionResult:
-        return ProcessExecutionResult(
-            command=["dummy"],
-            stdout="ok",
-            stderr="",
-            exit_code=0,
-            timed_out=False,
-            duration_seconds=0,
-        )
-
-    monkeypatch.setattr(
-        "orcheo.nodes.ai.external.base.execute_process",
-        fake_execute,
-    )
 
     result = await node.run(state, RunnableConfig())
 
@@ -548,30 +524,13 @@ async def test_run_succeeds_with_zero_exit(
 
 
 @pytest.mark.asyncio
-async def test_run_preserves_workspace_id_when_present(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+async def test_run_preserves_workspace_id_when_present(tmp_path: Path) -> None:
     resolution = _make_runtime_resolution(tmp_path)
     manager = FakeRuntimeManager(provider=DummyProvider(), resolution=resolution)
     node = _make_node(manager)
     state = _make_state({"prompt": "run", "workspace_id": "workspace-1"})
-
-    async def fake_execute(*args: object, **kwargs: object) -> ProcessExecutionResult:
-        return ProcessExecutionResult(
-            command=["dummy"],
-            stdout="ok",
-            stderr="",
-            exit_code=0,
-            timed_out=False,
-            duration_seconds=0,
-        )
-
-    monkeypatch.setattr(
-        "orcheo.nodes.ai.external.base.execute_process",
-        fake_execute,
-    )
-
     state["workspace_id"] = "workspace-1"
+
     result = await node.run(state, RunnableConfig())
 
     assert result["status"] == "succeeded"
@@ -580,7 +539,6 @@ async def test_run_preserves_workspace_id_when_present(
 
 @pytest.mark.asyncio
 async def test_run_logs_bypass_flag_audit_event(
-    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -595,21 +553,6 @@ async def test_run_logs_bypass_flag_audit_event(
     manager = FakeRuntimeManager(provider=provider, resolution=resolution)
     node = _make_node(manager)
     state = _make_state({"prompt": "run"})
-
-    async def fake_execute(*args: object, **kwargs: object) -> ProcessExecutionResult:
-        return ProcessExecutionResult(
-            command=["dummy"],
-            stdout="ok",
-            stderr="",
-            exit_code=0,
-            timed_out=False,
-            duration_seconds=0,
-        )
-
-    monkeypatch.setattr(
-        "orcheo.nodes.ai.external.base.execute_process",
-        fake_execute,
-    )
 
     with caplog.at_level(logging.INFO, logger="orcheo.nodes.ai.external.base"):
         await node.run(state, RunnableConfig())

--- a/tests/nodes/test_external_agent_node.py
+++ b/tests/nodes/test_external_agent_node.py
@@ -567,3 +567,93 @@ async def test_run_logs_bypass_flag_audit_event(
     assert record.bypass_flags == ["--dangerous"]
     assert record.security_boundary == "container_isolation"
     assert record.node_name == "test-node"
+
+
+@pytest.mark.asyncio
+async def test_run_treats_non_string_workspace_id_as_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """workspace_id that is not a non-empty string must be normalised to None (line 127)."""
+    import orcheo.nodes.ai.external.base as base_module
+    from orcheo.external_agents.models import ProcessExecutionResult
+
+    captured_workspace_ids: list[Any] = []
+
+    async def _fake_run_process(
+        command: list[str],
+        *,
+        workspace_id: str | None = None,
+        cwd: Any = None,
+        env: Any = None,
+        timeout_seconds: Any = None,
+    ) -> ProcessExecutionResult:
+        captured_workspace_ids.append(workspace_id)
+        return ProcessExecutionResult(
+            command=command,
+            stdout="",
+            stderr="",
+            exit_code=0,
+            timed_out=False,
+            duration_seconds=0.0,
+        )
+
+    monkeypatch.setattr(base_module, "run_external_agent_process", _fake_run_process)
+
+    resolution = _make_runtime_resolution(tmp_path)
+    manager = FakeRuntimeManager(provider=DummyProvider(), resolution=resolution)
+    node = _make_node(manager)
+
+    # Put a non-string value into workspace_id to trigger the normalisation branch.
+    state = _make_state({"prompt": "run"})
+    state["workspace_id"] = 12345  # type: ignore[typeddict-item]
+
+    result = await node.run(state, RunnableConfig())
+
+    assert result["status"] == "succeeded"
+    # The manager should have received None, not the integer.
+    assert manager.workspace_id is None
+    assert captured_workspace_ids == [None]
+
+
+@pytest.mark.asyncio
+async def test_run_treats_blank_workspace_id_as_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A whitespace-only workspace_id must also be normalised to None (line 127)."""
+    import orcheo.nodes.ai.external.base as base_module
+    from orcheo.external_agents.models import ProcessExecutionResult
+
+    captured_workspace_ids: list[Any] = []
+
+    async def _fake_run_process(
+        command: list[str],
+        *,
+        workspace_id: str | None = None,
+        cwd: Any = None,
+        env: Any = None,
+        timeout_seconds: Any = None,
+    ) -> ProcessExecutionResult:
+        captured_workspace_ids.append(workspace_id)
+        return ProcessExecutionResult(
+            command=command,
+            stdout="",
+            stderr="",
+            exit_code=0,
+            timed_out=False,
+            duration_seconds=0.0,
+        )
+
+    monkeypatch.setattr(base_module, "run_external_agent_process", _fake_run_process)
+
+    resolution = _make_runtime_resolution(tmp_path)
+    manager = FakeRuntimeManager(provider=DummyProvider(), resolution=resolution)
+    node = _make_node(manager)
+
+    state = _make_state({"prompt": "run"})
+    state["workspace_id"] = "   "
+
+    result = await node.run(state, RunnableConfig())
+
+    assert result["status"] == "succeeded"
+    assert manager.workspace_id is None
+    assert captured_workspace_ids == [None]

--- a/tests/nodes/test_external_agent_nodes.py
+++ b/tests/nodes/test_external_agent_nodes.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 import subprocess
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 import pytest
+from orcheo.external_agents.models import ProcessExecutionResult
+from orcheo.external_agents.process import execute_process
 from orcheo.external_agents.runtime import ExternalAgentRuntimeManager
 from orcheo.graph.state import State
 from orcheo.nodes.claude_code import ClaudeCodeNode
@@ -17,8 +20,53 @@ from orcheo.nodes.ai.external.codex import CodexNode as ExternalCodexNode
 from orcheo.nodes.ai.external.gemini import GeminiNode as ExternalGeminiNode
 from orcheo.nodes.registry import registry
 from orcheo.runtime.credentials import CredentialReferenceNotFoundError
+from orcheo.sandbox.dispatch import use_launcher
 from orcheo.tracing.model_metadata import TRACE_METADATA_KEY
 from tests.external_agents.test_runtime import FakeProvider
+
+
+class _HostBypassLauncher:
+    """Test launcher that runs the command on the host via ``execute_process``.
+
+    The agent CLI under test is itself a fake shell script — there's no
+    real sandbox to launch into. This launcher satisfies the dispatcher
+    contract while still letting the test exercise the actual process
+    behavior (stdout, exit code, timeout) of the fake binary.
+    """
+
+    async def run(
+        self,
+        *,
+        workspace_id: str,
+        command: list[str],
+        cwd: Any,
+        env: Mapping[str, str] | None,
+        timeout_seconds: float | int | None,
+    ) -> ProcessExecutionResult:
+        del workspace_id
+        return await execute_process(
+            command,
+            cwd=cwd,
+            env=env,
+            timeout_seconds=timeout_seconds,
+        )
+
+
+@pytest.fixture(autouse=True)
+def _bind_host_launcher(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Any:
+    """Bind a host-exec launcher so every test in this file can run the fake CLI.
+
+    The workspace_id we set on State activates a check that the working
+    directory must live under ``DEFAULT_WORKSPACE_AGENT_ROOT`` (``/workspace/
+    agents`` in production). For unit tests we relax that root to ``tmp_path``
+    so the fake CLI can run in pytest's tmp directory.
+    """
+    monkeypatch.setattr(
+        "orcheo.external_agents.paths.DEFAULT_WORKSPACE_AGENT_ROOT",
+        tmp_path,
+    )
+    with use_launcher(_HostBypassLauncher()):  # type: ignore[arg-type]
+        yield
 
 
 class FakeCodexRuntimeManager(ExternalAgentRuntimeManager):
@@ -84,12 +132,12 @@ async def test_codex_node_successfully_installs_and_runs(
     )
 
     result = await node(
-        State({"inputs": {}, "results": {}, "messages": []}),
+        State({"inputs": {}, "results": {}, "messages": [], "workspace_id": "ws-test"}),
         {},
     )
 
     payload = result["results"]["codex_fix"]
-    assert payload["status"] == "succeeded"
+    assert payload["status"] == "succeeded", payload
     assert payload["provider"] == "codex"
     assert payload["resolved_version"] == "1.0.0"
     assert payload["stdout"] == "fix tests\n"
@@ -121,7 +169,7 @@ async def test_claude_node_returns_setup_needed_when_auth_missing(
     )
 
     result = await node(
-        State({"inputs": {}, "results": {}, "messages": []}),
+        State({"inputs": {}, "results": {}, "messages": [], "workspace_id": "ws-test"}),
         {},
     )
 
@@ -150,7 +198,7 @@ async def test_gemini_node_successfully_installs_and_runs(
     )
 
     result = await node(
-        State({"inputs": {}, "results": {}, "messages": []}),
+        State({"inputs": {}, "results": {}, "messages": [], "workspace_id": "ws-test"}),
         {},
     )
 
@@ -180,7 +228,7 @@ async def test_codex_node_normalizes_timeout_failures(
     )
 
     result = await node(
-        State({"inputs": {}, "results": {}, "messages": []}),
+        State({"inputs": {}, "results": {}, "messages": [], "workspace_id": "ws-test"}),
         {},
     )
 

--- a/tests/sandbox/test_config.py
+++ b/tests/sandbox/test_config.py
@@ -1,0 +1,72 @@
+"""Tests for ``SandboxSettings`` env-var loading."""
+
+from __future__ import annotations
+import pytest
+from orcheo.sandbox.config import SandboxSettings
+
+
+def test_defaults_preserve_secure_runsc_choice() -> None:
+    """The in-process default must keep the gVisor runtime so production is
+    secure even if the operator forgets to set the env var."""
+    assert SandboxSettings().container_runtime == "runsc"
+    assert (
+        SandboxSettings().credential_broker_url
+        == "http://sandbox-runtime:9090/credentials/resolve"
+    )
+
+
+def test_from_mapping_overrides_each_documented_field() -> None:
+    """All documented ORCHEO_* variables must influence the built settings."""
+    source = {
+        "ORCHEO_CONTAINER_RUNTIME": "runc",
+        "ORCHEO_SANDBOX_IMAGE": "registry.local/orcheo/sandbox:test",
+        "ORCHEO_SANDBOX_DEFAULT_CPU_LIMIT": "2.0",
+        "ORCHEO_SANDBOX_DEFAULT_MEMORY_LIMIT": "1g",
+        "ORCHEO_SANDBOX_DEFAULT_PID_LIMIT": "512",
+        "ORCHEO_SANDBOX_DEFAULT_SCRATCH_DISK_LIMIT": "2g",
+        "ORCHEO_SANDBOX_DEFAULT_IDLE_TTL_SECONDS": "120",
+        "ORCHEO_SANDBOX_DEFAULT_POOL_MIN": "1",
+        "ORCHEO_SANDBOX_DEFAULT_POOL_MAX": "8",
+        "ORCHEO_EGRESS_PROXY_URL": "http://envoy:3128",
+        "ORCHEO_CREDENTIAL_BROKER_URL": "http://backend.local/internal/creds",
+        "ORCHEO_SANDBOX_AUDIT_LOGGER_NAME": "custom.audit",
+    }
+
+    settings = SandboxSettings.from_mapping(source)
+
+    assert settings.container_runtime == "runc"
+    assert settings.image == "registry.local/orcheo/sandbox:test"
+    assert settings.default_cpu_limit == "2.0"
+    assert settings.default_memory_limit == "1g"
+    assert settings.default_pid_limit == 512
+    assert settings.default_scratch_disk_limit == "2g"
+    assert settings.default_idle_ttl_seconds == 120
+    assert settings.default_pool_min == 1
+    assert settings.default_pool_max == 8
+    assert settings.egress_proxy_url == "http://envoy:3128"
+    assert settings.credential_broker_url == "http://backend.local/internal/creds"
+    assert settings.audit_logger_name == "custom.audit"
+
+
+def test_from_mapping_ignores_blank_and_missing_values() -> None:
+    """Empty / whitespace overrides fall back to the secure defaults."""
+    source = {
+        "ORCHEO_CONTAINER_RUNTIME": "   ",  # whitespace → ignored
+        # ORCHEO_SANDBOX_IMAGE deliberately omitted
+    }
+
+    settings = SandboxSettings.from_mapping(source)
+
+    assert settings.container_runtime == "runsc"
+    assert settings.image.startswith("orcheo/workspace-sandbox")
+
+
+def test_from_env_reads_process_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``from_env()`` is the production hook into ``os.environ``."""
+    monkeypatch.setenv("ORCHEO_CONTAINER_RUNTIME", "runc")
+    monkeypatch.setenv("ORCHEO_SANDBOX_DEFAULT_POOL_MAX", "12")
+
+    settings = SandboxSettings.from_env()
+
+    assert settings.container_runtime == "runc"
+    assert settings.default_pool_max == 12

--- a/tests/sandbox/test_dispatch_and_launcher.py
+++ b/tests/sandbox/test_dispatch_and_launcher.py
@@ -110,3 +110,56 @@ def test_dispatcher_missing_workspace_id_raises() -> None:
     with pytest.raises(SandboxDispatchError, match="workspace_id is required"):
         asyncio.run(go())
     assert runtime.started == []
+
+
+# ---------------------------------------------------------------------------
+# LocalProcessLauncher tests (lines 128-129)
+# ---------------------------------------------------------------------------
+
+
+def test_local_process_launcher_runs_command_in_process_tree() -> None:
+    """LocalProcessLauncher.run() executes the command via execute_process (lines 128-129)."""
+    from orcheo.sandbox.launcher import LocalProcessLauncher
+
+    results: list[ProcessExecutionResult] = []
+
+    async def _fake_execute(
+        command: list[str],
+        *,
+        cwd: object = None,
+        env: object = None,
+        timeout_seconds: object = None,
+    ) -> ProcessExecutionResult:
+        result = ProcessExecutionResult(
+            command=command,
+            stdout="hello",
+            stderr="",
+            exit_code=0,
+            timed_out=False,
+            duration_seconds=0.0,
+        )
+        results.append(result)
+        return result
+
+    async def go() -> ProcessExecutionResult:
+        import orcheo.sandbox.launcher as launcher_module
+
+        original = launcher_module.execute_process
+        launcher_module.execute_process = _fake_execute  # type: ignore[assignment]
+        try:
+            launcher = LocalProcessLauncher()
+            return await launcher.run(
+                workspace_id="ws-ignored",
+                command=["echo", "hello"],
+                cwd=None,
+                env={"FOO": "bar"},
+                timeout_seconds=5.0,
+            )
+        finally:
+            launcher_module.execute_process = original
+
+    result = asyncio.run(go())
+    assert result.stdout == "hello"
+    assert result.exit_code == 0
+    assert len(results) == 1
+    assert results[0].command == ["echo", "hello"]

--- a/tests/sandbox/test_dispatch_and_launcher.py
+++ b/tests/sandbox/test_dispatch_and_launcher.py
@@ -7,11 +7,12 @@ from pathlib import Path
 import pytest
 from orcheo.external_agents.models import ProcessExecutionResult
 from orcheo.sandbox.dispatch import (
+    SandboxDispatchError,
     get_active_launcher,
     run_external_agent_process,
     use_launcher,
 )
-from orcheo.sandbox.launcher import HostFallbackExec, SandboxedProcessLauncher
+from orcheo.sandbox.launcher import SandboxedProcessLauncher
 from orcheo.sandbox.manager import SandboxRuntimeManager
 from orcheo.sandbox.runtime import InMemoryContainerRuntime
 
@@ -43,40 +44,18 @@ class _FakeExec:
         )
 
 
-def test_no_launcher_active_falls_through(monkeypatch: pytest.MonkeyPatch) -> None:
-    """With no launcher bound, run_external_agent_process calls execute_process."""
-
-    async def fake_execute(
-        command: list[str],
-        *,
-        cwd: Path | None,
-        env: Mapping[str, str] | None,
-        timeout_seconds: float | int | None,
-    ) -> ProcessExecutionResult:
-        del cwd, env, timeout_seconds
-        return ProcessExecutionResult(
-            command=command,
-            stdout="legacy",
-            stderr="",
-            exit_code=0,
-            timed_out=False,
-            duration_seconds=0.0,
+def test_no_launcher_active_raises() -> None:
+    """Without an active launcher, dispatch fails closed — no host fallback."""
+    with pytest.raises(SandboxDispatchError, match="No sandbox launcher"):
+        asyncio.run(
+            run_external_agent_process(
+                ["echo", "hi"],
+                workspace_id="ws",
+                cwd=None,
+                env=None,
+                timeout_seconds=None,
+            )
         )
-
-    monkeypatch.setattr(
-        "orcheo.sandbox.dispatch.execute_process",
-        fake_execute,
-    )
-    result = asyncio.run(
-        run_external_agent_process(
-            ["echo", "hi"],
-            workspace_id="ws",
-            cwd=None,
-            env=None,
-            timeout_seconds=None,
-        )
-    )
-    assert result.stdout == "legacy"
 
 
 def test_active_launcher_routes_through_sandbox() -> None:
@@ -112,32 +91,11 @@ def test_active_launcher_routes_through_sandbox() -> None:
     assert get_active_launcher() is None
 
 
-def test_dispatcher_falls_back_when_workspace_id_missing(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Without a workspace_id we cannot scope a sandbox — fall through."""
+def test_dispatcher_missing_workspace_id_raises() -> None:
+    """Without a workspace_id, dispatch fails closed — no host fallback."""
     runtime = InMemoryContainerRuntime()
     manager = SandboxRuntimeManager(runtime=runtime)
     launcher = SandboxedProcessLauncher(manager=manager, exec_backend=_FakeExec())
-
-    async def fake_execute(
-        command: list[str],
-        *,
-        cwd: Path | None,
-        env: Mapping[str, str] | None,
-        timeout_seconds: float | int | None,
-    ) -> ProcessExecutionResult:
-        del cwd, env, timeout_seconds
-        return ProcessExecutionResult(
-            command=command,
-            stdout="fallback",
-            stderr="",
-            exit_code=0,
-            timed_out=False,
-            duration_seconds=0.0,
-        )
-
-    monkeypatch.setattr("orcheo.sandbox.dispatch.execute_process", fake_execute)
 
     async def go() -> ProcessExecutionResult:
         with use_launcher(launcher):
@@ -149,46 +107,6 @@ def test_dispatcher_falls_back_when_workspace_id_missing(
                 timeout_seconds=None,
             )
 
-    result = asyncio.run(go())
-    # No sandbox container was started.
+    with pytest.raises(SandboxDispatchError, match="workspace_id is required"):
+        asyncio.run(go())
     assert runtime.started == []
-    assert result.stdout == "fallback"
-
-
-def test_host_fallback_exec_uses_real_execute_process(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """HostFallbackExec proxies straight to execute_process."""
-
-    async def fake_execute(
-        command: list[str],
-        *,
-        cwd: Path | None,
-        env: Mapping[str, str] | None,
-        timeout_seconds: float | int | None,
-    ) -> ProcessExecutionResult:
-        del cwd, env, timeout_seconds
-        return ProcessExecutionResult(
-            command=command,
-            stdout="x",
-            stderr="",
-            exit_code=0,
-            timed_out=False,
-            duration_seconds=0.0,
-        )
-
-    monkeypatch.setattr(
-        "orcheo.sandbox.launcher.execute_process",
-        fake_execute,
-    )
-    backend = HostFallbackExec()
-    result = asyncio.run(
-        backend.exec(
-            "sb-1",
-            ["true"],
-            cwd=None,
-            env=None,
-            timeout_seconds=None,
-        )
-    )
-    assert result.exit_code == 0

--- a/tests/sandbox/test_manager.py
+++ b/tests/sandbox/test_manager.py
@@ -38,6 +38,12 @@ def test_acquire_provisions_and_marks_in_use() -> None:
     assert lease.workspace_id == "ws"
     assert len(runtime.started) == 1
     assert runtime.started[0][1].labels["orcheo.workspace_id"] == "ws"
+    assert runtime.started[0][1].environment == {
+        "ORCHEO_CREDENTIAL_BROKER_URL": (
+            "http://sandbox-runtime:9090/credentials/resolve"
+        ),
+        "ORCHEO_AGENT_RUNTIME_ROOT": "/scratch/agent-runtimes",
+    }
 
 
 def test_release_returns_lease_to_pool_then_reuses() -> None:

--- a/tests/sandbox/test_runtime.py
+++ b/tests/sandbox/test_runtime.py
@@ -151,7 +151,7 @@ def test_docker_runtime_start_raises_actionable_error_when_image_missing() -> No
         runtime.start(spec)
     message = str(excinfo.value)
     assert "make docker-build" in message
-    assert "build-only" in message
+    assert "docker compose build workspace-sandbox" in message
     # The container.run call must not have fired — we fail fast before the
     # implicit registry pull.
     assert client.containers.runs == []

--- a/tests/sandbox/test_runtime.py
+++ b/tests/sandbox/test_runtime.py
@@ -66,11 +66,41 @@ class _FakeContainers:
         return self._containers[container_id]
 
 
+class _FakeImage:
+    """Stand-in for a docker SDK ``Image``."""
+
+    def __init__(self, tag: str) -> None:
+        self.tags = [tag]
+
+
+class _FakeImages:
+    """Stand-in for ``client.images``.
+
+    Pretends every requested image is locally available unless the test
+    explicitly removes it via :meth:`forget`.
+    """
+
+    def __init__(self) -> None:
+        self._missing: set[str] = set()
+
+    def get(self, image: str) -> _FakeImage:
+        """Return a fake image or raise to mimic the SDK's ``ImageNotFound``."""
+        if image in self._missing:
+            msg = f"404 Client Error for image: No such image: {image}"
+            raise RuntimeError(msg)
+        return _FakeImage(image)
+
+    def forget(self, image: str) -> None:
+        """Mark ``image`` as missing for the next ``get`` call."""
+        self._missing.add(image)
+
+
 class _FakeClient:
     """Stand-in for ``docker.DockerClient``."""
 
     def __init__(self) -> None:
         self.containers = _FakeContainers()
+        self.images = _FakeImages()
 
 
 def test_docker_runtime_start_passes_through_security_flags() -> None:
@@ -99,7 +129,32 @@ def test_docker_runtime_start_passes_through_security_flags() -> None:
     assert call["network_mode"] == "sandbox-egress"
     assert call["pids_limit"] == 128
     assert call["cpu_quota"] == 150_000
-    assert call["tmpfs"] == {"/scratch": "size=500m,mode=1777"}
+    assert call["tmpfs"] == {
+        "/scratch": "size=500m,mode=1777,exec",
+        "/workspace": "size=500m,mode=1777,exec",
+        "/home/orcheo": "size=500m,mode=1777,exec",
+    }
+
+
+def test_docker_runtime_start_raises_actionable_error_when_image_missing() -> None:
+    """start() must point operators at ``make docker-build`` when the image
+    isn't on the daemon, instead of letting the docker SDK silently attempt a
+    registry pull and surface ``pull access denied``."""
+    client = _FakeClient()
+    client.images.forget("orcheo/workspace-sandbox:latest")
+    runtime = DockerContainerRuntime(client=client)
+    spec = ContainerSpec(
+        image="orcheo/workspace-sandbox:latest",
+        workspace_id="W",
+    )
+    with pytest.raises(RuntimeError) as excinfo:
+        runtime.start(spec)
+    message = str(excinfo.value)
+    assert "make docker-build" in message
+    assert "build-only" in message
+    # The container.run call must not have fired — we fail fast before the
+    # implicit registry pull.
+    assert client.containers.runs == []
 
 
 def test_docker_runtime_stop_kills_and_removes_container() -> None:
@@ -185,3 +240,78 @@ def test_docker_runtime_no_new_privileges_false_omits_security_opt() -> None:
     call = client.containers.runs[0]
     assert handle is not None
     assert call["security_opt"] == []
+
+
+class _UnknownRuntimeContainers(_FakeContainers):
+    """Containers facade that mimics Docker's 'unknown runtime' 400 error."""
+
+    def run(self, **kwargs: object) -> _FakeContainer:  # type: ignore[override]
+        raise RuntimeError(
+            "docker.errors.APIError: 400 Client Error: "
+            "unknown or invalid runtime name: runsc"
+        )
+
+
+class _ClientWithRuntimes(_FakeClient):
+    """Fake client that also exposes ``info()`` so the helper can probe runtimes."""
+
+    def __init__(self, available: list[str] | None = None) -> None:
+        super().__init__()
+        self.containers = _UnknownRuntimeContainers()
+        self._available = available or ["runc", "io.containerd.runc.v2"]
+
+    def info(self) -> dict[str, object]:
+        return {"Runtimes": {name: {"path": name} for name in self._available}}
+
+
+def test_docker_runtime_translates_unknown_runtime_error() -> None:
+    """An 'unknown runtime' Docker error is rewritten with available runtimes
+    and a hint pointing at ORCHEO_CONTAINER_RUNTIME."""
+    import pytest
+
+    client = _ClientWithRuntimes(available=["runc"])
+    runtime = DockerContainerRuntime(client=client)
+    spec = ContainerSpec(image="img", workspace_id="W", runtime="runsc")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        runtime.start(spec)
+
+    message = str(excinfo.value)
+    assert "'runsc'" in message
+    assert "runc" in message  # lists available runtimes
+    assert "ORCHEO_CONTAINER_RUNTIME" in message
+
+
+def test_docker_runtime_other_errors_are_left_untouched() -> None:
+    """Non-runtime errors are propagated unchanged so debugging is unaffected."""
+    import pytest
+
+    class _BoomContainers(_FakeContainers):
+        def run(self, **kwargs: object) -> _FakeContainer:  # type: ignore[override]
+            raise RuntimeError("some unrelated docker failure")
+
+    client = _FakeClient()
+    client.containers = _BoomContainers()
+    runtime = DockerContainerRuntime(client=client)
+
+    with pytest.raises(RuntimeError, match="some unrelated docker failure"):
+        runtime.start(ContainerSpec(image="img", workspace_id="W"))
+
+
+def test_docker_runtime_translates_runtime_error_without_info() -> None:
+    """If ``client.info()`` itself fails the helper still surfaces a clean message."""
+    import pytest
+
+    class _NoInfoClient(_ClientWithRuntimes):
+        def info(self) -> dict[str, object]:  # type: ignore[override]
+            raise RuntimeError("info unavailable")
+
+    runtime = DockerContainerRuntime(client=_NoInfoClient())
+    spec = ContainerSpec(image="img", workspace_id="W", runtime="runsc")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        runtime.start(spec)
+
+    message = str(excinfo.value)
+    assert "'runsc'" in message
+    assert "ORCHEO_CONTAINER_RUNTIME" in message

--- a/tests/sandbox/test_runtime.py
+++ b/tests/sandbox/test_runtime.py
@@ -133,6 +133,7 @@ def test_docker_runtime_start_passes_through_security_flags() -> None:
         "/scratch": "size=500m,mode=1777,exec",
         "/workspace": "size=500m,mode=1777,exec",
         "/home/orcheo": "size=500m,mode=1777,exec",
+        "/tmp": "size=500m,mode=1777,exec",
     }
 
 

--- a/tests/sandbox/test_runtime.py
+++ b/tests/sandbox/test_runtime.py
@@ -316,3 +316,72 @@ def test_docker_runtime_translates_runtime_error_without_info() -> None:
     message = str(excinfo.value)
     assert "'runsc'" in message
     assert "ORCHEO_CONTAINER_RUNTIME" in message
+
+
+def test_require_local_image_passes_through_non_notfound_errors() -> None:
+    """_require_local_image returns (does not raise) for non-'not found' image errors (line 192)."""
+
+    class _FakeImages:
+        def get(self, image: str) -> object:
+            # A non-"not found" error (e.g. daemon connectivity issue).
+            raise RuntimeError("connection refused to docker daemon")
+
+    class _FakeClientConnErr:
+        def __init__(self) -> None:
+            self.images = _FakeImages()
+
+    # The method should return (not raise) for non-missing-image errors.
+    DockerContainerRuntime._require_local_image(
+        _FakeClientConnErr(), "orcheo/workspace-sandbox:latest"
+    )
+    # If we reach here without an exception the branch is covered.
+
+
+def test_docker_runtime_stop_remove_called_even_if_kill_raises() -> None:
+    """stop() calls remove in the finally block even when kill() raises (branch 221->225)."""
+
+    class _KillBoomContainer(_FakeContainer):
+        def kill(self) -> None:
+            raise RuntimeError("kill blocked by OOM killer")
+
+    class _KillBoomContainers(_FakeContainers):
+        def run(self, **kwargs: object) -> _KillBoomContainer:
+            container_id = f"c{len(self.runs)}"
+            container = _KillBoomContainer(container_id)
+            self._containers[container_id] = container
+            self.runs.append({"id": container_id, **kwargs})
+            return container
+
+    client = _FakeClient()
+    client.containers = _KillBoomContainers()
+    runtime = DockerContainerRuntime(client=client)
+    handle = runtime.start(ContainerSpec(image="img", workspace_id="W"))
+    container = client.containers.get(handle.container_id)
+
+    with pytest.raises(RuntimeError, match="kill blocked"):
+        runtime.stop(handle)
+
+    # remove must have been called in the finally block despite kill raising.
+    assert container.removed is True
+
+
+def test_docker_runtime_translates_runtime_error_with_empty_runtimes_info() -> None:
+    """Branch 221->225: when info() Runtimes is not a dict, available stays empty."""
+    import pytest
+
+    class _NoRuntimesClient(_ClientWithRuntimes):
+        def info(self) -> dict[str, object]:
+            # info() returns a dict without 'Runtimes', so runtimes is None.
+            return {}
+
+    runtime = DockerContainerRuntime(client=_NoRuntimesClient())
+    spec = ContainerSpec(image="img", workspace_id="W", runtime="runsc")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        runtime.start(spec)
+
+    message = str(excinfo.value)
+    assert "'runsc'" in message
+    assert "ORCHEO_CONTAINER_RUNTIME" in message
+    # No available runtimes listed since info had none.
+    assert "Available runtimes" not in message

--- a/tests/sandbox/test_service_and_remote.py
+++ b/tests/sandbox/test_service_and_remote.py
@@ -8,6 +8,7 @@ from typing import Any
 import httpx
 import pytest
 from fastapi.testclient import TestClient
+from orcheo.sandbox import service as service_module
 from orcheo.external_agents.models import ProcessExecutionResult
 from orcheo.sandbox.remote import (
     RemoteContainerRuntime,
@@ -89,6 +90,63 @@ def test_healthz(app_with_fakes: tuple[TestClient, Any, Any, Any]) -> None:
     assert client.get("/healthz").json() == {"status": "ok"}
 
 
+def test_credential_relay_forwards_broker_request(
+    app_with_fakes: tuple[TestClient, Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sandbox credential requests cross the runtime relay unchanged."""
+    client, *_ = app_with_fakes
+    calls: list[tuple[str, dict[str, Any], dict[str, str]]] = []
+
+    class _FakeAsyncClient:
+        def __init__(self, *, timeout: float) -> None:
+            assert timeout == 30.0
+
+        async def __aenter__(self) -> _FakeAsyncClient:
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+        async def post(
+            self,
+            url: str,
+            *,
+            json: dict[str, Any],
+            headers: dict[str, str],
+        ) -> httpx.Response:
+            calls.append((url, json, headers))
+            return httpx.Response(200, json={"value": "resolved"})
+
+    monkeypatch.setenv(
+        "ORCHEO_CREDENTIAL_BROKER_URL",
+        "http://backend/internal/credentials/resolve",
+    )
+    monkeypatch.setattr(service_module.httpx, "AsyncClient", _FakeAsyncClient)
+
+    response = client.post(
+        "/credentials/resolve",
+        json={"run_id": "run-1", "credential_name": "openai_api_key"},
+        headers={
+            "Authorization": "Bearer broker-token",
+            "X-Orcheo-Workspace": "ws-1",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"value": "resolved"}
+    assert calls == [
+        (
+            "http://backend/internal/credentials/resolve",
+            {"run_id": "run-1", "credential_name": "openai_api_key"},
+            {
+                "Authorization": "Bearer broker-token",
+                "X-Orcheo-Workspace": "ws-1",
+            },
+        )
+    ]
+
+
 def test_provision_stop_lifecycle(
     app_with_fakes: tuple[TestClient, InMemoryContainerRuntime, Any, Any],
 ) -> None:
@@ -159,6 +217,8 @@ def test_dispatch_workflow_endpoint(
             "workflow_definition": {"nodes": []},
             "inputs": {"a": 1},
             "node_types": ["AINode"],
+            "runnable_config": {"configurable": {"thread_id": "r-1"}},
+            "state_config": {"configurable": {"ai_model": "openai:test"}},
         },
         "broker_token": "tok-1",
     }
@@ -171,6 +231,8 @@ def test_dispatch_workflow_endpoint(
     assert sandbox_id == "sb-1"
     assert spec.workspace_id == "ws"
     assert spec.node_types == ("AINode",)
+    assert spec.runnable_config == {"configurable": {"thread_id": "r-1"}}
+    assert spec.state_config == {"configurable": {"ai_model": "openai:test"}}
     assert broker_token == "tok-1"
 
 
@@ -259,6 +321,8 @@ def test_remote_runner_dispatches_workflow(
         workflow_definition={"nodes": [{"type": "AINode"}]},
         inputs={},
         node_types=("AINode",),
+        runnable_config={"configurable": {"thread_id": "r-2"}},
+        state_config={"configurable": {"ai_model": "openai:test"}},
     )
 
     async def go() -> WorkflowRunResult:
@@ -278,6 +342,10 @@ def test_remote_runner_dispatches_workflow(
     result = asyncio.run(go())
     assert result.status == "succeeded"
     assert result.outputs == {"hello": "world"}
+    assert invoker.calls[0][1].runnable_config == {"configurable": {"thread_id": "r-2"}}
+    assert invoker.calls[0][1].state_config == {
+        "configurable": {"ai_model": "openai:test"}
+    }
     assert invoker.calls[0][2] == "broker-token"
 
 

--- a/tests/sandbox/test_service_and_remote.py
+++ b/tests/sandbox/test_service_and_remote.py
@@ -172,8 +172,29 @@ def test_provision_stop_lifecycle(
     assert stop.status_code == 204
     assert runtime.stopped, "runtime.stop was not invoked"
 
-    # Stopping again is a 404 because the handle is gone.
+    # Stopping again is a 404 because the container is no longer running.
     assert client.delete(f"/containers/{container_id}").status_code == 404
+
+
+def test_stop_works_without_cached_handle(
+    app_with_fakes: tuple[TestClient, InMemoryContainerRuntime, _FakeExecutor, _FakeInvoker],
+) -> None:
+    """DELETE /containers/{id} still stops a running container after restart."""
+    client, runtime, executor, invoker = app_with_fakes
+    spec = ContainerSpec(image="img", workspace_id="ws")
+    provision = client.post("/containers", json=_spec_payload(spec))
+    container_id = provision.json()["container_id"]
+
+    # Simulate runtime-service restart by rebuilding the app with the same runtime.
+    running_handle, _ = runtime.started[0]
+    assert runtime.is_running(running_handle) is True
+    restarted_client = TestClient(
+        build_service_app(runtime=runtime, executor=executor, invoker=invoker)
+    )
+
+    stop = restarted_client.delete(f"/containers/{container_id}")
+    assert stop.status_code == 204
+    assert runtime.is_running(running_handle) is False
 
 
 def test_exec_endpoint_calls_executor(

--- a/tests/sandbox/test_service_and_remote.py
+++ b/tests/sandbox/test_service_and_remote.py
@@ -1,0 +1,302 @@
+"""Tests for the sandbox-runtime HTTP service and its remote clients."""
+
+from __future__ import annotations
+import asyncio
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+from orcheo.external_agents.models import ProcessExecutionResult
+from orcheo.sandbox.remote import (
+    RemoteContainerRuntime,
+    RemoteSandboxExec,
+    RemoteSandboxRunner,
+)
+from orcheo.sandbox.runtime import ContainerSpec, InMemoryContainerRuntime
+from orcheo.sandbox.service import (
+    ContainerExecutor,
+    ExecRequest,
+    WorkflowSandboxInvoker,
+    build_service_app,
+)
+from orcheo.sandbox.workflow import WorkflowRunResult, WorkflowRunSpec
+
+
+class _FakeExecutor(ContainerExecutor):
+    """Test double that records exec calls and returns a canned result."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, ExecRequest]] = []
+        self.result = ProcessExecutionResult(
+            command=["echo", "ok"],
+            stdout="ok",
+            stderr="",
+            exit_code=0,
+            timed_out=False,
+            duration_seconds=0.01,
+        )
+
+    async def exec(
+        self, sandbox_id: str, request: ExecRequest
+    ) -> ProcessExecutionResult:
+        self.calls.append((sandbox_id, request))
+        return self.result
+
+
+class _FakeInvoker(WorkflowSandboxInvoker):
+    """Test double that records invocations and returns a canned result."""
+
+    def __init__(self) -> None:
+        # Skip parent __init__ (no executor needed).
+        self.calls: list[tuple[str, WorkflowRunSpec, str]] = []
+        self.result = WorkflowRunResult(
+            run_id="r1",
+            status="succeeded",
+            outputs={"hello": "world"},
+            error=None,
+        )
+
+    async def invoke(
+        self,
+        sandbox_id: str,
+        spec: WorkflowRunSpec,
+        broker_token: str,
+        *,
+        timeout_seconds: float | None = None,
+    ) -> WorkflowRunResult:
+        del timeout_seconds
+        self.calls.append((sandbox_id, spec, broker_token))
+        return self.result
+
+
+@pytest.fixture
+def app_with_fakes() -> tuple[
+    TestClient, InMemoryContainerRuntime, _FakeExecutor, _FakeInvoker
+]:
+    """Build the FastAPI app with in-memory runtime and fake executor / invoker."""
+    runtime = InMemoryContainerRuntime()
+    executor = _FakeExecutor()
+    invoker = _FakeInvoker()
+    app = build_service_app(runtime=runtime, executor=executor, invoker=invoker)
+    return TestClient(app), runtime, executor, invoker
+
+
+def test_healthz(app_with_fakes: tuple[TestClient, Any, Any, Any]) -> None:
+    """The service exposes a /healthz endpoint."""
+    client, *_ = app_with_fakes
+    assert client.get("/healthz").json() == {"status": "ok"}
+
+
+def test_provision_stop_lifecycle(
+    app_with_fakes: tuple[TestClient, InMemoryContainerRuntime, Any, Any],
+) -> None:
+    """POST /containers + DELETE round-trips through the underlying runtime."""
+    client, runtime, _executor, _invoker = app_with_fakes
+    spec = ContainerSpec(
+        image="img",
+        workspace_id="ws",
+        runtime="runsc",
+        command=("agent",),
+        environment={"K": "V"},
+    )
+    response = client.post("/containers", json=_spec_payload(spec))
+    assert response.status_code == 201, response.text
+    container_id = response.json()["container_id"]
+    assert runtime.started, "runtime.start was not invoked"
+
+    inspect = client.get(f"/containers/{container_id}")
+    assert inspect.status_code == 200
+    assert inspect.json()["running"] is True
+
+    stop = client.delete(f"/containers/{container_id}")
+    assert stop.status_code == 204
+    assert runtime.stopped, "runtime.stop was not invoked"
+
+    # Stopping again is a 404 because the handle is gone.
+    assert client.delete(f"/containers/{container_id}").status_code == 404
+
+
+def test_exec_endpoint_calls_executor(
+    app_with_fakes: tuple[TestClient, Any, _FakeExecutor, Any],
+) -> None:
+    """POST /sandboxes/{id}/exec routes through ContainerExecutor.exec."""
+    client, _runtime, executor, _invoker = app_with_fakes
+    response = client.post(
+        "/sandboxes/sb-1/exec",
+        json={
+            "command": ["echo", "hello"],
+            "cwd": "/scratch",
+            "env": {"FOO": "bar"},
+            "timeout_seconds": 5.0,
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["exit_code"] == 0
+    assert executor.calls == [
+        (
+            "sb-1",
+            ExecRequest(
+                command=["echo", "hello"],
+                cwd="/scratch",
+                env={"FOO": "bar"},
+                timeout_seconds=5.0,
+            ),
+        )
+    ]
+
+
+def test_dispatch_workflow_endpoint(
+    app_with_fakes: tuple[TestClient, Any, Any, _FakeInvoker],
+) -> None:
+    """POST /sandboxes/{id}/dispatch_workflow goes through the invoker."""
+    client, _runtime, _executor, invoker = app_with_fakes
+    payload = {
+        "spec": {
+            "run_id": "r-1",
+            "workspace_id": "ws",
+            "workflow_definition": {"nodes": []},
+            "inputs": {"a": 1},
+            "node_types": ["AINode"],
+        },
+        "broker_token": "tok-1",
+    }
+    response = client.post("/sandboxes/sb-1/dispatch_workflow", json=payload)
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["status"] == "succeeded"
+    assert data["outputs"] == {"hello": "world"}
+    sandbox_id, spec, broker_token = invoker.calls[0]
+    assert sandbox_id == "sb-1"
+    assert spec.workspace_id == "ws"
+    assert spec.node_types == ("AINode",)
+    assert broker_token == "tok-1"
+
+
+def test_remote_container_runtime_round_trip() -> None:
+    """RemoteContainerRuntime parses runtime-service responses correctly."""
+    state: dict[str, Any] = {"running": True}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path == "/containers":
+            return httpx.Response(
+                201,
+                json={
+                    "container_id": "c-1",
+                    "image": "img",
+                    "workspace_id": "ws-remote",
+                    "runtime": "runsc",
+                },
+            )
+        if request.method == "GET" and request.url.path == "/containers/c-1":
+            return httpx.Response(
+                200,
+                json={
+                    "container_id": "c-1",
+                    "image": "img",
+                    "workspace_id": "ws-remote",
+                    "runtime": "runsc",
+                    "running": state["running"],
+                },
+            )
+        if request.method == "DELETE" and request.url.path == "/containers/c-1":
+            state["running"] = False
+            return httpx.Response(204)
+        return httpx.Response(404, json={"detail": "not found"})
+
+    transport = httpx.MockTransport(handler)
+    sync_client = httpx.Client(transport=transport, base_url="http://test")
+    remote = RemoteContainerRuntime("http://test", client=sync_client)
+    try:
+        handle = remote.start(ContainerSpec(image="img", workspace_id="ws-remote"))
+        assert handle.workspace_id == "ws-remote"
+        assert remote.is_running(handle) is True
+        remote.stop(handle)
+        assert state["running"] is False
+    finally:
+        remote.close()
+
+
+def test_remote_exec_returns_process_result(
+    app_with_fakes: tuple[TestClient, Any, _FakeExecutor, Any],
+) -> None:
+    """RemoteSandboxExec parses the service's JSON into ProcessExecutionResult."""
+    client, _runtime, executor, _invoker = app_with_fakes
+    transport = httpx.ASGITransport(app=client.app)
+    async_client = httpx.AsyncClient(transport=transport, base_url="http://testserver")
+    backend = RemoteSandboxExec("http://testserver", client=async_client)
+
+    async def go() -> ProcessExecutionResult:
+        try:
+            return await backend.exec(
+                "sb-1",
+                ["echo", "hi"],
+                cwd=Path("/scratch"),
+                env={"FOO": "bar"},
+                timeout_seconds=2.5,
+            )
+        finally:
+            await async_client.aclose()
+
+    result = asyncio.run(go())
+    assert result.exit_code == 0
+    assert executor.calls[0][0] == "sb-1"
+
+
+def test_remote_runner_dispatches_workflow(
+    app_with_fakes: tuple[TestClient, Any, Any, _FakeInvoker],
+) -> None:
+    """RemoteSandboxRunner returns a WorkflowRunResult parsed from the service."""
+    client, _runtime, _executor, invoker = app_with_fakes
+    transport = httpx.ASGITransport(app=client.app)
+    async_client = httpx.AsyncClient(transport=transport, base_url="http://testserver")
+    runner = RemoteSandboxRunner("http://testserver", client=async_client)
+
+    spec = WorkflowRunSpec(
+        run_id="r-2",
+        workspace_id="ws-2",
+        workflow_definition={"nodes": [{"type": "AINode"}]},
+        inputs={},
+        node_types=("AINode",),
+    )
+
+    async def go() -> WorkflowRunResult:
+        try:
+            from orcheo.sandbox.models import SandboxLease, SandboxState
+
+            lease = SandboxLease(
+                lease_id="l",
+                workspace_id="ws-2",
+                sandbox_id="sb-9",
+                state=SandboxState.IN_USE,
+            )
+            return await runner.execute(lease, spec, "broker-token")
+        finally:
+            await async_client.aclose()
+
+    result = asyncio.run(go())
+    assert result.status == "succeeded"
+    assert result.outputs == {"hello": "world"}
+    assert invoker.calls[0][2] == "broker-token"
+
+
+def _spec_payload(spec: ContainerSpec) -> Mapping[str, Any]:
+    """Render a ``ContainerSpec`` as the JSON the service expects."""
+    return {
+        "image": spec.image,
+        "workspace_id": spec.workspace_id,
+        "runtime": spec.runtime,
+        "command": list(spec.command),
+        "environment": dict(spec.environment),
+        "cpu_limit": spec.cpu_limit,
+        "memory_limit": spec.memory_limit,
+        "pid_limit": spec.pid_limit,
+        "scratch_size": spec.scratch_size,
+        "user": spec.user,
+        "network_mode": spec.network_mode,
+        "read_only_root": spec.read_only_root,
+        "cap_drop": list(spec.cap_drop),
+        "no_new_privileges": spec.no_new_privileges,
+        "labels": dict(spec.labels),
+    }

--- a/tests/sandbox/test_service_and_remote.py
+++ b/tests/sandbox/test_service_and_remote.py
@@ -177,7 +177,9 @@ def test_provision_stop_lifecycle(
 
 
 def test_stop_works_without_cached_handle(
-    app_with_fakes: tuple[TestClient, InMemoryContainerRuntime, _FakeExecutor, _FakeInvoker],
+    app_with_fakes: tuple[
+        TestClient, InMemoryContainerRuntime, _FakeExecutor, _FakeInvoker
+    ],
 ) -> None:
     """DELETE /containers/{id} still stops a running container after restart."""
     client, runtime, executor, invoker = app_with_fakes
@@ -389,3 +391,883 @@ def _spec_payload(spec: ContainerSpec) -> Mapping[str, Any]:
         "no_new_privileges": spec.no_new_privileges,
         "labels": dict(spec.labels),
     }
+
+
+# ---------------------------------------------------------------------------
+# RemoteContainerRuntime additional coverage (lines 96, 113, 122, 131-138)
+# ---------------------------------------------------------------------------
+
+
+def test_remote_container_runtime_close_owned_client() -> None:
+    """close() disposes of the client when the runtime owns it (line 96)."""
+    closed: list[bool] = []
+
+    class _TrackingClient:
+        def close(self) -> None:
+            closed.append(True)
+
+    transport = httpx.MockTransport(lambda r: httpx.Response(200))
+    real_client = httpx.Client(transport=transport)
+    runtime = RemoteContainerRuntime("http://test", client=real_client)
+    # Override the client with the tracking one for the close test.
+    runtime._client = _TrackingClient()  # type: ignore[assignment]
+    runtime._owns_client = True
+    runtime.close()
+    assert closed == [True]
+
+
+def test_remote_container_runtime_close_unowned_client_does_nothing() -> None:
+    """close() skips disposal when the runtime does NOT own the client."""
+    closed: list[bool] = []
+
+    class _TrackingClient:
+        def close(self) -> None:
+            closed.append(True)
+
+    transport = httpx.MockTransport(lambda r: httpx.Response(200))
+    real_client = httpx.Client(transport=transport)
+    runtime = RemoteContainerRuntime("http://test", client=real_client)
+    runtime._client = _TrackingClient()  # type: ignore[assignment]
+    runtime._owns_client = False
+    runtime.close()
+    assert closed == []
+
+
+def test_remote_container_runtime_stop_returns_on_404() -> None:
+    """stop() returns early without raising when the container is already gone (line 113)."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "DELETE"
+        return httpx.Response(404, json={"detail": "not found"})
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport, base_url="http://test")
+    runtime = RemoteContainerRuntime("http://test", client=client)
+    from orcheo.sandbox.runtime import ContainerHandle
+
+    handle = ContainerHandle(
+        container_id="gone-c1", image="img", workspace_id="ws", runtime="runsc"
+    )
+    runtime.stop(handle)  # must not raise
+
+
+def test_remote_container_runtime_is_running_returns_false_on_404() -> None:
+    """is_running() returns False when the service reports 404 (line 122)."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404)
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport, base_url="http://test")
+    runtime = RemoteContainerRuntime("http://test", client=client)
+    from orcheo.sandbox.runtime import ContainerHandle
+
+    handle = ContainerHandle(
+        container_id="no-c1", image="img", workspace_id="ws", runtime="runsc"
+    )
+    assert runtime.is_running(handle) is False
+
+
+def test_remote_container_runtime_raise_for_status_conflict_raises_acquire_error() -> (
+    None
+):
+    """409 Conflict translates to SandboxAcquireError (lines 131-138)."""
+    from orcheo.sandbox.errors import SandboxAcquireError
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(409, json={"detail": "conflict"})
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport, base_url="http://test")
+    runtime = RemoteContainerRuntime("http://test", client=client)
+    spec = ContainerSpec(image="img", workspace_id="ws")
+    with pytest.raises(SandboxAcquireError):
+        runtime.start(spec)
+
+
+def test_remote_container_runtime_raise_for_status_other_error() -> None:
+    """Non-2xx non-409 responses raise RemoteRuntimeError (lines 131-138)."""
+    from orcheo.sandbox.remote import RemoteRuntimeError
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"detail": "server error"})
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport, base_url="http://test")
+    runtime = RemoteContainerRuntime("http://test", client=client)
+    spec = ContainerSpec(image="img", workspace_id="ws")
+    with pytest.raises(RemoteRuntimeError, match="500"):
+        runtime.start(spec)
+
+
+def test_remote_container_runtime_raise_for_status_non_json_body() -> None:
+    """Non-JSON response body falls back to raw text in the error (lines 131-138)."""
+    from orcheo.sandbox.remote import RemoteRuntimeError
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            503, content=b"Service Unavailable", headers={"content-type": "text/plain"}
+        )
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport, base_url="http://test")
+    runtime = RemoteContainerRuntime("http://test", client=client)
+    spec = ContainerSpec(image="img", workspace_id="ws")
+    with pytest.raises(RemoteRuntimeError):
+        runtime.start(spec)
+
+
+# ---------------------------------------------------------------------------
+# RemoteSandboxExec additional coverage (lines 165-166, 199-204)
+# ---------------------------------------------------------------------------
+
+
+def test_remote_sandbox_exec_aclose_owned_client() -> None:
+    """aclose() closes the underlying client when owned (lines 165-166)."""
+    closed: list[bool] = []
+
+    class _TrackingAsyncClient:
+        async def aclose(self) -> None:
+            closed.append(True)
+
+    backend = RemoteSandboxExec("http://test")
+    backend._client = _TrackingAsyncClient()  # type: ignore[assignment]
+    backend._owns_client = True
+    asyncio.run(backend.aclose())
+    assert closed == [True]
+
+
+def test_remote_sandbox_exec_aclose_unowned_client_skips() -> None:
+    """aclose() skips disposal when not owning the client."""
+    closed: list[bool] = []
+
+    class _TrackingAsyncClient:
+        async def aclose(self) -> None:
+            closed.append(True)
+
+    backend = RemoteSandboxExec("http://test")
+    backend._client = _TrackingAsyncClient()  # type: ignore[assignment]
+    backend._owns_client = False
+    asyncio.run(backend.aclose())
+    assert closed == []
+
+
+def test_remote_sandbox_exec_raises_on_error_response() -> None:
+    """exec() raises RemoteRuntimeError on a non-success response (lines 199-204)."""
+    from orcheo.sandbox.remote import RemoteRuntimeError
+
+    async def go() -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, json={"detail": "exec failed"})
+
+        transport = httpx.ASGITransport  # not used — mock directly
+        async_client = httpx.AsyncClient(
+            transport=httpx.MockTransport(handler), base_url="http://test"
+        )
+        backend = RemoteSandboxExec("http://test", client=async_client)
+        try:
+            await backend.exec(
+                "sb-1",
+                ["echo", "hi"],
+                cwd=None,
+                env=None,
+                timeout_seconds=None,
+            )
+        finally:
+            await async_client.aclose()
+
+    with pytest.raises(RemoteRuntimeError, match="exec failed"):
+        asyncio.run(go())
+
+
+def test_remote_sandbox_exec_non_json_error_uses_text() -> None:
+    """exec() with a non-JSON error body uses raw text in the message (lines 199-204)."""
+    from orcheo.sandbox.remote import RemoteRuntimeError
+
+    async def go() -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                502, content=b"Bad Gateway", headers={"content-type": "text/plain"}
+            )
+
+        async_client = httpx.AsyncClient(
+            transport=httpx.MockTransport(handler), base_url="http://test"
+        )
+        backend = RemoteSandboxExec("http://test", client=async_client)
+        try:
+            await backend.exec(
+                "sb-1", ["cmd"], cwd=None, env=None, timeout_seconds=None
+            )
+        finally:
+            await async_client.aclose()
+
+    with pytest.raises(RemoteRuntimeError):
+        asyncio.run(go())
+
+
+# ---------------------------------------------------------------------------
+# RemoteSandboxRunner additional coverage (lines 264-265, 284-292)
+# ---------------------------------------------------------------------------
+
+
+def test_remote_sandbox_runner_aclose_owned_client() -> None:
+    """aclose() closes the underlying client when owned (lines 264-265)."""
+    closed: list[bool] = []
+
+    class _TrackingAsyncClient:
+        async def aclose(self) -> None:
+            closed.append(True)
+
+    runner = RemoteSandboxRunner("http://test")
+    runner._client = _TrackingAsyncClient()  # type: ignore[assignment]
+    runner._owns_client = True
+    asyncio.run(runner.aclose())
+    assert closed == [True]
+
+
+def test_remote_sandbox_runner_aclose_unowned_client_skips() -> None:
+    """aclose() skips disposal when not owning the client."""
+    closed: list[bool] = []
+
+    class _TrackingAsyncClient:
+        async def aclose(self) -> None:
+            closed.append(True)
+
+    runner = RemoteSandboxRunner("http://test")
+    runner._client = _TrackingAsyncClient()  # type: ignore[assignment]
+    runner._owns_client = False
+    asyncio.run(runner.aclose())
+    assert closed == []
+
+
+def test_remote_sandbox_runner_raises_on_error_response() -> None:
+    """execute() raises RemoteRuntimeError on a non-success response (lines 284-292)."""
+    from orcheo.sandbox.remote import RemoteRuntimeError
+    from orcheo.sandbox.models import SandboxLease, SandboxState
+
+    async def go() -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, json={"detail": "dispatch failed"})
+
+        async_client = httpx.AsyncClient(
+            transport=httpx.MockTransport(handler), base_url="http://test"
+        )
+        runner = RemoteSandboxRunner("http://test", client=async_client)
+        lease = SandboxLease(
+            lease_id="l1",
+            workspace_id="ws",
+            sandbox_id="sb-err",
+            state=SandboxState.IN_USE,
+        )
+        spec = WorkflowRunSpec(
+            run_id="r-err",
+            workspace_id="ws",
+            workflow_definition={},
+            inputs={},
+            node_types=(),
+            runnable_config={},
+            state_config={},
+        )
+        try:
+            await runner.execute(lease, spec, "token")
+        finally:
+            await async_client.aclose()
+
+    with pytest.raises(RemoteRuntimeError, match="dispatch failed"):
+        asyncio.run(go())
+
+
+def test_remote_sandbox_runner_non_json_error_uses_text() -> None:
+    """execute() with a non-JSON error body uses raw text (lines 284-292)."""
+    from orcheo.sandbox.remote import RemoteRuntimeError
+    from orcheo.sandbox.models import SandboxLease, SandboxState
+
+    async def go() -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                503,
+                content=b"Service Unavailable",
+                headers={"content-type": "text/plain"},
+            )
+
+        async_client = httpx.AsyncClient(
+            transport=httpx.MockTransport(handler), base_url="http://test"
+        )
+        runner = RemoteSandboxRunner("http://test", client=async_client)
+        lease = SandboxLease(
+            lease_id="l2",
+            workspace_id="ws",
+            sandbox_id="sb-503",
+            state=SandboxState.IN_USE,
+        )
+        spec = WorkflowRunSpec(
+            run_id="r-503",
+            workspace_id="ws",
+            workflow_definition={},
+            inputs={},
+            node_types=(),
+            runnable_config={},
+            state_config={},
+        )
+        try:
+            await runner.execute(lease, spec, "tok")
+        finally:
+            await async_client.aclose()
+
+    with pytest.raises(RemoteRuntimeError):
+        asyncio.run(go())
+
+
+# ---------------------------------------------------------------------------
+# serialize_workflow_run_result (lines 304-306) — non-dataclass path
+# ---------------------------------------------------------------------------
+
+
+def test_serialize_workflow_run_result_non_dataclass() -> None:
+    """serialize_workflow_run_result works for non-dataclass objects (lines 304-306)."""
+    from orcheo.sandbox.remote import serialize_workflow_run_result
+
+    result = WorkflowRunResult(
+        run_id="r-serial",
+        status="succeeded",
+        outputs={"x": 1},
+        error=None,
+    )
+    # WorkflowRunResult IS a dataclass, so patch is_dataclass to return False.
+    import dataclasses
+
+    original = dataclasses.is_dataclass
+
+    def _fake_is_dataclass(obj: object) -> bool:
+        return False
+
+    import orcheo.sandbox.remote as remote_module
+
+    original_fn = remote_module.is_dataclass
+    remote_module.is_dataclass = _fake_is_dataclass  # type: ignore[assignment]
+    try:
+        serialized = serialize_workflow_run_result(result)
+    finally:
+        remote_module.is_dataclass = original_fn  # type: ignore[assignment]
+
+    assert serialized["run_id"] == "r-serial"
+    assert serialized["status"] == "succeeded"
+    assert serialized["outputs"] == {"x": 1}
+    assert serialized["error"] is None
+
+
+# ---------------------------------------------------------------------------
+# service.py additional coverage
+# ---------------------------------------------------------------------------
+
+
+def test_container_executor_init_and_invoker_init() -> None:
+    """ContainerExecutor and WorkflowSandboxInvoker can be constructed directly (line 183)."""
+    from orcheo.sandbox.service import ContainerExecutor, WorkflowSandboxInvoker
+
+    executor = ContainerExecutor()
+    invoker = WorkflowSandboxInvoker(executor)
+    assert invoker._executor is executor
+
+
+def test_last_json_line_returns_last_valid_json() -> None:
+    """_last_json_line returns the last {...} line (lines 268-274)."""
+    from orcheo.sandbox.service import _last_json_line
+
+    blob = 'some log line\n{"status": "ok"}\nmore log\n{"status": "done"}\n'
+    assert _last_json_line(blob) == '{"status": "done"}'
+
+
+def test_last_json_line_skips_empty_lines() -> None:
+    """_last_json_line skips blank lines when searching (lines 268-274)."""
+    from orcheo.sandbox.service import _last_json_line
+
+    blob = '{"status": "ok"}\n\n   \n'
+    assert _last_json_line(blob) == '{"status": "ok"}'
+
+
+def test_last_json_line_returns_none_when_no_json() -> None:
+    """_last_json_line returns None when no JSON line exists (lines 268-274)."""
+    from orcheo.sandbox.service import _last_json_line
+
+    assert _last_json_line("no json here\nplain text") is None
+    assert _last_json_line("") is None
+
+
+def test_parse_workflow_spec_raises_400_on_missing_field() -> None:
+    """_parse_workflow_spec raises HTTPException 400 on KeyError (lines 289-290)."""
+    from orcheo.sandbox.service import WorkflowDispatchPayload, _parse_workflow_spec
+
+    payload = WorkflowDispatchPayload(spec={"workspace_id": "ws"}, broker_token="tok")
+    # Missing "run_id" → KeyError → 400.
+    with pytest.raises(Exception) as exc_info:
+        _parse_workflow_spec(payload)
+    assert exc_info.value.status_code == 400  # type: ignore[attr-defined]
+    assert "run_id" in exc_info.value.detail  # type: ignore[attr-defined]
+
+
+def test_provision_endpoint_returns_500_on_runtime_failure(
+    app_with_fakes: tuple[
+        TestClient, InMemoryContainerRuntime, _FakeExecutor, _FakeInvoker
+    ],
+) -> None:
+    """POST /containers returns 500 when runtime.start raises (lines 308-310)."""
+    client, runtime, _executor, _invoker = app_with_fakes
+
+    class _BoomRuntime(InMemoryContainerRuntime):
+        def start(self, spec: ContainerSpec) -> Any:  # type: ignore[override]
+            raise RuntimeError("docker is gone")
+
+    boom_app = build_service_app(
+        runtime=_BoomRuntime(),
+        executor=_executor,
+        invoker=_invoker,
+    )
+    boom_client = TestClient(boom_app)
+    spec = ContainerSpec(image="img", workspace_id="ws")
+    response = boom_client.post("/containers", json=_spec_payload(spec))
+    assert response.status_code == 500
+    assert "provision failed" in response.json()["detail"]
+
+
+def test_stop_endpoint_returns_500_on_runtime_failure(
+    app_with_fakes: tuple[
+        TestClient, InMemoryContainerRuntime, _FakeExecutor, _FakeInvoker
+    ],
+) -> None:
+    """DELETE /containers/{id} returns 500 when runtime.stop raises (lines 332-334)."""
+    client, runtime, executor, invoker = app_with_fakes
+
+    spec = ContainerSpec(image="img", workspace_id="ws")
+    provision = client.post("/containers", json=_spec_payload(spec))
+    container_id = provision.json()["container_id"]
+
+    class _BoomStopRuntime(InMemoryContainerRuntime):
+        def stop(self, handle: Any) -> None:  # type: ignore[override]
+            raise RuntimeError("kill failed")
+
+    boom_runtime = _BoomStopRuntime()
+    # Pre-populate the handles so the new app thinks the container exists.
+    handle, _ = runtime.started[0]
+    boom_runtime._running.add(handle.container_id)
+    boom_runtime.started.append(runtime.started[0])
+
+    boom_app = build_service_app(
+        runtime=boom_runtime,
+        executor=executor,
+        invoker=invoker,
+    )
+    boom_client = TestClient(boom_app)
+    # First provision to register the handle in the new app's state.
+    boom_provision = boom_client.post("/containers", json=_spec_payload(spec))
+    boom_container_id = boom_provision.json()["container_id"]
+
+    response = boom_client.delete(f"/containers/{boom_container_id}")
+    assert response.status_code == 500
+    assert "stop failed" in response.json()["detail"]
+
+
+def test_inspect_endpoint_returns_running_status(
+    app_with_fakes: tuple[
+        TestClient, InMemoryContainerRuntime, _FakeExecutor, _FakeInvoker
+    ],
+) -> None:
+    """GET /containers/{id} returns the running status (line 343)."""
+    client, runtime, _executor, _invoker = app_with_fakes
+    spec = ContainerSpec(image="img", workspace_id="ws")
+    provision = client.post("/containers", json=_spec_payload(spec))
+    container_id = provision.json()["container_id"]
+
+    response = client.get(f"/containers/{container_id}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["running"] is True
+    assert data["container_id"] == container_id
+
+
+def test_inspect_endpoint_returns_404_for_unknown_container(
+    app_with_fakes: tuple[
+        TestClient, InMemoryContainerRuntime, _FakeExecutor, _FakeInvoker
+    ],
+) -> None:
+    """GET /containers/{id} returns 404 when container is not registered."""
+    client, _runtime, _executor, _invoker = app_with_fakes
+    response = client.get("/containers/unknown-id")
+    assert response.status_code == 404
+
+
+def test_credential_relay_without_optional_headers(
+    app_with_fakes: tuple[TestClient, Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Credential relay works when Authorization and X-Orcheo-Workspace are absent (390->392, 392->394)."""
+    client, *_ = app_with_fakes
+
+    class _MinimalAsyncClient:
+        def __init__(self, *, timeout: float) -> None:
+            pass
+
+        async def __aenter__(self) -> _MinimalAsyncClient:
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            pass
+
+        async def post(
+            self,
+            url: str,
+            *,
+            json: dict[str, Any],
+            headers: dict[str, str],
+        ) -> httpx.Response:
+            # Neither Authorization nor X-Orcheo-Workspace should be in headers.
+            assert "Authorization" not in headers
+            assert "X-Orcheo-Workspace" not in headers
+            return httpx.Response(200, json={"value": "ok"})
+
+    monkeypatch.setenv(
+        "ORCHEO_CREDENTIAL_BROKER_URL",
+        "http://backend/internal/credentials/resolve",
+    )
+    monkeypatch.setattr(service_module.httpx, "AsyncClient", _MinimalAsyncClient)
+
+    response = client.post(
+        "/credentials/resolve",
+        json={"run_id": "r-2", "credential_name": "key"},
+        # No Authorization or X-Orcheo-Workspace headers
+    )
+    assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# WorkflowSandboxInvoker.invoke() additional paths (lines 194-258)
+# ---------------------------------------------------------------------------
+
+
+def test_invoker_returns_failed_on_timeout() -> None:
+    """invoke() returns a failed WorkflowRunResult when executor times out."""
+
+    async def go() -> WorkflowRunResult:
+        executor = _FakeExecutor()
+        executor.result = asyncio.get_event_loop()
+        # Override to return timed_out=True.
+        from orcheo.external_agents.models import ProcessExecutionResult
+
+        timed_out_result = ProcessExecutionResult(
+            command=["sh"],
+            stdout="",
+            stderr="",
+            exit_code=None,
+            timed_out=True,
+            duration_seconds=30.0,
+        )
+        executor.result = timed_out_result
+
+        from orcheo.sandbox.service import WorkflowSandboxInvoker
+        from orcheo.sandbox.workflow import WorkflowRunSpec
+
+        invoker = WorkflowSandboxInvoker(executor)
+        spec = WorkflowRunSpec(
+            run_id="r-timeout",
+            workspace_id="ws",
+            workflow_definition={},
+            inputs={},
+            node_types=(),
+            runnable_config={},
+            state_config={},
+        )
+        return await invoker.invoke("sb-1", spec, "token")
+
+    result = asyncio.run(go())
+    assert result.status == "failed"
+    assert "timed out" in (result.error or "")
+
+
+def test_invoker_returns_failed_on_non_zero_exit() -> None:
+    """invoke() returns failed when the runner exits with non-zero code."""
+
+    async def go() -> WorkflowRunResult:
+        from orcheo.external_agents.models import ProcessExecutionResult
+
+        executor = _FakeExecutor()
+        executor.result = ProcessExecutionResult(
+            command=["sh"],
+            stdout="",
+            stderr="runner crashed",
+            exit_code=1,
+            timed_out=False,
+            duration_seconds=0.1,
+        )
+        from orcheo.sandbox.service import WorkflowSandboxInvoker
+        from orcheo.sandbox.workflow import WorkflowRunSpec
+
+        invoker = WorkflowSandboxInvoker(executor)
+        spec = WorkflowRunSpec(
+            run_id="r-exitcode",
+            workspace_id="ws",
+            workflow_definition={},
+            inputs={},
+            node_types=(),
+            runnable_config={},
+            state_config={},
+        )
+        return await invoker.invoke("sb-1", spec, "token")
+
+    result = asyncio.run(go())
+    assert result.status == "failed"
+    assert "exited with" in (result.error or "") or result.error is not None
+
+
+def test_invoker_returns_failed_when_no_json_output() -> None:
+    """invoke() returns failed when runner produces no JSON on stdout."""
+
+    async def go() -> WorkflowRunResult:
+        from orcheo.external_agents.models import ProcessExecutionResult
+
+        executor = _FakeExecutor()
+        executor.result = ProcessExecutionResult(
+            command=["sh"],
+            stdout="some non-json log output",
+            stderr="",
+            exit_code=0,
+            timed_out=False,
+            duration_seconds=0.1,
+        )
+        from orcheo.sandbox.service import WorkflowSandboxInvoker
+        from orcheo.sandbox.workflow import WorkflowRunSpec
+
+        invoker = WorkflowSandboxInvoker(executor)
+        spec = WorkflowRunSpec(
+            run_id="r-nojson",
+            workspace_id="ws",
+            workflow_definition={},
+            inputs={},
+            node_types=(),
+            runnable_config={},
+            state_config={},
+        )
+        return await invoker.invoke("sb-1", spec, "token")
+
+    result = asyncio.run(go())
+    assert result.status == "failed"
+    assert "no JSON output" in (result.error or "")
+
+
+def test_invoker_returns_failed_on_json_decode_error() -> None:
+    """invoke() returns failed when runner output is invalid JSON."""
+
+    async def go() -> WorkflowRunResult:
+        from orcheo.external_agents.models import ProcessExecutionResult
+
+        executor = _FakeExecutor()
+        executor.result = ProcessExecutionResult(
+            command=["sh"],
+            stdout="{not valid json}",
+            stderr="",
+            exit_code=0,
+            timed_out=False,
+            duration_seconds=0.1,
+        )
+        from orcheo.sandbox.service import WorkflowSandboxInvoker
+        from orcheo.sandbox.workflow import WorkflowRunSpec
+
+        invoker = WorkflowSandboxInvoker(executor)
+        spec = WorkflowRunSpec(
+            run_id="r-badjson",
+            workspace_id="ws",
+            workflow_definition={},
+            inputs={},
+            node_types=(),
+            runnable_config={},
+            state_config={},
+        )
+        return await invoker.invoke("sb-1", spec, "token")
+
+    result = asyncio.run(go())
+    assert result.status == "failed"
+    assert "parse" in (result.error or "").lower()
+
+
+def test_invoker_returns_succeeded_on_valid_json_output() -> None:
+    """invoke() parses a valid JSON result from runner stdout."""
+    import json
+
+    async def go() -> WorkflowRunResult:
+        from orcheo.external_agents.models import ProcessExecutionResult
+
+        result_json = json.dumps(
+            {"status": "succeeded", "outputs": {"answer": 42}, "error": None}
+        )
+        executor = _FakeExecutor()
+        executor.result = ProcessExecutionResult(
+            command=["sh"],
+            stdout=f"some logs\n{result_json}\n",
+            stderr="",
+            exit_code=0,
+            timed_out=False,
+            duration_seconds=0.1,
+        )
+        from orcheo.sandbox.service import WorkflowSandboxInvoker
+        from orcheo.sandbox.workflow import WorkflowRunSpec
+
+        invoker = WorkflowSandboxInvoker(executor)
+        spec = WorkflowRunSpec(
+            run_id="r-ok",
+            workspace_id="ws",
+            workflow_definition={},
+            inputs={},
+            node_types=(),
+            runnable_config={},
+            state_config={},
+        )
+        return await invoker.invoke("sb-1", spec, "token")
+
+    result = asyncio.run(go())
+    assert result.status == "succeeded"
+    assert result.outputs == {"answer": 42}
+
+
+# ---------------------------------------------------------------------------
+# ContainerExecutor.exec() direct tests (lines 125-161)
+# ---------------------------------------------------------------------------
+
+
+def test_container_executor_exec_builds_argv_and_returns_result() -> None:
+    """ContainerExecutor.exec() runs docker exec with cwd and env (lines 125-161)."""
+    import unittest.mock as mock
+
+    async def go() -> ProcessExecutionResult:
+        from orcheo.sandbox.service import ContainerExecutor, ExecRequest
+
+        executor = ContainerExecutor()
+        request = ExecRequest(
+            command=["echo", "hi"],
+            cwd="/workspace",
+            env={"FOO": "bar"},
+            timeout_seconds=10.0,
+        )
+
+        fake_process = mock.AsyncMock()
+        fake_process.communicate = mock.AsyncMock(return_value=(b"hi\n", b""))
+        fake_process.returncode = 0
+
+        with mock.patch(
+            "orcheo.sandbox.service.asyncio.create_subprocess_exec",
+            return_value=fake_process,
+        ) as patched:
+            result = await executor.exec("ctr-1", request)
+
+        call_args = patched.call_args[0]
+        assert "docker" in call_args
+        assert "exec" in call_args
+        assert "-w" in call_args
+        assert "/workspace" in call_args
+        assert "-e" in call_args
+        assert "FOO=bar" in call_args
+        assert "echo" in call_args
+        assert result.stdout == "hi\n"
+        assert result.exit_code == 0
+        return result
+
+    asyncio.run(go())
+
+
+def test_container_executor_exec_no_cwd_no_env() -> None:
+    """ContainerExecutor.exec() omits -w and -e when cwd/env are absent."""
+    import unittest.mock as mock
+
+    async def go() -> ProcessExecutionResult:
+        from orcheo.sandbox.service import ContainerExecutor, ExecRequest
+
+        executor = ContainerExecutor()
+        request = ExecRequest(
+            command=["ls"],
+            cwd=None,
+            env=None,
+            timeout_seconds=5.0,
+        )
+
+        fake_process = mock.AsyncMock()
+        fake_process.communicate = mock.AsyncMock(return_value=(b"", b""))
+        fake_process.returncode = 0
+
+        with mock.patch(
+            "orcheo.sandbox.service.asyncio.create_subprocess_exec",
+            return_value=fake_process,
+        ) as patched:
+            result = await executor.exec("ctr-2", request)
+
+        call_args = patched.call_args[0]
+        assert "-w" not in call_args
+        assert "-e" not in call_args
+        assert result.exit_code == 0
+        return result
+
+    asyncio.run(go())
+
+
+def test_container_executor_exec_handles_timeout() -> None:
+    """ContainerExecutor.exec() kills the process on TimeoutError (lines 155-159)."""
+    import unittest.mock as mock
+
+    async def go() -> ProcessExecutionResult:
+        from orcheo.sandbox.service import ContainerExecutor, ExecRequest
+
+        executor = ContainerExecutor()
+        request = ExecRequest(
+            command=["sleep", "9999"],
+            cwd=None,
+            env=None,
+            timeout_seconds=0.001,
+        )
+
+        killed = []
+
+        fake_process = mock.AsyncMock()
+        fake_process.kill = mock.MagicMock(side_effect=lambda: killed.append(True))
+        fake_process.communicate = mock.AsyncMock(return_value=(b"", b""))
+        fake_process.returncode = None
+
+        async def _wait_for_raises(coro: Any, *, timeout: float) -> Any:
+            coro.close()
+            raise TimeoutError
+
+        with mock.patch(
+            "orcheo.sandbox.service.asyncio.create_subprocess_exec",
+            return_value=fake_process,
+        ):
+            with mock.patch(
+                "orcheo.sandbox.service.asyncio.wait_for",
+                side_effect=_wait_for_raises,
+            ):
+                result = await executor.exec("ctr-3", request)
+
+        assert result.timed_out is True
+        assert result.exit_code is None
+        assert killed  # kill() was called
+        return result
+
+    asyncio.run(go())
+
+
+# ---------------------------------------------------------------------------
+# serialize_workflow_run_result — dataclass path (line 305 in remote.py)
+# ---------------------------------------------------------------------------
+
+
+def test_serialize_workflow_run_result_with_real_dataclass() -> None:
+    """serialize_workflow_run_result returns asdict() when result is a real dataclass (line 305)."""
+    from orcheo.sandbox.remote import serialize_workflow_run_result
+    from orcheo.sandbox.workflow import WorkflowRunResult
+
+    result = WorkflowRunResult(
+        run_id="r-dc",
+        status="succeeded",
+        outputs={"k": "v"},
+        error=None,
+    )
+    serialized = serialize_workflow_run_result(result)
+    assert serialized["run_id"] == "r-dc"
+    assert serialized["status"] == "succeeded"
+    assert serialized["outputs"] == {"k": "v"}
+    assert serialized["error"] is None

--- a/tests/sandbox/test_workflow.py
+++ b/tests/sandbox/test_workflow.py
@@ -4,7 +4,15 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Mapping
 from typing import Any
+import json
 import pytest
+import httpx
+from langchain_core.messages import HumanMessage
+from orcheo.runtime.credentials import (
+    UnknownCredentialPayloadError,
+    credential_ref,
+    get_active_credential_resolver,
+)
 from orcheo.sandbox.broker import CredentialBroker
 from orcheo.sandbox.config import SandboxSettings
 from orcheo.sandbox.manager import SandboxRuntimeManager
@@ -69,6 +77,17 @@ def test_requires_sandbox_flags_unknown_node_types() -> None:
     assert not requires_sandbox(tuple(TRUSTED_NODE_TYPES))
 
 
+def test_requires_sandbox_fails_closed_on_empty_node_types() -> None:
+    """An unparseable graph (no node types) must route to the sandbox."""
+    assert requires_sandbox(())
+
+
+def test_trusted_set_excludes_code_bearing_base_types() -> None:
+    """Base / code-bearing node types must not appear in the trusted set."""
+    forbidden = {"TaskNode", "BaseNode", "IntegrationNode", "DataTransformNode"}
+    assert forbidden.isdisjoint(TRUSTED_NODE_TYPES)
+
+
 def test_dispatcher_routes_through_sandbox_by_default() -> None:
     """With fast-path off, every run acquires a workflow sandbox."""
     manager, runtime = _manager()
@@ -107,7 +126,7 @@ def test_dispatcher_fast_path_skips_sandbox_for_trusted_only() -> None:
         workspace_id="ws",
         workflow_definition={"nodes": []},
         inputs={},
-        node_types=("AINode", "TaskNode"),
+        node_types=("AINode", "ChatModelNode"),
     )
     asyncio.run(dispatcher.dispatch(spec))
     assert runtime.started == []
@@ -131,7 +150,7 @@ def test_dispatcher_releases_sandbox_and_revokes_token_on_runner_error() -> None
     )
     result = asyncio.run(dispatcher.dispatch(spec))
     assert result.status == "failed"
-    assert result.error == "boom"
+    assert result.error == "RuntimeError: boom"
     assert len(runtime.started) == 1
     # The sandbox should have been released back to the pool, not destroyed.
     assert len(runtime.stopped) == 0
@@ -150,7 +169,9 @@ def test_run_in_subprocess_returns_failure_for_runtime_error(
     """A failure in the run-graph implementation is surfaced cleanly."""
 
     def _fail(
-        definition: Mapping[str, Any], inputs: Mapping[str, Any]
+        definition: Mapping[str, Any],
+        inputs: Mapping[str, Any],
+        **_: object,
     ) -> Mapping[str, Any]:
         del definition, inputs
         raise RuntimeError("graph blew up")
@@ -165,7 +186,9 @@ def test_run_in_subprocess_returns_success(monkeypatch: pytest.MonkeyPatch) -> N
     """A successful run produces a succeeded result with outputs."""
 
     def _ok(
-        definition: Mapping[str, Any], inputs: Mapping[str, Any]
+        definition: Mapping[str, Any],
+        inputs: Mapping[str, Any],
+        **_: object,
     ) -> Mapping[str, Any]:
         del definition
         return {"sum": inputs["a"] + inputs["b"]}
@@ -174,6 +197,21 @@ def test_run_in_subprocess_returns_success(monkeypatch: pytest.MonkeyPatch) -> N
     result = run_in_subprocess({}, {"a": 2, "b": 3}, spawn=False)
     assert result["status"] == "succeeded"
     assert result["outputs"]["sum"] == 5
+
+
+def test_workflow_result_json_serializes_langchain_messages() -> None:
+    """Sandbox results retain LangChain message fields across JSON transport."""
+    from orcheo.sandbox import workflow_runner
+
+    payload = json.loads(
+        json.dumps(
+            {"messages": [HumanMessage(content="hello")]},
+            default=workflow_runner._json_default,
+        )
+    )
+
+    assert payload["messages"][0]["type"] == "human"
+    assert payload["messages"][0]["content"] == "hello"
 
 
 def test_should_sandbox_obeys_fast_path_flag() -> None:
@@ -210,7 +248,7 @@ def test_synthetic_lease_used_when_fast_path_engages() -> None:
         workspace_id="ws",
         workflow_definition={},
         inputs={},
-        node_types=("TaskNode",),
+        node_types=("AINode",),
     )
     asyncio.run(dispatcher.dispatch(spec))
     lease = runner.calls[0][0]
@@ -219,13 +257,21 @@ def test_synthetic_lease_used_when_fast_path_engages() -> None:
 
 
 def test_run_graph_delegates_to_build_graph(monkeypatch: pytest.MonkeyPatch) -> None:
-    """_run_graph imports build_graph lazily and invokes it with the definition."""
+    """_run_graph imports build_graph lazily and async-invokes the graph."""
     from orcheo.sandbox import workflow_runner
 
     fake_outputs: Mapping[str, Any] = {"answer": 42}
+    captured: dict[str, object] = {}
 
     class _FakeCompiled:
-        def invoke(self, inputs: object) -> Mapping[str, Any]:
+        async def ainvoke(
+            self,
+            inputs: object,
+            *,
+            config: object,
+        ) -> Mapping[str, Any]:
+            captured["inputs"] = inputs
+            captured["config"] = config
             return fake_outputs
 
     class _FakeGraph:
@@ -236,8 +282,80 @@ def test_run_graph_delegates_to_build_graph(monkeypatch: pytest.MonkeyPatch) -> 
 
     monkeypatch.setattr(_builder_module, "build_graph", lambda _d: _FakeGraph())
 
-    result = workflow_runner._run_graph({"nodes": []}, {"x": 1})
+    result = workflow_runner._run_graph(
+        {"format": "langgraph-script"},
+        {"x": 1},
+        runnable_config={"configurable": {"thread_id": "run-1"}},
+        state_config={"configurable": {"ai_model": "openai:test"}},
+        workspace_id="ws-1",
+    )
     assert result == fake_outputs
+    assert captured == {
+        "inputs": {
+            "x": 1,
+            "inputs": {"x": 1},
+            "results": {},
+            "messages": [],
+            "workspace_id": "ws-1",
+            "config": {"configurable": {"ai_model": "openai:test"}},
+        },
+        "config": {"configurable": {"thread_id": "run-1"}},
+    }
+
+
+def test_broker_credential_context_resolves_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sandbox credential placeholders resolve through the broker HTTP API."""
+    from orcheo.sandbox import workflow_runner
+
+    calls: list[tuple[str, dict[str, object], dict[str, str]]] = []
+
+    def _post(
+        url: str,
+        *,
+        json: dict[str, object],
+        headers: dict[str, str],
+        timeout: float,
+    ) -> httpx.Response:
+        assert timeout == 30.0
+        calls.append((url, json, headers))
+        return httpx.Response(200, json={"value": "vault-secret"})
+
+    monkeypatch.setenv("ORCHEO_BROKER_TOKEN", "broker-token")
+    monkeypatch.setenv("ORCHEO_CREDENTIAL_BROKER_URL", "http://runtime/broker")
+    monkeypatch.setattr(workflow_runner.httpx, "post", _post)
+
+    with workflow_runner._credential_context(run_id="run-1", workspace_id="ws-1"):
+        resolver = get_active_credential_resolver()
+        assert resolver is not None
+        assert resolver.resolve(credential_ref("openai_api_key")) == "vault-secret"
+
+    assert calls == [
+        (
+            "http://runtime/broker",
+            {"run_id": "run-1", "credential_name": "openai_api_key"},
+            {
+                "Authorization": "Bearer broker-token",
+                "X-Orcheo-Workspace": "ws-1",
+            },
+        )
+    ]
+
+
+def test_broker_credential_resolver_rejects_non_secret_payload() -> None:
+    """The sandbox broker channel rejects payload shapes it cannot return."""
+    from orcheo.sandbox import workflow_runner
+
+    resolver = workflow_runner._BrokerCredentialResolver(
+        broker_url="http://runtime/broker",
+        broker_token="token",
+        run_id="run-1",
+        workspace_id="ws-1",
+    )
+
+    with pytest.raises(UnknownCredentialPayloadError, match="only supports secret"):
+        resolver.resolve(credential_ref("oauth-ref", payload="oauth.access_token"))
 
 
 def test_run_in_subprocess_spawn_mode_creates_child_process(

--- a/tests/sandbox/test_workflow_runner.py
+++ b/tests/sandbox/test_workflow_runner.py
@@ -1,0 +1,432 @@
+"""Tests for the in-sandbox workflow runner module."""
+
+from __future__ import annotations
+import os
+from collections.abc import Mapping
+from typing import Any
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# _BrokerCredentialResolver tests (lines 67->69, 79-83, 86-90)
+# ---------------------------------------------------------------------------
+
+
+def test_broker_resolver_raises_for_unsupported_payload_path() -> None:
+    """resolve() raises UnknownCredentialPayloadError for non-secret paths (lines 67->69)."""
+    from orcheo.runtime.credentials import UnknownCredentialPayloadError
+    from orcheo.runtime.credentials.references import CredentialReference
+    from orcheo.sandbox.workflow_runner import _BrokerCredentialResolver
+
+    resolver = _BrokerCredentialResolver(
+        broker_url="http://broker",
+        broker_token="tok",
+        run_id="run-1",
+        workspace_id="ws-1",
+    )
+    ref = CredentialReference(identifier="openai_api_key", payload_path=("metadata",))
+    with pytest.raises(UnknownCredentialPayloadError, match="metadata"):
+        resolver.resolve(ref)
+
+
+def test_broker_resolver_sends_request_without_workspace_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """resolve() omits X-Orcheo-Workspace when workspace_id is None (lines 79-83)."""
+    import httpx
+    from orcheo.runtime.credentials.references import CredentialReference
+    from orcheo.sandbox.workflow_runner import _BrokerCredentialResolver
+
+    sent_headers: list[dict[str, str]] = []
+
+    class _FakeClient:
+        @staticmethod
+        def post(
+            url: str, *, json: Any, headers: Any, timeout: float
+        ) -> httpx.Response:
+            sent_headers.append(dict(headers))
+            return httpx.Response(200, json={"value": "secret-value"})
+
+    monkeypatch.setattr(
+        "orcheo.sandbox.workflow_runner.httpx",
+        type("httpx", (), {"post": staticmethod(_FakeClient.post)})(),
+    )
+
+    resolver = _BrokerCredentialResolver(
+        broker_url="http://broker",
+        broker_token="tok",
+        run_id="run-1",
+        workspace_id=None,
+    )
+    ref = CredentialReference(identifier="openai_api_key", payload_path=())
+    value = resolver.resolve(ref)
+
+    assert value == "secret-value"
+    assert len(sent_headers) == 1
+    assert "X-Orcheo-Workspace" not in sent_headers[0]
+    assert sent_headers[0]["Authorization"] == "Bearer tok"
+
+
+def test_broker_resolver_raises_on_http_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """resolve() raises RuntimeError when the broker returns a non-success status (lines 86-90)."""
+    import httpx
+    from orcheo.runtime.credentials.references import CredentialReference
+    from orcheo.sandbox.workflow_runner import _BrokerCredentialResolver
+
+    class _FailClient:
+        @staticmethod
+        def post(
+            url: str, *, json: Any, headers: Any, timeout: float
+        ) -> httpx.Response:
+            return httpx.Response(401, text="Unauthorized")
+
+    monkeypatch.setattr(
+        "orcheo.sandbox.workflow_runner.httpx",
+        type("httpx", (), {"post": staticmethod(_FailClient.post)})(),
+    )
+
+    resolver = _BrokerCredentialResolver(
+        broker_url="http://broker",
+        broker_token="bad-token",
+        run_id="run-1",
+        workspace_id="ws-1",
+    )
+    ref = CredentialReference(identifier="openai_api_key", payload_path=("secret",))
+    with pytest.raises(RuntimeError, match="401"):
+        resolver.resolve(ref)
+
+
+def test_broker_resolver_raises_when_value_is_not_string(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """resolve() raises RuntimeError when broker response value is not a string."""
+    import httpx
+    from orcheo.runtime.credentials.references import CredentialReference
+    from orcheo.sandbox.workflow_runner import _BrokerCredentialResolver
+
+    class _WrongTypeClient:
+        @staticmethod
+        def post(
+            url: str, *, json: Any, headers: Any, timeout: float
+        ) -> httpx.Response:
+            return httpx.Response(200, json={"value": 12345})
+
+    monkeypatch.setattr(
+        "orcheo.sandbox.workflow_runner.httpx",
+        type("httpx", (), {"post": staticmethod(_WrongTypeClient.post)})(),
+    )
+
+    resolver = _BrokerCredentialResolver(
+        broker_url="http://broker",
+        broker_token="tok",
+        run_id="run-1",
+        workspace_id="ws-1",
+    )
+    ref = CredentialReference(identifier="openai_api_key", payload_path=())
+    with pytest.raises(RuntimeError, match="invalid value"):
+        resolver.resolve(ref)
+
+
+# ---------------------------------------------------------------------------
+# _credential_context tests (lines 105-106)
+# ---------------------------------------------------------------------------
+
+
+def test_credential_context_raises_when_broker_url_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_credential_context raises RuntimeError when ORCHEO_CREDENTIAL_BROKER_URL is unset (lines 105-106)."""
+    from orcheo.sandbox.workflow_runner import _credential_context
+
+    monkeypatch.setenv("ORCHEO_BROKER_TOKEN", "some-token")
+    monkeypatch.delenv("ORCHEO_CREDENTIAL_BROKER_URL", raising=False)
+
+    with pytest.raises(RuntimeError, match="ORCHEO_CREDENTIAL_BROKER_URL"):
+        _credential_context(run_id="r1", workspace_id="ws-1")
+
+
+def test_credential_context_returns_nullcontext_when_no_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_credential_context returns nullcontext() when no broker token is set."""
+    from contextlib import nullcontext
+    from orcheo.sandbox.workflow_runner import _credential_context
+
+    monkeypatch.delenv("ORCHEO_BROKER_TOKEN", raising=False)
+    ctx = _credential_context(run_id="r1", workspace_id="ws-1")
+    # nullcontext is the expected type when no token is available.
+    assert isinstance(ctx, type(nullcontext()))
+
+
+# ---------------------------------------------------------------------------
+# run_in_subprocess (lines 270-285) — empty queue path
+# ---------------------------------------------------------------------------
+
+
+def test_run_in_subprocess_handles_empty_queue_on_child_exit() -> None:
+    """run_in_subprocess returns a failed result when the child process puts nothing (lines 270-285)."""
+    from orcheo.sandbox.workflow_runner import run_in_subprocess
+
+    # spawn=True with a definition that causes the child to crash before putting anything.
+    # We achieve this by making the child import fail — inject a stub _run_graph that
+    # forces an OOM-like immediate crash by killing the child process.
+
+    # Use spawn=False and simulate the Empty path by directly exercising the fallback:
+    # When spawn=True but the queue is empty we simulate by calling the private helper.
+    import multiprocessing as mp
+    from queue import Empty
+    from orcheo.sandbox.workflow_runner import run_in_subprocess
+
+    # Patch the mp.Process to simulate a killed child (exitcode < 0).
+    class _FakeProcess:
+        exitcode: int | None = -9
+
+        def start(self) -> None:
+            pass
+
+        def join(self) -> None:
+            pass
+
+    class _EmptyQueue:
+        def get_nowait(self) -> Any:
+            raise Empty()
+
+    original_get_context = mp.get_context
+
+    def _fake_get_context(method: str) -> Any:
+        ctx = original_get_context(method)
+
+        class _PatchedCtx:
+            def Queue(self) -> _EmptyQueue:
+                return _EmptyQueue()  # type: ignore[return-value]
+
+            def Process(self, *, target: Any, args: Any, daemon: bool) -> _FakeProcess:
+                return _FakeProcess()
+
+        return _PatchedCtx()
+
+    import orcheo.sandbox.workflow_runner as runner_module
+
+    original_ctx_fn = runner_module.mp.get_context  # type: ignore[attr-defined]
+    runner_module.mp.get_context = _fake_get_context  # type: ignore[attr-defined]
+    try:
+        result = run_in_subprocess({}, {})
+    finally:
+        runner_module.mp.get_context = original_ctx_fn  # type: ignore[attr-defined]
+
+    assert result["status"] == "failed"
+    assert "signal" in str(result.get("error", "")).lower()
+
+
+def test_run_in_subprocess_handles_clean_exit_with_empty_queue() -> None:
+    """run_in_subprocess surfaces 'exited cleanly without result' for exitcode=0 (lines 270-285)."""
+    import multiprocessing as mp
+    from queue import Empty
+    from orcheo.sandbox.workflow_runner import run_in_subprocess
+
+    class _ZeroExitProcess:
+        exitcode: int | None = 0
+
+        def start(self) -> None:
+            pass
+
+        def join(self) -> None:
+            pass
+
+    class _EmptyQueue:
+        def get_nowait(self) -> Any:
+            raise Empty()
+
+    original_get_context = mp.get_context
+
+    def _fake_get_context(method: str) -> Any:
+        class _PatchedCtx:
+            def Queue(self) -> _EmptyQueue:
+                return _EmptyQueue()  # type: ignore[return-value]
+
+            def Process(
+                self, *, target: Any, args: Any, daemon: bool
+            ) -> _ZeroExitProcess:
+                return _ZeroExitProcess()
+
+        return _PatchedCtx()
+
+    import orcheo.sandbox.workflow_runner as runner_module
+
+    original_ctx_fn = runner_module.mp.get_context  # type: ignore[attr-defined]
+    runner_module.mp.get_context = _fake_get_context  # type: ignore[attr-defined]
+    try:
+        result = run_in_subprocess({}, {})
+    finally:
+        runner_module.mp.get_context = original_ctx_fn  # type: ignore[attr-defined]
+
+    assert result["status"] == "failed"
+    assert "cleanly" in str(result.get("error", ""))
+
+
+def test_run_in_subprocess_handles_nonzero_exit_with_empty_queue() -> None:
+    """run_in_subprocess surfaces exit status when queue is empty and exitcode > 0 (lines 270-285)."""
+    import multiprocessing as mp
+    from queue import Empty
+    from orcheo.sandbox.workflow_runner import run_in_subprocess
+
+    class _NonzeroExitProcess:
+        exitcode: int | None = 42
+
+        def start(self) -> None:
+            pass
+
+        def join(self) -> None:
+            pass
+
+    class _EmptyQueue:
+        def get_nowait(self) -> Any:
+            raise Empty()
+
+    original_get_context = mp.get_context
+
+    def _fake_get_context(method: str) -> Any:
+        class _PatchedCtx:
+            def Queue(self) -> _EmptyQueue:
+                return _EmptyQueue()  # type: ignore[return-value]
+
+            def Process(
+                self, *, target: Any, args: Any, daemon: bool
+            ) -> _NonzeroExitProcess:
+                return _NonzeroExitProcess()
+
+        return _PatchedCtx()
+
+    import orcheo.sandbox.workflow_runner as runner_module
+
+    original_ctx_fn = runner_module.mp.get_context  # type: ignore[attr-defined]
+    runner_module.mp.get_context = _fake_get_context  # type: ignore[attr-defined]
+    try:
+        result = run_in_subprocess({}, {})
+    finally:
+        runner_module.mp.get_context = original_ctx_fn  # type: ignore[attr-defined]
+
+    assert result["status"] == "failed"
+    assert "status 42" in str(result.get("error", ""))
+
+
+def test_run_in_subprocess_handles_still_running_child() -> None:
+    """run_in_subprocess surfaces 'still running' when exitcode is None (lines 270-285)."""
+    import multiprocessing as mp
+    from queue import Empty
+    from orcheo.sandbox.workflow_runner import run_in_subprocess
+
+    class _StillRunningProcess:
+        exitcode: int | None = None
+
+        def start(self) -> None:
+            pass
+
+        def join(self) -> None:
+            pass
+
+    class _EmptyQueue:
+        def get_nowait(self) -> Any:
+            raise Empty()
+
+    original_get_context = mp.get_context
+
+    def _fake_get_context(method: str) -> Any:
+        class _PatchedCtx:
+            def Queue(self) -> _EmptyQueue:
+                return _EmptyQueue()  # type: ignore[return-value]
+
+            def Process(
+                self, *, target: Any, args: Any, daemon: bool
+            ) -> _StillRunningProcess:
+                return _StillRunningProcess()
+
+        return _PatchedCtx()
+
+    import orcheo.sandbox.workflow_runner as runner_module
+
+    original_ctx_fn = runner_module.mp.get_context  # type: ignore[attr-defined]
+    runner_module.mp.get_context = _fake_get_context  # type: ignore[attr-defined]
+    try:
+        result = run_in_subprocess({}, {})
+    finally:
+        runner_module.mp.get_context = original_ctx_fn  # type: ignore[attr-defined]
+
+    assert result["status"] == "failed"
+    assert "still running" in str(result.get("error", ""))
+
+
+# ---------------------------------------------------------------------------
+# _json_default (lines 295, 301-309)
+# ---------------------------------------------------------------------------
+
+
+def test_json_default_calls_model_dump_without_mode_when_type_error() -> None:
+    """_json_default falls back to model_dump() without 'mode' on TypeError (line 295)."""
+    from orcheo.sandbox.workflow_runner import _json_default
+
+    class _PydanticV1Like:
+        def model_dump(self, *, mode: str | None = None) -> dict[str, Any]:
+            if mode is not None:
+                raise TypeError("unexpected keyword argument 'mode'")
+            return {"v1": "data"}
+
+    result = _json_default(_PydanticV1Like())
+    assert result == {"v1": "data"}
+
+
+def test_json_default_serializes_bytes() -> None:
+    """_json_default decodes bytes to string (lines 301-303)."""
+    from orcheo.sandbox.workflow_runner import _json_default
+
+    assert _json_default(b"hello") == "hello"
+    assert _json_default(b"\xff\xfe") == "��"  # replacement chars
+
+
+def test_json_default_serializes_set() -> None:
+    """_json_default converts set to list (lines 304-306)."""
+    from orcheo.sandbox.workflow_runner import _json_default
+
+    result = _json_default({1, 2, 3})
+    assert isinstance(result, list)
+    assert sorted(result) == [1, 2, 3]
+
+
+def test_json_default_serializes_frozenset() -> None:
+    """_json_default converts frozenset to list (lines 304-306)."""
+    from orcheo.sandbox.workflow_runner import _json_default
+
+    result = _json_default(frozenset(["a", "b"]))
+    assert isinstance(result, list)
+    assert sorted(result) == ["a", "b"]
+
+
+def test_json_default_falls_back_to_str() -> None:
+    """_json_default falls back to str() for unrecognised types (lines 307-309)."""
+    from orcheo.sandbox.workflow_runner import _json_default
+
+    class _Opaque:
+        def __repr__(self) -> str:
+            return "opaque-object"
+
+        def __str__(self) -> str:
+            return "opaque-str"
+
+    result = _json_default(_Opaque())
+    assert result == "opaque-str"
+
+
+def test_json_default_serializes_dataclass() -> None:
+    """_json_default returns asdict() for a real dataclass (line 295)."""
+    from dataclasses import dataclass
+    from orcheo.sandbox.workflow_runner import _json_default
+
+    @dataclass
+    class _Point:
+        x: int
+        y: int
+
+    result = _json_default(_Point(x=3, y=7))
+    assert result == {"x": 3, "y": 7}

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -493,7 +493,8 @@ def test_build_credential_broker_resolver_returns_secret(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The inner _resolve_credential finds and returns the matching credential."""
-    from orcheo_backend.app.factory import _build_credential_broker
+    from orcheo_backend.app import sandbox as sandbox_module
+    from orcheo_backend.app.sandbox import build_credential_broker
 
     cred_id = "cred-uuid-1"
     fake_metadata = SimpleNamespace(name="my-secret", id=cred_id)
@@ -501,10 +502,10 @@ def test_build_credential_broker_resolver_returns_secret(
         list_credentials=lambda context, workspace_id: [fake_metadata],
         reveal_secret=lambda credential_id, context: "super-secret-value",
     )
-    monkeypatch.setattr(factory_module, "get_vault", lambda: fake_vault)
+    monkeypatch.setattr(sandbox_module, "get_vault", lambda: fake_vault)
     monkeypatch.setenv("ORCHEO_CREDENTIAL_BROKER_SECRET", "test-secret")
 
-    broker = _build_credential_broker()
+    broker = build_credential_broker()
     token = broker.issue(
         workspace_id="00000000-0000-0000-0000-000000000001", run_id="r1"
     )
@@ -517,20 +518,21 @@ def test_build_credential_broker_resolver_raises_key_error_when_no_match(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The inner _resolve_credential raises KeyError when no credential matches name."""
-    from orcheo_backend.app.factory import _build_credential_broker
     from orcheo.sandbox.broker import BrokerScopeError
+    from orcheo_backend.app import sandbox as sandbox_module
+    from orcheo_backend.app.sandbox import build_credential_broker
 
     # Vault has one credential, but it does NOT match the requested name.
-    # This exercises the `if metadata.name == credential_name:` False branch (193->189).
+    # This exercises the `if metadata.name == credential_name:` False branch.
     other_cred = SimpleNamespace(name="other-secret", id="cred-id-other")
     fake_vault = SimpleNamespace(
         list_credentials=lambda context, workspace_id: [other_cred],
         reveal_secret=lambda credential_id, context: "other-value",
     )
-    monkeypatch.setattr(factory_module, "get_vault", lambda: fake_vault)
+    monkeypatch.setattr(sandbox_module, "get_vault", lambda: fake_vault)
     monkeypatch.setenv("ORCHEO_CREDENTIAL_BROKER_SECRET", "test-secret")
 
-    broker = _build_credential_broker()
+    broker = build_credential_broker()
     token = broker.issue(
         workspace_id="00000000-0000-0000-0000-000000000001", run_id="r2"
     )

--- a/uv.lock
+++ b/uv.lock
@@ -1017,6 +1017,20 @@ wheels = [
 ]
 
 [[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
+]
+
+[[package]]
 name = "docstring-parser"
 version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3573,6 +3587,9 @@ docs = [
 examples = [
     { name = "orcheo-backend" },
 ]
+sandbox-runtime = [
+    { name = "docker" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -3647,6 +3664,7 @@ docs = [
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.28.1" },
 ]
 examples = [{ name = "orcheo-backend", editable = "apps/backend" }]
+sandbox-runtime = [{ name = "docker", specifier = ">=7.0.0" }]
 
 [[package]]
 name = "orcheo-backend"


### PR DESCRIPTION
## Summary
- Add a standalone `sandbox-runtime` service that owns the Docker socket and exposes HTTP endpoints for container lifecycle, one-shot exec, workflow dispatch, and credential relay.
- Update backend and worker workflow execution to use remote sandbox clients, centralize sandbox bootstrap, and default tenant workflow runs to the per-workspace sandbox with an opt-in trusted-node fast path.
- Tighten single-node, evaluation, and training paths so untrusted nodes are rejected outside the sandboxed workflow path.
- Update compose/deploy assets, image build targets, environment variables, docs, and tests for the new isolation model.

## Testing
- Not run (not requested).