### PR TITLE
Fix workspace-sandbox provisioning in prod deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,7 @@ jobs:
       stack_repo: ${{ steps.meta.outputs.stack_repo }}
       canvas_repo: ${{ steps.meta.outputs.canvas_repo }}
       sandbox_runtime_repo: ${{ steps.meta.outputs.sandbox_runtime_repo }}
+      workspace_sandbox_repo: ${{ steps.meta.outputs.workspace_sandbox_repo }}
     steps:
       - name: Determine image metadata
         id: meta
@@ -220,6 +221,7 @@ jobs:
           echo "stack_repo=ghcr.io/${owner_lc}/orcheo-stack" >> "$GITHUB_OUTPUT"
           echo "canvas_repo=ghcr.io/${owner_lc}/orcheo-canvas" >> "$GITHUB_OUTPUT"
           echo "sandbox_runtime_repo=ghcr.io/${owner_lc}/orcheo-sandbox-runtime" >> "$GITHUB_OUTPUT"
+          echo "workspace_sandbox_repo=ghcr.io/${owner_lc}/orcheo-workspace-sandbox" >> "$GITHUB_OUTPUT"
 
   image-build:
     needs: [stack-image-metadata]
@@ -242,6 +244,10 @@ jobs:
             context: .
             file: Dockerfile.sandbox-runtime
             repo: ${{ needs.stack-image-metadata.outputs.sandbox_runtime_repo }}
+          - name: workspace-sandbox
+            context: .
+            file: Dockerfile.workspace-sandbox
+            repo: ${{ needs.stack-image-metadata.outputs.workspace_sandbox_repo }}
         platform:
           - runner: ubuntu-latest
             arch: amd64
@@ -300,6 +306,8 @@ jobs:
             repo: ${{ needs.stack-image-metadata.outputs.canvas_repo }}
           - name: sandbox-runtime
             repo: ${{ needs.stack-image-metadata.outputs.sandbox_runtime_repo }}
+          - name: workspace-sandbox
+            repo: ${{ needs.stack-image-metadata.outputs.workspace_sandbox_repo }}
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4

--- a/deploy/stack/.env.example
+++ b/deploy/stack/.env.example
@@ -47,7 +47,9 @@ ORCHEO_SANDBOX_RUNTIME_URL=http://sandbox-runtime:9090
 # Override here only when this env file is used against a non-default host.
 ORCHEO_CONTAINER_RUNTIME=runsc
 # OCI image hosting agent CLIs, the Orcheo CLI, and the workflow runner.
-ORCHEO_SANDBOX_IMAGE=orcheo/workspace-sandbox:latest
+# Published by CI to GHCR on `stack-v*` tags; sandbox-runtime pulls it on
+# first use. Override to a locally-built tag if you build it from source.
+ORCHEO_SANDBOX_IMAGE=ghcr.io/ai-colleagues/orcheo-workspace-sandbox:latest
 # When `true`, workflows composed only of trusted built-in nodes skip the
 # sandbox (faster cold-start). Vibe agents always run sandboxed regardless.
 ORCHEO_SANDBOX_FAST_PATH_TRUSTED=false

--- a/deploy/stack/docker-compose.yml
+++ b/deploy/stack/docker-compose.yml
@@ -64,7 +64,7 @@ services:
       # Backend/worker embed this image name in every ContainerSpec they send
       # to sandbox-runtime, so it must match the image sandbox-runtime is
       # allowed to spawn.
-      ORCHEO_SANDBOX_IMAGE: ${ORCHEO_SANDBOX_IMAGE:-orcheo/workspace-sandbox:latest}
+      ORCHEO_SANDBOX_IMAGE: ${ORCHEO_SANDBOX_IMAGE:-ghcr.io/ai-colleagues/orcheo-workspace-sandbox:latest}
       ORCHEO_CONTAINER_RUNTIME: ${ORCHEO_CONTAINER_RUNTIME:-runsc}
       ORCHEO_MCP_STDIO_LOG: /dev/stderr
       PYTHONUNBUFFERED: "1"
@@ -117,7 +117,7 @@ services:
       # Backend/worker embed this image name in every ContainerSpec they send
       # to sandbox-runtime, so it must match the image sandbox-runtime is
       # allowed to spawn.
-      ORCHEO_SANDBOX_IMAGE: ${ORCHEO_SANDBOX_IMAGE:-orcheo/workspace-sandbox:latest}
+      ORCHEO_SANDBOX_IMAGE: ${ORCHEO_SANDBOX_IMAGE:-ghcr.io/ai-colleagues/orcheo-workspace-sandbox:latest}
       ORCHEO_CONTAINER_RUNTIME: ${ORCHEO_CONTAINER_RUNTIME:-runsc}
       ORCHEO_MCP_STDIO_LOG: /dev/stderr
       PYTHONUNBUFFERED: "1"
@@ -222,7 +222,7 @@ services:
       - sandbox_scratch:/scratch
     environment:
       ORCHEO_CONTAINER_RUNTIME: ${ORCHEO_CONTAINER_RUNTIME:-runsc}
-      ORCHEO_SANDBOX_IMAGE: ${ORCHEO_SANDBOX_IMAGE:-orcheo/workspace-sandbox:latest}
+      ORCHEO_SANDBOX_IMAGE: ${ORCHEO_SANDBOX_IMAGE:-ghcr.io/ai-colleagues/orcheo-workspace-sandbox:latest}
       ORCHEO_EGRESS_PROXY_URL: http://egress-proxy:3128
       ORCHEO_CREDENTIAL_BROKER_URL: http://backend:2025/internal/credentials/resolve
       ORCHEO_CREDENTIAL_BROKER_SECRET: ${ORCHEO_CREDENTIAL_BROKER_SECRET:?set ORCHEO_CREDENTIAL_BROKER_SECRET}

--- a/docs/operators/workspace_runtime_isolation.md
+++ b/docs/operators/workspace_runtime_isolation.md
@@ -14,14 +14,17 @@ For background, see the initiative documents under
 1. A Linux host with the `runsc` (gVisor) Docker runtime registered. On
    standard EC2 (no `/dev/kvm`) gVisor's `systrap` platform is required.
 2. `nftables` available on the host so the L3/L4 deny ruleset can be loaded.
-3. The `orcheo/workspace-sandbox:latest` image must be available to the
-   Docker daemon that `sandbox-runtime` talks to. `docker compose up -d`
-   builds it as part of bringing the stack up; you can also rebuild just
-   that image with `make workspace-sandbox-build` after editing
-   `Dockerfile.workspace-sandbox`. Alternatively, push a tagged version
-   to a registry the host can pull from and point `ORCHEO_SANDBOX_IMAGE`
-   at it. One sandbox image hosts both vibe agent sessions and tenant
-   workflow runs per workspace.
+3. The workspace-sandbox image must be available to the Docker daemon that
+   `sandbox-runtime` talks to. The deploy stack defaults
+   `ORCHEO_SANDBOX_IMAGE` to
+   `ghcr.io/ai-colleagues/orcheo-workspace-sandbox:latest`, which CI
+   publishes on `stack-v*` tags alongside the other stack images;
+   `sandbox-runtime` pulls it on first use. For local development the root
+   `docker compose up -d` builds it from `Dockerfile.workspace-sandbox`
+   instead (rebuild just that image with `make workspace-sandbox-build`).
+   You can also push your own tagged build to a registry the host can pull
+   from and point `ORCHEO_SANDBOX_IMAGE` at it. One sandbox image hosts both
+   vibe agent sessions and tenant workflow runs per workspace.
 
 ## Configuration
 
@@ -32,7 +35,7 @@ override:
 | Variable                              | Default                                                                | Purpose                                                  |
 |---------------------------------------|------------------------------------------------------------------------|----------------------------------------------------------|
 | `ORCHEO_CONTAINER_RUNTIME`            | `runsc`                                                                | Docker runtime name (`runsc` for gVisor).                |
-| `ORCHEO_SANDBOX_IMAGE`                | `orcheo/workspace-sandbox:latest`                                      | Image hosting agent CLIs, Orcheo CLI, and workflow runner. |
+| `ORCHEO_SANDBOX_IMAGE`                | `ghcr.io/ai-colleagues/orcheo-workspace-sandbox:latest`                | Image hosting agent CLIs, Orcheo CLI, and workflow runner. Pulled from GHCR in prod; built locally by the dev compose. |
 | `ORCHEO_SANDBOX_RUNTIME_URL`          | `http://sandbox-runtime:9090`                                          | Internal URL of the sandbox-runtime service. Backend and worker call this to provision sandboxes and dispatch runs — they never mount the Docker socket themselves. |
 | `ORCHEO_EGRESS_PROXY_URL`             | `http://egress-proxy:3128`                                             | Envoy forward proxy for permitted HTTP/HTTPS.            |
 | `ORCHEO_CREDENTIAL_BROKER_URL`        | `http://sandbox-runtime:9090/credentials/resolve`                      | Endpoint workspace sandboxes use to resolve run-scoped credentials. The `sandbox-runtime` service overrides this to the backend broker upstream. |

--- a/packages/sdk/src/orcheo_sdk/cli/setup.py
+++ b/packages/sdk/src/orcheo_sdk/cli/setup.py
@@ -560,6 +560,129 @@ def _attempt_docker_autoinstall(*, console: Console) -> bool:
     return installer(console=console)
 
 
+# Pipelines run as root via `sh -c` so the apt key + source list land in the
+# locations the official gVisor install docs use.
+_GVISOR_KEYRING_COMMAND = (
+    "curl -fsSL https://gvisor.dev/archive.key | "
+    "gpg --dearmor -o /usr/share/keyrings/gvisor-archive-keyring.gpg"
+)
+_GVISOR_SOURCES_COMMAND = (
+    'echo "deb [arch=$(dpkg --print-architecture) '
+    "signed-by=/usr/share/keyrings/gvisor-archive-keyring.gpg] "
+    'https://storage.googleapis.com/gvisor/releases release main" '
+    "> /etc/apt/sources.list.d/gvisor.list"
+)
+
+
+def _docker_runtimes(*, use_privileged: bool) -> set[str] | None:
+    """Return the runtime names Docker has registered, or None if unknown."""
+    docker_command = _docker_command()
+    if docker_command is None:
+        return None
+    command = [*docker_command, "info", "--format", "{{json .Runtimes}}"]
+    if use_privileged and os.geteuid() != 0:
+        if not _has_binary("sudo"):
+            return None
+        command = ["sudo", *command]
+    result = subprocess.run(command, check=False, capture_output=True, text=True)
+    if result.returncode != 0:
+        return None
+    try:
+        data = json.loads(result.stdout.strip() or "{}")
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    return set(data.keys())
+
+
+def _attempt_linux_gvisor_autoinstall(*, console: Console) -> bool:
+    if not _is_supported_docker_autoinstall_linux():
+        console.print(
+            "[yellow]Automatic gVisor installation currently supports apt-based "
+            "Ubuntu/Debian systems on Linux. Install runsc manually or set "
+            "ORCHEO_CONTAINER_RUNTIME=runc.[/yellow]"
+        )
+        return False
+    if not _has_binary("apt-get"):
+        console.print(
+            "[yellow]Automatic gVisor installation currently supports apt-based "
+            "Ubuntu/Debian systems on Linux.[/yellow]"
+        )
+        return False
+
+    try:
+        _run_privileged_command(["apt-get", "update"], console=console)
+        _run_privileged_command(
+            [
+                "apt-get",
+                "install",
+                "-y",
+                "--no-install-recommends",
+                "ca-certificates",
+                "curl",
+                "gnupg",
+            ],
+            console=console,
+        )
+        _run_privileged_command(["sh", "-c", _GVISOR_KEYRING_COMMAND], console=console)
+        _run_privileged_command(["sh", "-c", _GVISOR_SOURCES_COMMAND], console=console)
+        _run_privileged_command(["apt-get", "update"], console=console)
+        _run_privileged_command(["apt-get", "install", "-y", "runsc"], console=console)
+        # `runsc install` registers the runtime in /etc/docker/daemon.json; the
+        # daemon must be restarted to pick it up.
+        _run_privileged_command(["runsc", "install"], console=console)
+        _run_privileged_command(["systemctl", "restart", "docker"], console=console)
+    except (typer.BadParameter, FileNotFoundError) as exc:
+        console.print(
+            "[yellow]Automatic gVisor installation failed: "
+            f"{exc}. The stack will start, but sandboxed workflows will fail "
+            "until runsc is installed and registered with Docker.[/yellow]"
+        )
+        return False
+
+    if not _has_binary("runsc"):
+        console.print(
+            "[yellow]gVisor installation completed but the runsc binary is still "
+            "not available in PATH.[/yellow]"
+        )
+        return False
+    return True
+
+
+def _ensure_gvisor_runtime(
+    config: SetupConfig,
+    *,
+    env_file: Path,
+    use_privileged_docker: bool,
+    console: Console,
+) -> None:
+    """Install + register gVisor when the stack is configured to use runsc."""
+    runtime = _read_env_value(env_file, "ORCHEO_CONTAINER_RUNTIME") or "runsc"
+    if runtime != "runsc":
+        return
+    if not config.install_docker_if_missing:
+        return
+    if platform.system() != "Linux":
+        console.print(
+            "[yellow]ORCHEO_CONTAINER_RUNTIME=runsc, but gVisor only runs on "
+            "Linux. Set ORCHEO_CONTAINER_RUNTIME=runc for a local Docker Desktop "
+            "host, or run sandboxes on a Linux host.[/yellow]"
+        )
+        return
+
+    runtimes = _docker_runtimes(use_privileged=use_privileged_docker)
+    if runtimes is not None and "runsc" in runtimes:
+        return
+
+    console.print(
+        "[cyan]ORCHEO_CONTAINER_RUNTIME=runsc but the runsc runtime is not "
+        "registered with Docker. Attempting automatic gVisor installation..."
+        "[/cyan]"
+    )
+    _attempt_linux_gvisor_autoinstall(console=console)
+
+
 def _resolve_mode(
     mode: SetupMode | None, *, yes: bool, env_exists: bool = False
 ) -> SetupMode:
@@ -577,6 +700,7 @@ def _resolve_backend_url(
     *,
     mode: SetupMode,
     yes: bool,
+    env_file: Path | None = None,
     env_exists: bool = False,
     default_backend_url: str = "http://localhost:2025",
     preserve_existing_default: bool = True,
@@ -586,14 +710,16 @@ def _resolve_backend_url(
     if preserve_existing_default and (mode == "upgrade" or env_exists):
         if yes:
             return default_backend_url, True
-        selected = _normalize_optional_value(
-            typer.prompt(
-                "Backend URL (Enter to keep existing)",
-                default="",
-                show_default=False,
-            )
+        existing = (
+            _read_env_value(env_file, "ORCHEO_API_URL")
+            if env_file is not None
+            else None
         )
-        if selected is None:
+        prompt_default = existing or default_backend_url
+        selected = _normalize_optional_value(
+            typer.prompt("Backend URL", default=prompt_default)
+        )
+        if selected is None or selected == existing:
             return default_backend_url, True
         return selected, False
     if yes:
@@ -1468,6 +1594,7 @@ def run_setup(
         backend_url,
         mode=resolved_mode,
         yes=yes,
+        env_file=stack_env_file,
         env_exists=has_existing_stack_env,
         default_backend_url=default_backend_url,
         preserve_existing_default=preserve_existing_backend_default,
@@ -1707,6 +1834,14 @@ def execute_setup(
     _, use_privileged_docker = _prepare_stack_start(config, console=console)
 
     if config.start_stack and _has_binary("docker"):
+        # Register gVisor before `compose up` — `runsc install` restarts the
+        # Docker daemon, which would otherwise bounce freshly-started services.
+        _ensure_gvisor_runtime(
+            config,
+            env_file=env_file,
+            use_privileged_docker=use_privileged_docker,
+            console=console,
+        )
         compose_args = _compose_args(stack_dir)
         command_runner = (
             _run_privileged_command if use_privileged_docker else _run_command

--- a/packages/sdk/src/orcheo_sdk/cli/setup.py
+++ b/packages/sdk/src/orcheo_sdk/cli/setup.py
@@ -712,7 +712,7 @@ def _resolve_backend_url(
             return default_backend_url, True
         existing = (
             _read_env_value(env_file, "ORCHEO_API_URL")
-            if env_file is not None
+            if env_file is not None and env_exists
             else None
         )
         prompt_default = existing or default_backend_url

--- a/src/orcheo/sandbox/config.py
+++ b/src/orcheo/sandbox/config.py
@@ -38,7 +38,7 @@ class SandboxSettings(BaseModel):
         ),
     )
     image: str = Field(
-        default="orcheo/workspace-sandbox:latest",
+        default="ghcr.io/ai-colleagues/orcheo-workspace-sandbox:latest",
         description=(
             "OCI image hosting the agent CLIs, Orcheo CLI, and workflow "
             "runner. One image per workspace sandbox."

--- a/src/orcheo/sandbox/runtime.py
+++ b/src/orcheo/sandbox/runtime.py
@@ -138,7 +138,7 @@ class DockerContainerRuntime:
     def start(self, spec: ContainerSpec) -> ContainerHandle:
         """Spawn a Docker container that satisfies ``spec``."""
         client = self._ensure_client()
-        self._require_local_image(client, spec.image)
+        self._ensure_image_present(client, spec.image)
         host_config = self._build_host_config(spec)
         cmd = list(spec.command) if spec.command else None
         try:
@@ -170,18 +170,21 @@ class DockerContainerRuntime:
         )
 
     @staticmethod
-    def _require_local_image(client: object, image: str) -> None:
-        """Fail fast if ``image`` isn't built locally.
+    def _ensure_image_present(client: object, image: str) -> None:
+        """Ensure ``image`` is on the daemon, pulling it if necessary.
 
-        ``client.containers.run`` quietly attempts a registry pull when the
-        image is missing — but ``orcheo/workspace-sandbox`` is a local-only
-        image (built via ``make docker-build``), so the implicit pull always
-        fails with a confusing "pull access denied" message. Catching the
-        absence here turns that into an actionable error pointing the
-        operator at the build target.
+        The workspace-sandbox image is published to the registry (CI pushes
+        ``ghcr.io/<owner>/orcheo-workspace-sandbox`` on ``stack-v*`` tags), so
+        a missing image is recoverable: we pull it explicitly. Doing the pull
+        here — rather than relying on the implicit pull inside
+        ``client.containers.run`` — lets us surface a single actionable error
+        that covers both the pull-failed case (registry access / wrong tag)
+        and the local-build fallback, instead of Docker's bare
+        "pull access denied".
         """
         try:
             client.images.get(image)  # type: ignore[attr-defined]
+            return
         except Exception as exc:  # noqa: BLE001 — translate any docker SDK error
             message = str(exc).lower()
             if "not found" not in message and "no such image" not in message:
@@ -190,11 +193,18 @@ class DockerContainerRuntime:
                 # outer try/except already routes it through the daemon-runtime
                 # diagnostic helper.
                 return
+
+        try:
+            client.images.pull(image)  # type: ignore[attr-defined]
+        except Exception as exc:  # noqa: BLE001 — translate any docker SDK error
             msg = (
                 f"Workspace sandbox image {image!r} is not present on the "
-                "Docker daemon. The image is local-only and cannot be pulled "
-                "from a registry. Run `make docker-build` (or "
-                "`docker compose build workspace-sandbox`) and try again."
+                "Docker daemon and could not be pulled. Ensure the image is "
+                "published to the configured registry (CI publishes "
+                "`ghcr.io/<owner>/orcheo-workspace-sandbox` on `stack-v*` "
+                "tags) and that ORCHEO_SANDBOX_IMAGE points at it, or build it "
+                "locally with `make docker-build` (or `docker compose build "
+                "workspace-sandbox`) and try again."
             )
             raise RuntimeError(msg) from exc
 

--- a/tests/sandbox/test_config.py
+++ b/tests/sandbox/test_config.py
@@ -58,7 +58,7 @@ def test_from_mapping_ignores_blank_and_missing_values() -> None:
     settings = SandboxSettings.from_mapping(source)
 
     assert settings.container_runtime == "runsc"
-    assert settings.image.startswith("orcheo/workspace-sandbox")
+    assert settings.image.endswith("orcheo-workspace-sandbox:latest")
 
 
 def test_from_env_reads_process_environment(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/sandbox/test_runtime.py
+++ b/tests/sandbox/test_runtime.py
@@ -82,6 +82,8 @@ class _FakeImages:
 
     def __init__(self) -> None:
         self._missing: set[str] = set()
+        self._pullable: set[str] = set()
+        self.pulled: list[str] = []
 
     def get(self, image: str) -> _FakeImage:
         """Return a fake image or raise to mimic the SDK's ``ImageNotFound``."""
@@ -90,9 +92,20 @@ class _FakeImages:
             raise RuntimeError(msg)
         return _FakeImage(image)
 
-    def forget(self, image: str) -> None:
-        """Mark ``image`` as missing for the next ``get`` call."""
+    def pull(self, image: str) -> _FakeImage:
+        """Mimic ``client.images.pull`` for registry-hosted images."""
+        self.pulled.append(image)
+        if image in self._pullable:
+            self._missing.discard(image)
+            return _FakeImage(image)
+        msg = f"pull access denied for {image}"
+        raise RuntimeError(msg)
+
+    def forget(self, image: str, *, pullable: bool = False) -> None:
+        """Mark ``image`` as missing locally; ``pullable`` allows a pull."""
         self._missing.add(image)
+        if pullable:
+            self._pullable.add(image)
 
 
 class _FakeClient:
@@ -137,25 +150,38 @@ def test_docker_runtime_start_passes_through_security_flags() -> None:
     }
 
 
-def test_docker_runtime_start_raises_actionable_error_when_image_missing() -> None:
-    """start() must point operators at ``make docker-build`` when the image
-    isn't on the daemon, instead of letting the docker SDK silently attempt a
-    registry pull and surface ``pull access denied``."""
+def test_docker_runtime_start_raises_actionable_error_when_pull_fails() -> None:
+    """start() must surface an actionable error when the image is absent and
+    can't be pulled, naming both the registry and the local-build fallback."""
     client = _FakeClient()
-    client.images.forget("orcheo/workspace-sandbox:latest")
+    client.images.forget("ghcr.io/ai-colleagues/orcheo-workspace-sandbox:latest")
     runtime = DockerContainerRuntime(client=client)
     spec = ContainerSpec(
-        image="orcheo/workspace-sandbox:latest",
+        image="ghcr.io/ai-colleagues/orcheo-workspace-sandbox:latest",
         workspace_id="W",
     )
     with pytest.raises(RuntimeError) as excinfo:
         runtime.start(spec)
     message = str(excinfo.value)
+    assert "orcheo-workspace-sandbox" in message
     assert "make docker-build" in message
-    assert "docker compose build workspace-sandbox" in message
-    # The container.run call must not have fired — we fail fast before the
-    # implicit registry pull.
+    # The pull was attempted, but the container.run call must not have fired.
+    assert client.images.pulled == [
+        "ghcr.io/ai-colleagues/orcheo-workspace-sandbox:latest"
+    ]
     assert client.containers.runs == []
+
+
+def test_docker_runtime_start_pulls_missing_image_then_runs() -> None:
+    """start() pulls a missing-but-published image and proceeds to run it."""
+    client = _FakeClient()
+    image = "ghcr.io/ai-colleagues/orcheo-workspace-sandbox:latest"
+    client.images.forget(image, pullable=True)
+    runtime = DockerContainerRuntime(client=client)
+    handle = runtime.start(ContainerSpec(image=image, workspace_id="W"))
+    assert client.images.pulled == [image]
+    assert len(client.containers.runs) == 1
+    assert handle.image == image
 
 
 def test_docker_runtime_stop_kills_and_removes_container() -> None:
@@ -318,20 +344,25 @@ def test_docker_runtime_translates_runtime_error_without_info() -> None:
     assert "ORCHEO_CONTAINER_RUNTIME" in message
 
 
-def test_require_local_image_passes_through_non_notfound_errors() -> None:
-    """_require_local_image returns (does not raise) for non-'not found' image errors (line 192)."""
+def test_ensure_image_present_passes_through_non_notfound_errors() -> None:
+    """_ensure_image_present returns (does not raise, and does not pull) for
+    non-'not found' image errors so daemon-connectivity issues bubble up via
+    start()'s outer handler."""
 
     class _FakeImages:
         def get(self, image: str) -> object:
             # A non-"not found" error (e.g. daemon connectivity issue).
             raise RuntimeError("connection refused to docker daemon")
 
+        def pull(self, image: str) -> object:
+            raise AssertionError("pull must not be attempted on daemon errors")
+
     class _FakeClientConnErr:
         def __init__(self) -> None:
             self.images = _FakeImages()
 
     # The method should return (not raise) for non-missing-image errors.
-    DockerContainerRuntime._require_local_image(
+    DockerContainerRuntime._ensure_image_present(
         _FakeClientConnErr(), "orcheo/workspace-sandbox:latest"
     )
     # If we reach here without an exception the branch is covered.

--- a/tests/sdk/test_cli_setup_extra.py
+++ b/tests/sdk/test_cli_setup_extra.py
@@ -439,3 +439,220 @@ def test_attempt_docker_autoinstall_unknown_platform(
 ) -> None:
     monkeypatch.setattr(setup_mod.platform, "system", lambda: "FreeBSD")
     assert not setup_mod._attempt_docker_autoinstall(console=Console())
+
+
+def _gvisor_config(**overrides: object) -> setup_mod.SetupConfig:
+    base: dict[str, object] = {
+        "mode": "install",
+        "backend_url": "http://localhost:2025",
+        "studio_url": "http://localhost:2026",
+        "auth_mode": "api-key",
+        "api_key": "key",
+        "chatkit_domain_key": None,
+        "public_ingress_enabled": False,
+        "public_host": None,
+        "publish_local_ports": True,
+        "backend_upstreams": "backend:2025",
+        "canvas_upstream": "canvas:2026",
+        "start_stack": True,
+        "install_docker_if_missing": True,
+    }
+    base.update(overrides)
+    return setup_mod.SetupConfig(**base)  # type: ignore[arg-type]
+
+
+def test_attempt_linux_gvisor_autoinstall_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    commands: list[list[str]] = []
+
+    monkeypatch.setattr(
+        setup_mod, "_is_supported_docker_autoinstall_linux", lambda: True
+    )
+    monkeypatch.setattr(
+        setup_mod, "_has_binary", lambda name: name in {"apt-get", "runsc"}
+    )
+    monkeypatch.setattr(
+        setup_mod,
+        "_run_privileged_command",
+        lambda command, *, console: commands.append(command),
+    )
+
+    assert setup_mod._attempt_linux_gvisor_autoinstall(console=Console())
+    assert ["apt-get", "install", "-y", "runsc"] in commands
+    assert ["runsc", "install"] in commands
+    assert ["systemctl", "restart", "docker"] in commands
+
+
+def test_attempt_linux_gvisor_autoinstall_warns_when_runsc_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        setup_mod, "_is_supported_docker_autoinstall_linux", lambda: True
+    )
+    monkeypatch.setattr(setup_mod, "_has_binary", lambda name: name == "apt-get")
+    monkeypatch.setattr(
+        setup_mod, "_run_privileged_command", lambda command, *, console: None
+    )
+
+    console = Console(file=io.StringIO(), force_terminal=False)
+    assert not setup_mod._attempt_linux_gvisor_autoinstall(console=console)
+    assert "runsc binary is still not available" in console.file.getvalue()
+
+
+def test_attempt_linux_gvisor_autoinstall_unsupported_platform(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        setup_mod, "_is_supported_docker_autoinstall_linux", lambda: False
+    )
+    console = Console(file=io.StringIO(), force_terminal=False)
+    assert not setup_mod._attempt_linux_gvisor_autoinstall(console=console)
+    assert "apt-based" in console.file.getvalue()
+
+
+def test_ensure_gvisor_runtime_skips_for_runc(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text("ORCHEO_CONTAINER_RUNTIME=runc\n", encoding="utf-8")
+    called: list[bool] = []
+    monkeypatch.setattr(
+        setup_mod,
+        "_attempt_linux_gvisor_autoinstall",
+        lambda *, console: called.append(True) or True,
+    )
+
+    setup_mod._ensure_gvisor_runtime(
+        _gvisor_config(),
+        env_file=env_file,
+        use_privileged_docker=False,
+        console=Console(),
+    )
+    assert called == []
+
+
+def test_ensure_gvisor_runtime_skips_when_already_registered(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text("ORCHEO_CONTAINER_RUNTIME=runsc\n", encoding="utf-8")
+    called: list[bool] = []
+    monkeypatch.setattr(setup_mod.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(
+        setup_mod, "_docker_runtimes", lambda *, use_privileged: {"runc", "runsc"}
+    )
+    monkeypatch.setattr(
+        setup_mod,
+        "_attempt_linux_gvisor_autoinstall",
+        lambda *, console: called.append(True) or True,
+    )
+
+    setup_mod._ensure_gvisor_runtime(
+        _gvisor_config(),
+        env_file=env_file,
+        use_privileged_docker=False,
+        console=Console(),
+    )
+    assert called == []
+
+
+def test_ensure_gvisor_runtime_installs_when_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text("ORCHEO_CONTAINER_RUNTIME=runsc\n", encoding="utf-8")
+    called: list[bool] = []
+    monkeypatch.setattr(setup_mod.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(
+        setup_mod, "_docker_runtimes", lambda *, use_privileged: {"runc"}
+    )
+    monkeypatch.setattr(
+        setup_mod,
+        "_attempt_linux_gvisor_autoinstall",
+        lambda *, console: called.append(True) or True,
+    )
+
+    setup_mod._ensure_gvisor_runtime(
+        _gvisor_config(),
+        env_file=env_file,
+        use_privileged_docker=False,
+        console=Console(),
+    )
+    assert called == [True]
+
+
+def test_ensure_gvisor_runtime_warns_on_non_linux(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text("ORCHEO_CONTAINER_RUNTIME=runsc\n", encoding="utf-8")
+    called: list[bool] = []
+    monkeypatch.setattr(setup_mod.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(
+        setup_mod,
+        "_attempt_linux_gvisor_autoinstall",
+        lambda *, console: called.append(True) or True,
+    )
+
+    console = Console(file=io.StringIO(), force_terminal=False)
+    setup_mod._ensure_gvisor_runtime(
+        _gvisor_config(),
+        env_file=env_file,
+        use_privileged_docker=False,
+        console=console,
+    )
+    assert called == []
+    assert "only runs on" in console.file.getvalue()
+
+
+def test_docker_runtimes_parses_info_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(setup_mod, "_docker_command", lambda: ["docker"])
+
+    class _Result:
+        returncode = 0
+        stdout = '{"runc": {}, "runsc": {}}'
+
+    monkeypatch.setattr(setup_mod.subprocess, "run", lambda *a, **k: _Result())
+    assert setup_mod._docker_runtimes(use_privileged=False) == {"runc", "runsc"}
+
+
+def test_docker_runtimes_returns_none_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(setup_mod, "_docker_command", lambda: ["docker"])
+
+    class _Result:
+        returncode = 1
+        stdout = ""
+
+    monkeypatch.setattr(setup_mod.subprocess, "run", lambda *a, **k: _Result())
+    assert setup_mod._docker_runtimes(use_privileged=False) is None
+
+
+def test_docker_runtimes_none_when_docker_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(setup_mod, "_docker_command", lambda: None)
+    assert setup_mod._docker_runtimes(use_privileged=False) is None
+
+
+def test_ensure_gvisor_runtime_respects_skip_docker_install(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text("ORCHEO_CONTAINER_RUNTIME=runsc\n", encoding="utf-8")
+    called: list[bool] = []
+    monkeypatch.setattr(
+        setup_mod,
+        "_attempt_linux_gvisor_autoinstall",
+        lambda *, console: called.append(True) or True,
+    )
+
+    setup_mod._ensure_gvisor_runtime(
+        _gvisor_config(install_docker_if_missing=False),
+        env_file=env_file,
+        use_privileged_docker=False,
+        console=Console(),
+    )
+    assert called == []

--- a/tests/sdk/test_cli_setup_extra.py
+++ b/tests/sdk/test_cli_setup_extra.py
@@ -637,6 +637,93 @@ def test_docker_runtimes_none_when_docker_missing(
     assert setup_mod._docker_runtimes(use_privileged=False) is None
 
 
+def test_docker_runtimes_none_when_privileged_without_sudo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(setup_mod, "_docker_command", lambda: ["docker"])
+    monkeypatch.setattr(setup_mod.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(setup_mod, "_has_binary", lambda name: False)
+    assert setup_mod._docker_runtimes(use_privileged=True) is None
+
+
+def test_docker_runtimes_prepends_sudo_when_privileged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(setup_mod, "_docker_command", lambda: ["docker"])
+    monkeypatch.setattr(setup_mod.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(setup_mod, "_has_binary", lambda name: name == "sudo")
+    captured: list[list[str]] = []
+
+    class _Result:
+        returncode = 0
+        stdout = '{"runc": {}}'
+
+    def _run(command: list[str], *a: object, **k: object) -> _Result:
+        captured.append(command)
+        return _Result()
+
+    monkeypatch.setattr(setup_mod.subprocess, "run", _run)
+    assert setup_mod._docker_runtimes(use_privileged=True) == {"runc"}
+    assert captured[0][0] == "sudo"
+
+
+def test_docker_runtimes_none_on_invalid_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(setup_mod, "_docker_command", lambda: ["docker"])
+
+    class _Result:
+        returncode = 0
+        stdout = "not-json"
+
+    monkeypatch.setattr(setup_mod.subprocess, "run", lambda *a, **k: _Result())
+    assert setup_mod._docker_runtimes(use_privileged=False) is None
+
+
+def test_docker_runtimes_none_when_json_not_dict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(setup_mod, "_docker_command", lambda: ["docker"])
+
+    class _Result:
+        returncode = 0
+        stdout = "[]"
+
+    monkeypatch.setattr(setup_mod.subprocess, "run", lambda *a, **k: _Result())
+    assert setup_mod._docker_runtimes(use_privileged=False) is None
+
+
+def test_attempt_linux_gvisor_autoinstall_warns_when_apt_get_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        setup_mod, "_is_supported_docker_autoinstall_linux", lambda: True
+    )
+    monkeypatch.setattr(setup_mod, "_has_binary", lambda name: False)
+
+    console = Console(file=io.StringIO(), force_terminal=False)
+    assert not setup_mod._attempt_linux_gvisor_autoinstall(console=console)
+    assert "apt-based" in console.file.getvalue()
+
+
+def test_attempt_linux_gvisor_autoinstall_handles_command_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        setup_mod, "_is_supported_docker_autoinstall_linux", lambda: True
+    )
+    monkeypatch.setattr(setup_mod, "_has_binary", lambda name: name == "apt-get")
+
+    def _fail(command: list[str], *, console: Console) -> None:
+        raise typer.BadParameter("boom")
+
+    monkeypatch.setattr(setup_mod, "_run_privileged_command", _fail)
+
+    console = Console(file=io.StringIO(), force_terminal=False)
+    assert not setup_mod._attempt_linux_gvisor_autoinstall(console=console)
+    assert "Automatic gVisor installation failed" in console.file.getvalue()
+
+
 def test_ensure_gvisor_runtime_respects_skip_docker_install(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/sdk/test_cli_setup_stack_assets.py
+++ b/tests/sdk/test_cli_setup_stack_assets.py
@@ -1233,6 +1233,23 @@ def test_resolve_backend_url_install_yes_uses_default() -> None:
     )
 
 
+def test_resolve_backend_url_upgrade_without_env_file_does_not_read_existing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from orcheo_sdk.cli import setup as setup_mod
+
+    missing_env = tmp_path / ".env"
+    monkeypatch.setattr(setup_mod.typer, "prompt", lambda *_args, **_kwargs: " ")
+    assert setup_mod._resolve_backend_url(
+        None,
+        mode="upgrade",
+        yes=False,
+        env_file=missing_env,
+        env_exists=False,
+    ) == ("http://localhost:2025", True)
+
+
 def test_setup_stack_dir_default_and_sync_no_change(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
The deploy stack consumed orcheo/workspace-sandbox:latest but had no way to produce it: CI never published it, the runtime refused to pull it, and the deploy stack has no source tree to build it from. Sandboxed workflows failed with ImageNotFound on any non-staging host.

- Publish orcheo-workspace-sandbox to GHCR via CI alongside the other three stack images, and default ORCHEO_SANDBOX_IMAGE at it.
- Replace the local-only guard in DockerContainerRuntime with an explicit pull-then-helpful-error path so a missing image is recovered.
- Auto-install + register gVisor (runsc) during `orcheo install` when the stack is configured for runsc and the runtime is not yet registered, before `compose up` so the daemon restart doesn't bounce the stack.