### PR TITLE
[codex] Fix multi-arch release image publishing and stack assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,7 +280,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ matrix.image.name }}-${{ matrix.platform.arch }}
+          name: digests-${{ matrix.image.name }}-${{ matrix.platform.arch }}-${{ github.run_attempt }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -305,7 +305,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-${{ matrix.image.name }}-*
+          pattern: digests-${{ matrix.image.name }}-*-${{ github.run_attempt }}
           merge-multiple: true
 
       - name: Set up Docker Buildx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,12 +221,33 @@ jobs:
           echo "canvas_repo=ghcr.io/${owner_lc}/orcheo-canvas" >> "$GITHUB_OUTPUT"
           echo "sandbox_runtime_repo=ghcr.io/${owner_lc}/orcheo-sandbox-runtime" >> "$GITHUB_OUTPUT"
 
-  stack-release:
+  image-build:
     needs: [stack-image-metadata]
-    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - name: stack
+            context: deploy/stack
+            file: deploy/stack/Dockerfile.orcheo
+            repo: ${{ needs.stack-image-metadata.outputs.stack_repo }}
+          - name: canvas
+            context: deploy/stack
+            file: deploy/stack/Dockerfile.canvas
+            repo: ${{ needs.stack-image-metadata.outputs.canvas_repo }}
+          - name: sandbox-runtime
+            context: .
+            file: Dockerfile.sandbox-runtime
+            repo: ${{ needs.stack-image-metadata.outputs.sandbox_runtime_repo }}
+        platform:
+          - runner: ubuntu-latest
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.platform.runner }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -241,26 +262,51 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push stack image
+      - name: Build and push ${{ matrix.image.name }} by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
-          context: deploy/stack
-          file: deploy/stack/Dockerfile.orcheo
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ${{ needs.stack-image-metadata.outputs.stack_repo }}:${{ needs.stack-image-metadata.outputs.version }}
-            ${{ needs.stack-image-metadata.outputs.stack_repo }}:latest
+          context: ${{ matrix.image.context }}
+          file: ${{ matrix.image.file }}
+          platforms: linux/${{ matrix.platform.arch }}
+          outputs: type=image,name=${{ matrix.image.repo }},push-by-digest=true,name-canonical=true,push=true
 
-  canvas-image-release:
-    needs: [stack-image-metadata]
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.image.name }}-${{ matrix.platform.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  image-merge:
+    needs: [stack-image-metadata, image-build]
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+    strategy:
+      matrix:
+        image:
+          - name: stack
+            repo: ${{ needs.stack-image-metadata.outputs.stack_repo }}
+          - name: canvas
+            repo: ${{ needs.stack-image-metadata.outputs.canvas_repo }}
+          - name: sandbox-runtime
+            repo: ${{ needs.stack-image-metadata.outputs.sandbox_runtime_repo }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-${{ matrix.image.name }}-*
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -272,47 +318,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push canvas image
-        uses: docker/build-push-action@v6
-        with:
-          context: deploy/stack
-          file: deploy/stack/Dockerfile.canvas
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ${{ needs.stack-image-metadata.outputs.canvas_repo }}:${{ needs.stack-image-metadata.outputs.version }}
-            ${{ needs.stack-image-metadata.outputs.canvas_repo }}:latest
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          repo="${{ matrix.image.repo }}"
+          version="${{ needs.stack-image-metadata.outputs.version }}"
+          docker buildx imagetools create \
+            -t "${repo}:${version}" \
+            -t "${repo}:latest" \
+            $(printf "${repo}@sha256:%s " *)
 
-  sandbox-runtime-image-release:
-    needs: [stack-image-metadata]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push sandbox-runtime image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile.sandbox-runtime
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ${{ needs.stack-image-metadata.outputs.sandbox_runtime_repo }}:${{ needs.stack-image-metadata.outputs.version }}
-            ${{ needs.stack-image-metadata.outputs.sandbox_runtime_repo }}:latest
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect "${{ matrix.image.repo }}:${{ needs.stack-image-metadata.outputs.version }}"
 
   canvas:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false

--- a/packages/sdk/src/orcheo_sdk/cli/setup.py
+++ b/packages/sdk/src/orcheo_sdk/cli/setup.py
@@ -36,6 +36,7 @@ _STACK_ASSET_FILES = (
     "docker-compose.yml",
     "Caddyfile",
     "Dockerfile.orcheo",
+    "envoy-forward-proxy.yaml",
     ".env.example",
     "chatkit_widgets/Single-choice list.widget",
     "chatkit_widgets/Multi-choice Selector.widget",
@@ -943,7 +944,7 @@ def _resolve_chatkit_domain_key(
         return None
     return _normalize_optional_value(
         typer.prompt(
-            "ChatKit domain key (VITE_ORCHEO_CHATKIT_DOMAIN_KEY, Enter to skip)",
+            "ChatKit domain key (Enter to skip)",
             default="",
             show_default=False,
         )

--- a/tests/sdk/test_cli_setup_stack_assets.py
+++ b/tests/sdk/test_cli_setup_stack_assets.py
@@ -103,6 +103,7 @@ def _default_assets() -> dict[str, bytes]:
         "docker-compose.yml": b"services: {}\n",
         "Caddyfile": b'localhost { respond "ok" }\n',
         "Dockerfile.orcheo": b"FROM python:3.12-slim\n",
+        "envoy-forward-proxy.yaml": b"static_resources: {}\n",
         ".env.example": _ENV_EXAMPLE,
         "chatkit_widgets/Single-choice list.widget": b"single",
         "chatkit_widgets/Multi-choice Selector.widget": b"multi",


### PR DESCRIPTION
## What changed
- Reworked the CI image release jobs into a build-and-merge flow that builds `stack`, `canvas`, and `sandbox-runtime` images on native amd64/arm64 runners, uploads per-arch digests, and assembles versioned plus `latest` manifest lists.
- Added `envoy-forward-proxy.yaml` to the stack setup asset bundle so generated stack artifacts include the proxy config.
- Simplified the ChatKit domain key prompt copy to remove the env-var-specific wording.

## Why
- Native-architecture builds and manifest assembly make multi-arch image publishing more reliable.
- The stack setup assets were missing the envoy proxy configuration, which could leave generated bundles incomplete.

## Validation
- Not run locally. These are workflow and packaging metadata changes only.