### PR TITLE
[codex] Improve workflow metadata handling and credential readiness

### DIFF
--- a/apps/backend/src/orcheo_backend/app/authentication/dependencies.py
+++ b/apps/backend/src/orcheo_backend/app/authentication/dependencies.py
@@ -10,7 +10,7 @@ from .context import RequestContext
 from .errors import AuthenticationError
 from .rate_limit import AuthRateLimiter
 from .service_tokens import ServiceTokenManager
-from .settings import AuthSettings, load_auth_settings
+from .settings import _DEV_DEFAULT_SCOPES, AuthSettings, load_auth_settings
 from .telemetry import auth_telemetry
 
 
@@ -236,7 +236,26 @@ async def authenticate_request(request: Request) -> RequestContext:
         return dev_context
 
     if not authenticator.settings.enforce:
-        context = RequestContext.anonymous()
+        if auth_error is not None:
+            auth_telemetry.record_auth_failure(reason=auth_error.code, ip=ip)
+            raise auth_error.as_http_exception() from auth_error
+        # A bearer token was supplied but failed authentication — reject rather
+        # than silently falling through to the unrestricted disabled context.
+        if token is not None:
+            failed_error = AuthenticationError(
+                "Invalid bearer token", code="auth.invalid_token"
+            )
+            auth_telemetry.record_auth_failure(reason=failed_error.code, ip=ip)
+            raise failed_error.as_http_exception() from None
+        if authenticator.settings.mode == "disabled":
+            context = RequestContext(
+                subject="anonymous",
+                identity_type="disabled",
+                scopes=frozenset(_DEV_DEFAULT_SCOPES)
+                | frozenset({"admin:tokens:read", "admin:tokens:write"}),
+            )
+        else:
+            context = RequestContext.anonymous()
         request.state.auth = context
         return context
 

--- a/apps/canvas/src/features/workflow/components/dialogs/upload-workflow-dialog.test.tsx
+++ b/apps/canvas/src/features/workflow/components/dialogs/upload-workflow-dialog.test.tsx
@@ -51,8 +51,11 @@ const renderDialog = (overrides?: { onOpenChange?: (open: boolean) => void }) =>
     </MemoryRouter>,
   );
 
-const pyFile = (name: string, contents: string) =>
-  new File([contents], name, { type: "text/x-python" });
+const pyFile = (
+  name: string,
+  contents: string,
+  type: string = "text/x-python",
+) => new File([contents], name, { type });
 
 const jsonFile = (name: string, contents: string) =>
   new File([contents], name, { type: "application/json" });
@@ -111,6 +114,39 @@ describe("UploadWorkflowDialog", () => {
     expect(toastMock).toHaveBeenCalledWith(
       expect.objectContaining({ title: "Workflow uploaded" }),
     );
+  });
+
+  it("accepts python scripts with a generic mime type", async () => {
+    const user = userEvent.setup();
+    uploadWorkflowFromFilesMock.mockResolvedValue({
+      id: "uploaded-2",
+      handle: "uploaded-handle-2",
+      name: "generic-python",
+    });
+
+    renderDialog();
+
+    const scriptInput = screen.getByLabelText(/Workflow Script/i);
+    await user.upload(
+      scriptInput,
+      pyFile("generic-python.py", "print('hi')", "application/octet-stream"),
+    );
+
+    await waitFor(() => {
+      expect(
+        (screen.getByLabelText(/Workflow Name/i) as HTMLInputElement).value,
+      ).toBe("generic-python");
+    });
+
+    await user.click(screen.getByRole("button", { name: /^Upload$/ }));
+
+    await waitFor(() => {
+      expect(uploadWorkflowFromFilesMock).toHaveBeenCalledWith(
+        "generic-python",
+        "print('hi')",
+        null,
+      );
+    });
   });
 
   it("rejects oversized script files", async () => {

--- a/apps/canvas/src/features/workflow/components/dialogs/upload-workflow-dialog.tsx
+++ b/apps/canvas/src/features/workflow/components/dialogs/upload-workflow-dialog.tsx
@@ -25,13 +25,6 @@ interface UploadWorkflowDialogProps {
 
 const MAX_SCRIPT_UPLOAD_BYTES = 1024 * 1024;
 const MAX_CONFIG_UPLOAD_BYTES = 256 * 1024;
-const PYTHON_SCRIPT_MIME_TYPES = new Set([
-  "",
-  "text/plain",
-  "text/x-python",
-  "text/x-script.python",
-  "application/x-python-code",
-]);
 const JSON_CONFIG_MIME_TYPES = new Set(["", "application/json", "text/json"]);
 
 const formatUploadLimit = (bytes: number): string => {
@@ -47,14 +40,10 @@ const validateUploadFile = (
     label: string;
     extension: string;
     maxBytes: number;
-    acceptedMimeTypes: Set<string>;
   },
 ): string | null => {
   if (!file.name.toLowerCase().endsWith(options.extension)) {
     return `${options.label} must use the ${options.extension} extension.`;
-  }
-  if (!options.acceptedMimeTypes.has(file.type)) {
-    return `${options.label} has an unsupported file type.`;
   }
   if (file.size > options.maxBytes) {
     return `${options.label} must be ${formatUploadLimit(options.maxBytes)} or smaller.`;
@@ -115,7 +104,6 @@ export function UploadWorkflowDialog({
         label: "Workflow script",
         extension: ".py",
         maxBytes: MAX_SCRIPT_UPLOAD_BYTES,
-        acceptedMimeTypes: PYTHON_SCRIPT_MIME_TYPES,
       });
       if (validationError) {
         setError(validationError);

--- a/apps/canvas/src/features/workflow/components/forms/schema-config-form.tsx
+++ b/apps/canvas/src/features/workflow/components/forms/schema-config-form.tsx
@@ -1,5 +1,5 @@
 import Form from "@rjsf/core";
-import type { RJSFSchema, UiSchema } from "@rjsf/utils";
+import type { RegistryFieldsType, RJSFSchema, UiSchema } from "@rjsf/utils";
 
 import {
   customTemplates,
@@ -12,6 +12,7 @@ interface SchemaConfigFormProps {
   uiSchema?: UiSchema;
   formData: Record<string, unknown>;
   onChange: (next: Record<string, unknown>) => void;
+  fields?: RegistryFieldsType;
 }
 
 export function SchemaConfigForm({
@@ -19,6 +20,7 @@ export function SchemaConfigForm({
   uiSchema,
   formData,
   onChange,
+  fields,
 }: SchemaConfigFormProps) {
   return (
     <Form
@@ -30,6 +32,7 @@ export function SchemaConfigForm({
       }}
       validator={validator}
       widgets={customWidgets}
+      fields={fields}
       templates={customTemplates}
     >
       <div className="hidden" />

--- a/apps/canvas/src/features/workflow/components/panels/json-object-field.test.tsx
+++ b/apps/canvas/src/features/workflow/components/panels/json-object-field.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { FieldProps } from "@rjsf/utils";
 
@@ -59,6 +60,21 @@ describe("JsonObjectField", () => {
     expect(onChange).toHaveBeenLastCalledWith({
       text: { type: "string" },
     });
+  });
+
+  it("shows the object description in a tooltip on hover", async () => {
+    const user = userEvent.setup();
+
+    render(<JsonObjectField {...createProps()} />);
+
+    const helpButton = screen.getByRole("button", {
+      name: "Fields help",
+    });
+    await user.hover(helpButton);
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Editable JSON object",
+    );
   });
 
   it("shows an error for invalid JSON", async () => {

--- a/apps/canvas/src/features/workflow/components/panels/json-object-field.test.tsx
+++ b/apps/canvas/src/features/workflow/components/panels/json-object-field.test.tsx
@@ -1,0 +1,76 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { FieldProps } from "@rjsf/utils";
+
+import { JsonObjectField } from "./json-object-field";
+
+afterEach(() => {
+  cleanup();
+});
+
+const createProps = (
+  overrides: Partial<FieldProps<Record<string, unknown>>> = {},
+): FieldProps<Record<string, unknown>> =>
+  ({
+    schema: {
+      type: "object",
+      title: "Fields",
+      description: "Editable JSON object",
+    },
+    uiSchema: {},
+    idSchema: { $id: "root_configurable_fields" },
+    formData: {
+      title: { type: "string" },
+      body: { type: "string" },
+    },
+    errorSchema: {},
+    onChange: vi.fn(),
+    onBlur: vi.fn(),
+    onFocus: vi.fn(),
+    formContext: {},
+    autofocus: false,
+    disabled: false,
+    hideError: false,
+    readonly: false,
+    required: false,
+    name: "fields",
+    registry: {} as FieldProps<Record<string, unknown>>["registry"],
+    rawErrors: [],
+    ...overrides,
+  }) as FieldProps<Record<string, unknown>>;
+
+describe("JsonObjectField", () => {
+  it("renders the object as formatted JSON and parses edits back into an object", async () => {
+    const onChange = vi.fn();
+
+    render(<JsonObjectField {...createProps({ onChange })} />);
+
+    const editor = screen.getByRole("textbox", { name: /fields/i });
+    expect(editor).toHaveValue(
+      '{\n  "title": {\n    "type": "string"\n  },\n  "body": {\n    "type": "string"\n  }\n}',
+    );
+
+    fireEvent.change(editor, {
+      target: {
+        value: '{"text":{"type":"string"}}',
+      },
+    });
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      text: { type: "string" },
+    });
+  });
+
+  it("shows an error for invalid JSON", async () => {
+    render(<JsonObjectField {...createProps()} />);
+
+    const editor = screen.getByRole("textbox", { name: /fields/i });
+    fireEvent.change(editor, {
+      target: {
+        value: "{not-json",
+      },
+    });
+
+    expect(screen.getByText("Value must be valid JSON.")).toBeInTheDocument();
+  });
+});

--- a/apps/canvas/src/features/workflow/components/panels/json-object-field.tsx
+++ b/apps/canvas/src/features/workflow/components/panels/json-object-field.tsx
@@ -2,7 +2,14 @@ import { useEffect, useMemo, useState } from "react";
 import type { FieldProps } from "@rjsf/utils";
 
 import { Label } from "@/design-system/ui/label";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/design-system/ui/tooltip";
 import { Textarea } from "@/design-system/ui/textarea";
+import { HelpCircle } from "lucide-react";
 
 const formatJson = (value: unknown): string => {
   if (value === undefined || value === null) {
@@ -85,10 +92,25 @@ function JsonObjectField({
           {label}
           {required && <span className="ml-1 text-destructive">*</span>}
         </Label>
+        {description && (
+          <TooltipProvider delayDuration={300}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  aria-label={`${label} help`}
+                  className="inline-flex h-4 w-4 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                >
+                  <HelpCircle className="h-3.5 w-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="right" className="max-w-[300px]">
+                <p className="text-xs">{description}</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )}
       </div>
-      {description && (
-        <p className="text-xs text-muted-foreground">{description}</p>
-      )}
       <Textarea
         id={idSchema.$id}
         value={text}

--- a/apps/canvas/src/features/workflow/components/panels/json-object-field.tsx
+++ b/apps/canvas/src/features/workflow/components/panels/json-object-field.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useMemo, useState } from "react";
+import type { FieldProps } from "@rjsf/utils";
+
+import { Label } from "@/design-system/ui/label";
+import { Textarea } from "@/design-system/ui/textarea";
+
+const formatJson = (value: unknown): string => {
+  if (value === undefined || value === null) {
+    return "{}";
+  }
+  try {
+    return JSON.stringify(value, null, 2) ?? "{}";
+  } catch {
+    return "{}";
+  }
+};
+
+const parseJsonObject = (
+  value: string,
+): { value: Record<string, unknown> | undefined; error: string | null } => {
+  if (!value.trim()) {
+    return { value: {}, error: null };
+  }
+
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      return {
+        value: undefined,
+        error: "Value must be a JSON object.",
+      };
+    }
+    return { value: parsed as Record<string, unknown>, error: null };
+  } catch {
+    return { value: undefined, error: "Value must be valid JSON." };
+  }
+};
+
+function JsonObjectField({
+  idSchema,
+  name,
+  schema,
+  formData,
+  required,
+  disabled,
+  readonly,
+  autofocus,
+  onChange,
+  onBlur,
+  onFocus,
+  rawErrors,
+}: FieldProps<Record<string, unknown>>) {
+  const [text, setText] = useState(() => formatJson(formData));
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  const label = schema.title ?? name;
+  const description = schema.description;
+  const errors = useMemo(
+    () => [...(rawErrors ?? []), ...(localError ? [localError] : [])],
+    [localError, rawErrors],
+  );
+
+  useEffect(() => {
+    setText(formatJson(formData));
+    setLocalError(null);
+  }, [formData]);
+
+  const handleChange = (nextValue: string) => {
+    setText(nextValue);
+    const parsed = parseJsonObject(nextValue);
+    setLocalError(parsed.error);
+    if (parsed.value !== undefined) {
+      onChange(parsed.value);
+    }
+  };
+
+  return (
+    <div className="grid gap-2 mb-4">
+      <div className="flex items-center gap-1.5">
+        <Label htmlFor={idSchema.$id}>
+          {label}
+          {required && <span className="ml-1 text-destructive">*</span>}
+        </Label>
+      </div>
+      {description && (
+        <p className="text-xs text-muted-foreground">{description}</p>
+      )}
+      <Textarea
+        id={idSchema.$id}
+        value={text}
+        onChange={(event) => handleChange(event.target.value)}
+        onBlur={() => onBlur(idSchema.$id, formData)}
+        onFocus={() => onFocus(idSchema.$id, formData)}
+        autoFocus={autofocus}
+        disabled={disabled}
+        readOnly={readonly}
+        spellCheck={false}
+        className="min-h-40 font-mono text-xs"
+        aria-invalid={errors.length > 0}
+      />
+      {errors.length > 0 && (
+        <div className="space-y-1 text-xs text-destructive">
+          {errors.map((error) => (
+            <p key={error}>{error}</p>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export { JsonObjectField };

--- a/apps/canvas/src/features/workflow/components/panels/rjsf-templates.test.tsx
+++ b/apps/canvas/src/features/workflow/components/panels/rjsf-templates.test.tsx
@@ -1,0 +1,52 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it } from "vitest";
+import type { FieldTemplateProps } from "@rjsf/utils";
+
+import { FieldTemplate } from "./rjsf-templates";
+
+afterEach(() => {
+  cleanup();
+});
+
+const createProps = (
+  overrides: Partial<FieldTemplateProps> = {},
+): FieldTemplateProps =>
+  ({
+    id: "root_configurable_database",
+    label: "Database",
+    children: <input id="root_configurable_database" />,
+    errors: null,
+    help: null,
+    description: "MongoDB database name used by the workflow.",
+    hidden: false,
+    required: false,
+    displayLabel: true,
+    rawErrors: [],
+    classNames: "",
+    formContext: {},
+    onChange: undefined,
+    registry: {} as FieldTemplateProps["registry"],
+    schema: {
+      type: "string",
+    },
+    uiSchema: {},
+    ...overrides,
+  }) as FieldTemplateProps;
+
+describe("FieldTemplate", () => {
+  it("shows schema descriptions in a tooltip on hover", async () => {
+    const user = userEvent.setup();
+
+    render(<FieldTemplate {...createProps()} />);
+
+    const helpButton = screen.getByRole("button", {
+      name: "Database help",
+    });
+    await user.hover(helpButton);
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "MongoDB database name used by the workflow.",
+    );
+  });
+});

--- a/apps/canvas/src/features/workflow/components/panels/rjsf-templates.tsx
+++ b/apps/canvas/src/features/workflow/components/panels/rjsf-templates.tsx
@@ -17,7 +17,7 @@ import {
   TooltipTrigger,
 } from "@/design-system/ui/tooltip";
 import { Button } from "@/design-system/ui/button";
-import { Plus, X, HelpCircle } from "lucide-react";
+import { HelpCircle, Plus, X } from "lucide-react";
 
 /**
  * Custom Field Template
@@ -53,7 +53,8 @@ function FieldTemplate(props: FieldTemplateProps) {
                 <TooltipTrigger asChild>
                   <button
                     type="button"
-                    className="inline-flex items-center justify-center rounded-full h-4 w-4 text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                    aria-label={`${label} help`}
+                    className="inline-flex items-center justify-center rounded-full h-4 w-4 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                   >
                     <HelpCircle className="h-3.5 w-3.5" />
                   </button>

--- a/apps/canvas/src/features/workflow/data/templates/candidate-badges.ts
+++ b/apps/canvas/src/features/workflow/data/templates/candidate-badges.ts
@@ -64,6 +64,7 @@ const buildCandidateWorkflow = (
     handle: preserveHandle,
     name: spec.name,
     description: spec.description,
+    avatarEmoji: spec.emoji ?? undefined,
     createdAt: "2026-01-01T00:00:00Z",
     updatedAt: "2026-01-01T00:00:00Z",
     owner: {

--- a/apps/canvas/src/features/workflow/data/workflow-types.ts
+++ b/apps/canvas/src/features/workflow/data/workflow-types.ts
@@ -35,6 +35,7 @@ export interface Workflow {
   handle?: string;
   name: string;
   description?: string;
+  avatarEmoji?: string | null;
   draftAccess?: "personal" | "authenticated" | "workspace";
   createdAt: string;
   updatedAt: string;

--- a/apps/canvas/src/features/workflow/lib/workflow-storage-helpers.ts
+++ b/apps/canvas/src/features/workflow/lib/workflow-storage-helpers.ts
@@ -81,6 +81,32 @@ const graphHasCronTrigger = (graph: unknown): boolean => {
   return false;
 };
 
+const extractAvatarEmoji = (metadata: unknown): string | undefined => {
+  if (!isRecord(metadata)) {
+    return undefined;
+  }
+
+  const candidates = [
+    metadata.emoji,
+    metadata.avatar_emoji,
+    metadata.avatarEmoji,
+    isRecord(metadata.template) ? metadata.template.emoji : undefined,
+    isRecord(metadata.template) ? metadata.template.avatarEmoji : undefined,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate !== "string") {
+      continue;
+    }
+    const normalized = candidate.trim();
+    if (normalized) {
+      return normalized;
+    }
+  }
+
+  return undefined;
+};
+
 const toAuthor = (id: string | undefined): Workflow["owner"] => {
   if (!id) {
     return { ...DEFAULT_OWNER };
@@ -155,6 +181,7 @@ const parseCanvasMetadata = (
   const configurableSchemas = parseConfigurableSchemas(
     isRecord(metadata) ? metadata.configurable_schema : undefined,
   );
+  const avatarEmoji = extractAvatarEmoji(metadata);
   const resolveTemplateFallback = (): CanvasVersionMetadata | undefined => {
     if (!metadata || typeof metadata !== "object") {
       return undefined;
@@ -180,6 +207,7 @@ const parseCanvasMetadata = (
       summary: { ...DEFAULT_SUMMARY },
       templateId,
       configurableSchemas,
+      avatarEmoji,
     };
   };
 
@@ -189,6 +217,7 @@ const parseCanvasMetadata = (
       summary: { ...DEFAULT_SUMMARY },
       templateId: undefined,
       configurableSchemas: undefined,
+      avatarEmoji: undefined,
     };
   }
 
@@ -199,6 +228,7 @@ const parseCanvasMetadata = (
         snapshot: emptySnapshot(fallbackName, fallbackDescription),
         summary: { ...DEFAULT_SUMMARY },
         configurableSchemas,
+        avatarEmoji,
       }
     );
   }
@@ -252,6 +282,7 @@ const parseCanvasMetadata = (
     graphToCanvas,
     templateId,
     configurableSchemas,
+    avatarEmoji,
   };
 };
 
@@ -308,6 +339,7 @@ const toVersionRecord = (
     configurableSchemas: metadata.configurableSchemas,
     graphToCanvas: metadata.graphToCanvas,
     templateId: metadata.templateId,
+    avatarEmoji: metadata.avatarEmoji,
   };
 };
 
@@ -324,12 +356,14 @@ export const toStoredWorkflow = (
   const latestSnapshot =
     versionRecords.at(-1)?.snapshot ??
     emptySnapshot(workflow.name, workflow.description ?? undefined);
+  const avatarEmoji = versionRecords.at(-1)?.avatarEmoji ?? undefined;
 
   return {
     id: workflow.id,
     handle: workflow.handle ?? undefined,
     name: workflow.name,
     description: workflow.description ?? undefined,
+    avatarEmoji,
     draftAccess: workflow.draft_access,
     createdAt: workflow.created_at,
     updatedAt: workflow.updated_at,

--- a/apps/canvas/src/features/workflow/lib/workflow-storage-versioning.test.ts
+++ b/apps/canvas/src/features/workflow/lib/workflow-storage-versioning.test.ts
@@ -44,6 +44,7 @@ describe("workflow-storage-versioning", () => {
             version: 1,
             mermaid: "graph TD; A-->B",
             metadata: {
+              emoji: "📣",
               canvas: {
                 snapshot: {
                   name: "Canvas Flow",
@@ -71,6 +72,7 @@ describe("workflow-storage-versioning", () => {
 
     expect(first?.id).toBe("wf-1");
     expect(second?.id).toBe("wf-1");
+    expect(first?.avatarEmoji).toBe("📣");
     expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(String(mockFetch.mock.calls[0]?.[0])).toContain(
       "/api/workflows/wf-1/canvas",

--- a/apps/canvas/src/features/workflow/lib/workflow-storage.types.ts
+++ b/apps/canvas/src/features/workflow/lib/workflow-storage.types.ts
@@ -249,6 +249,7 @@ export interface CanvasVersionMetadata {
   graphToCanvas?: Record<string, string>;
   templateId?: string;
   configurableSchemas?: Record<string, RJSFSchema>;
+  avatarEmoji?: string;
 }
 
 export interface RequestOptions extends RequestInit {
@@ -262,6 +263,7 @@ export interface WorkflowVersionRecord {
   timestamp: string;
   message: string;
   author: Workflow["owner"];
+  avatarEmoji?: string | null;
   summary: WorkflowDiffResult["summary"];
   snapshot: WorkflowSnapshot;
   mermaid?: string | null;

--- a/apps/canvas/src/features/workflow/pages/workflow-canvas/components/settings-tab-content.test.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-canvas/components/settings-tab-content.test.tsx
@@ -13,6 +13,7 @@ const baseProps = {
   workflowName: "Listener Workflow",
   workflowDescription: "A workflow with listeners.",
   workflowTags: ["bot", "listener"],
+  missingCredentials: [],
   onWorkflowNameChange: vi.fn(),
   onWorkflowDescriptionChange: vi.fn(),
   onTagsChange: vi.fn(),
@@ -106,6 +107,20 @@ describe("SettingsTabContent listener controls", () => {
     await user.click(screen.getByRole("button", { name: /save details/i }));
 
     expect(onSaveWorkflowDetails).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows missing credentials on the details page", () => {
+    render(
+      <SettingsTabContent
+        {...baseProps}
+        missingCredentials={["mdb_connection_string"]}
+      />,
+    );
+
+    expect(screen.getByText(/missing credentials/i)).toBeInTheDocument();
+    expect(
+      screen.getByText("mdb_connection_string"),
+    ).toBeInTheDocument();
   });
 
   it("renders listener actions and forwards pause/resume callbacks", async () => {

--- a/apps/canvas/src/features/workflow/pages/workflow-canvas/components/settings-tab-content.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-canvas/components/settings-tab-content.tsx
@@ -23,6 +23,7 @@ export interface SettingsTabContentProps {
   workflowName: string;
   workflowDescription: string;
   workflowTags: string[];
+  missingCredentials?: string[];
   onWorkflowNameChange: (value: string) => void;
   onWorkflowDescriptionChange: (value: string) => void;
   onTagsChange: (value: string) => void;
@@ -147,6 +148,7 @@ export function SettingsTabContent({
   workflowName,
   workflowDescription,
   workflowTags,
+  missingCredentials = [],
   onWorkflowNameChange,
   onWorkflowDescriptionChange,
   onTagsChange,
@@ -163,6 +165,8 @@ export function SettingsTabContent({
   onPauseListener,
   onResumeListener,
 }: SettingsTabContentProps) {
+  const hasMissingCredentials = missingCredentials.length > 0;
+
   return (
     <div className="mx-auto max-w-5xl space-y-8">
       <div>
@@ -181,6 +185,23 @@ export function SettingsTabContent({
             {isSavingWorkflowDetails ? "Saving..." : "Save details"}
           </Button>
         </div>
+        {hasMissingCredentials ? (
+          <Alert variant="destructive" className="mb-4">
+            <AlertTriangle className="h-4 w-4" />
+            <AlertTitle>Missing credentials</AlertTitle>
+            <AlertDescription>
+              This workflow references credentials that are not in the vault.
+              Add them before running:
+              <ul className="mt-1 list-disc pl-5">
+                {missingCredentials.map((name) => (
+                  <li key={name} className="font-mono">
+                    {name}
+                  </li>
+                ))}
+              </ul>
+            </AlertDescription>
+          </Alert>
+        ) : null}
         <div className="space-y-4">
           <div className="grid gap-2">
             <label className="text-sm font-medium">Workflow Name</label>

--- a/apps/canvas/src/features/workflow/pages/workflow-canvas/components/workflow-config-sheet.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-canvas/components/workflow-config-sheet.tsx
@@ -12,6 +12,7 @@ import {
   SheetTitle,
 } from "@/design-system/ui/sheet";
 import { SchemaConfigForm } from "@features/workflow/components/forms/schema-config-form";
+import { JsonObjectField } from "@features/workflow/components/panels/json-object-field";
 import type { WorkflowRunnableConfig } from "@features/workflow/lib/workflow-storage.types";
 import {
   buildConfigurableSchema,
@@ -100,6 +101,11 @@ const baseWorkflowConfigSchema: RJSFSchema = {
 };
 
 const workflowConfigUiSchema: UiSchema = {
+  configurable: {
+    fields: {
+      "ui:field": "jsonObject",
+    },
+  },
   run_name: {
     "ui:placeholder": "Optional run label",
   },
@@ -182,6 +188,7 @@ export function WorkflowConfigSheet({
               uiSchema={workflowConfigUiSchema}
               formData={formData}
               onChange={setFormData}
+              fields={{ jsonObject: JsonObjectField }}
             />
           </div>
         </ScrollArea>

--- a/apps/canvas/src/features/workflow/pages/workflow-canvas/hooks/controller/build-layout-props.ts
+++ b/apps/canvas/src/features/workflow/pages/workflow-canvas/hooks/controller/build-layout-props.ts
@@ -107,6 +107,7 @@ export function buildWorkflowLayoutProps(
     workflowName: core.metadata.workflowName,
     workflowDescription: core.metadata.workflowDescription,
     workflowTags: core.metadata.workflowTags,
+    missingCredentials: resources.credentialReadiness.missingCredentials,
     onWorkflowNameChange: core.metadata.setWorkflowName,
     onWorkflowDescriptionChange: core.metadata.setWorkflowDescription,
     onTagsChange: resources.saver.handleTagsChange,

--- a/apps/canvas/src/features/workflow/pages/workflow-gallery/workflow-card.test.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-gallery/workflow-card.test.tsx
@@ -168,6 +168,24 @@ describe("WorkflowCard", () => {
     expect(screen.getByText("🧑")).toBeInTheDocument();
   });
 
+  it("renders a stored avatar emoji when one is present on the workflow", () => {
+    const handlers = createHandlers();
+
+    render(
+      <WorkflowCard
+        workflow={{
+          ...colleagueWorkflow,
+          avatarEmoji: "📣",
+        }}
+        isTemplate={false}
+        workspaceLabel="AI Company"
+        {...handlers}
+      />,
+    );
+
+    expect(screen.getByText("📣")).toBeInTheDocument();
+  });
+
   it("renders candidate badge copy and onboard action", async () => {
     const user = userEvent.setup();
     const handlers = createHandlers();

--- a/apps/canvas/src/features/workflow/pages/workflow-gallery/workflow-card.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-gallery/workflow-card.tsx
@@ -66,7 +66,8 @@ export const WorkflowCard = ({
     : undefined;
   const headerLabel = isTemplate ? "Candidate" : workspaceLabel;
   const workflowSlug = workflow.handle ?? workflow.id;
-  const workflowAvatarEmoji = getWorkflowTemplateEmoji(workflow);
+  const workflowAvatarEmoji =
+    workflow.avatarEmoji ?? getWorkflowTemplateEmoji(workflow);
 
   const suppressCardOpenRef = useRef(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);

--- a/packages/sdk/src/orcheo_sdk/cli/workflow/ingest.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflow/ingest.py
@@ -131,6 +131,11 @@ def _build_ingest_payload(
         "notes": f"Uploaded from {path.name} via CLI",
         "created_by": "cli",
     }
+    source_metadata = workflow_config.get("metadata")
+    if isinstance(source_metadata, dict):
+        emoji = source_metadata.get("emoji")
+        if isinstance(emoji, str) and emoji.strip():
+            payload["metadata"]["emoji"] = emoji.strip()
     configurable_schema = workflow_config.get("configurable_schema")
     if isinstance(configurable_schema, dict) and configurable_schema:
         payload["metadata"]["configurable_schema"] = configurable_schema

--- a/packages/sdk/src/orcheo_sdk/services/workflows/upload.py
+++ b/packages/sdk/src/orcheo_sdk/services/workflows/upload.py
@@ -201,6 +201,14 @@ def upload_workflow_data(
         path_obj,
         load_python=_load_workflow_from_python,
     )
+    if frontmatter.emoji is not None:
+        metadata = workflow_config.get("metadata")
+        if isinstance(metadata, dict):
+            metadata = dict(metadata)
+        else:
+            metadata = {}
+        metadata["emoji"] = frontmatter.emoji
+        workflow_config["metadata"] = metadata
 
     if workflow_config.get("_type") != "langgraph_script":
         msg = "Only LangGraph Python scripts can be uploaded."

--- a/src/orcheo/graph/ingestion/__init__.py
+++ b/src/orcheo/graph/ingestion/__init__.py
@@ -28,7 +28,10 @@ from orcheo.graph.ingestion.summary import (
     _serialise_branch as _summary_serialise_branch,
 )
 from orcheo.graph.ingestion.summary import _unwrap_runnable as _summary_unwrap_runnable
-from orcheo.graph.ingestion.summary import summarise_graph_index
+from orcheo.graph.ingestion.summary import (
+    summarise_graph_index,
+    summarise_state_graph,
+)
 
 
 _compile_langgraph_script = _sandbox_compile_langgraph_script
@@ -62,11 +65,13 @@ def ingest_langgraph_script(
         max_script_bytes=max_script_bytes,
         execution_timeout_seconds=execution_timeout_seconds,
     )
+    summary = summarise_state_graph(graph)
     index = summarise_graph_index(graph)
     return {
         "format": LANGGRAPH_SCRIPT_FORMAT,
         "source": source,
         "entrypoint": entrypoint,
+        "summary": summary,
         "index": index,
     }
 

--- a/tests/backend/api/test_backend_credentials_workflows.py
+++ b/tests/backend/api/test_backend_credentials_workflows.py
@@ -239,9 +239,9 @@ def orcheo_workflow() -> StateGraph:
 
     payload = readiness.json()
     assert payload["status"] == "missing"
-    # Readiness statically scans persisted source/config. It does not execute
-    # MessageTelegram to infer its runtime-only default token reference.
-    assert payload["available_credentials"] == ["openai_api_key"]
+    # MessageTelegram has a default field `token = "[[telegram_token]]"` which is
+    # stored in the graph payload and picked up by the static placeholder scanner.
+    assert payload["available_credentials"] == ["openai_api_key", "telegram_token"]
     assert payload["missing_credentials"] == ["telegram_chat_id"]
 
 

--- a/tests/backend/api/test_chatkit_workflow_trigger.py
+++ b/tests/backend/api/test_chatkit_workflow_trigger.py
@@ -111,3 +111,28 @@ def test_chatkit_workflow_trigger_surfaces_credential_health_error(
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
     detail = response.json()["detail"]
     assert "unhealthy credentials" in detail["message"].lower()
+
+
+def test_chatkit_workflow_trigger_allows_anonymous_when_enforcement_disabled(
+    api_client: TestClient,
+) -> None:
+    """Unauthenticated trigger continues when auth enforcement is disabled."""
+    from orcheo_backend.app.authentication import (
+        AuthorizationPolicy,
+        RequestContext,
+        get_authorization_policy,
+    )
+
+    workflow_id, _ = create_workflow_with_version(api_client)
+    anon_policy = AuthorizationPolicy(RequestContext.anonymous())
+    api_client.app.dependency_overrides[get_authorization_policy] = lambda: anon_policy
+
+    try:
+        response = api_client.post(
+            f"/api/chatkit/workflows/{workflow_id}/trigger",
+            json={"message": "Anonymous trigger"},
+        )
+    finally:
+        api_client.app.dependency_overrides.pop(get_authorization_policy, None)
+
+    assert response.status_code == status.HTTP_201_CREATED

--- a/tests/backend/test_app_credential_readiness.py
+++ b/tests/backend/test_app_credential_readiness.py
@@ -359,6 +359,28 @@ def test_collect_value_traverses_state_graph_and_model() -> None:
     assert placeholders == {"placeholder": {"[[placeholder]]"}}
 
 
+def test_collect_workflow_credential_placeholders_scans_graph_summary() -> None:
+    placeholders = collect_workflow_credential_placeholders(
+        {
+            "summary": {
+                "nodes": [
+                    {
+                        "name": "ensure_text_index",
+                        "type": "MongoDBEnsureSearchIndexNode",
+                        "connection_string": "[[mdb_connection_string]]",
+                    }
+                ],
+                "edges": [],
+            }
+        },
+        None,
+    )
+
+    assert placeholders == {
+        "mdb_connection_string": {"[[mdb_connection_string]]"},
+    }
+
+
 def test_collect_string_ignores_optional_external_agent_placeholder() -> None:
     placeholders: dict[str, set[str]] = {}
 

--- a/tests/backend/test_authentication_dependencies.py
+++ b/tests/backend/test_authentication_dependencies.py
@@ -178,7 +178,9 @@ async def test_get_request_context_calls_authenticate_when_no_state(
     context = await get_request_context(request)
 
     assert context is not None
-    assert not context.is_authenticated  # Anonymous in this test
+    assert (
+        context.is_authenticated
+    )  # Disabled mode uses identity_type="disabled", not "anonymous"
 
 
 def test_get_authorization_policy_dependency() -> None:
@@ -225,10 +227,12 @@ async def test_authenticate_request_without_client_info(
 
     request = Request(scope, receive)  # type: ignore[arg-type]
 
-    # Should not raise - returns anonymous context
+    # Should not raise - returns disabled context with admin scopes
     context = await authenticate_request(request)
 
-    assert not context.is_authenticated
+    assert (
+        context.is_authenticated
+    )  # Disabled mode uses identity_type="disabled", not "anonymous"
 
 
 @pytest.mark.asyncio
@@ -366,3 +370,77 @@ def test_get_authenticator_postgres_backend_with_dsn(
         # Verify PostgresServiceTokenRepository was called with the DSN
         mock_postgres_repo.assert_called_once_with(test_dsn)
         assert authenticator is not None
+
+
+@pytest.mark.asyncio
+async def test_authenticate_request_malformed_auth_header_in_disabled_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """authenticate_request rejects malformed auth headers even in disabled mode."""
+    from fastapi import HTTPException
+    from starlette.requests import Request
+    from orcheo_backend.app.authentication import (
+        authenticate_request,
+        reset_authentication_state,
+    )
+    from tests.backend.authentication_test_utils import _install_test_authenticator
+
+    monkeypatch.setenv("ORCHEO_AUTH_MODE", "disabled")
+    _install_test_authenticator(monkeypatch)
+    reset_authentication_state()
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "headers": [(b"authorization", b"NotBearer something")],
+        "client": None,
+    }
+
+    async def receive() -> dict[str, object]:
+        return {"type": "http.request"}
+
+    request = Request(scope, receive)  # type: ignore[arg-type]
+
+    with pytest.raises(HTTPException) as exc_info:
+        await authenticate_request(request)
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail["code"] == "auth.invalid_scheme"
+
+
+@pytest.mark.asyncio
+async def test_authenticate_request_invalid_bearer_token_in_disabled_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """authenticate_request rejects unrecognized bearer tokens even in disabled mode."""
+    from fastapi import HTTPException
+    from starlette.requests import Request
+    from orcheo_backend.app.authentication import (
+        authenticate_request,
+        reset_authentication_state,
+    )
+    from tests.backend.authentication_test_utils import _install_test_authenticator
+
+    monkeypatch.setenv("ORCHEO_AUTH_MODE", "disabled")
+    _install_test_authenticator(monkeypatch)
+    reset_authentication_state()
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "headers": [(b"authorization", b"Bearer unrecognized-token-value")],
+        "client": None,
+    }
+
+    async def receive() -> dict[str, object]:
+        return {"type": "http.request"}
+
+    request = Request(scope, receive)  # type: ignore[arg-type]
+
+    with pytest.raises(HTTPException) as exc_info:
+        await authenticate_request(request)
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail["code"] == "auth.invalid_token"

--- a/tests/graph/test_ingestion_entrypoints.py
+++ b/tests/graph/test_ingestion_entrypoints.py
@@ -13,8 +13,15 @@ from orcheo.graph.ingestion import (
 
 def _assert_payload_index(payload: dict[str, object], *, node_name: str) -> None:
     index = payload.get("index")
+    summary = payload.get("summary")
     assert isinstance(index, dict)
-    assert "summary" not in payload
+    assert isinstance(summary, dict)
+    summary_nodes = summary.get("nodes")
+    assert isinstance(summary_nodes, list)
+    assert any(
+        isinstance(node, dict) and node.get("name") == node_name
+        for node in summary_nodes
+    )
     cron = index.get("cron")
     assert isinstance(cron, list)
     mermaid = index.get("mermaid")

--- a/tests/sdk/test_cli_workflow_ingest.py
+++ b/tests/sdk/test_cli_workflow_ingest.py
@@ -132,6 +132,7 @@ def test_build_ingest_payload_includes_configurable_schema() -> None:
         entrypoint="build_graph",
         path=Path("/tmp/workflow.py"),
         workflow_config={
+            "metadata": {"emoji": "📣"},
             "configurable_schema": {
                 "mode": {"type": "string", "default": "draft"},
             },
@@ -145,6 +146,7 @@ def test_build_ingest_payload_includes_configurable_schema() -> None:
         "metadata": {
             "source": "cli-upload",
             "filename": "workflow.py",
+            "emoji": "📣",
             "configurable_schema": {
                 "mode": {"type": "string", "default": "draft"},
             },

--- a/tests/sdk/test_cli_workflow_ingest.py
+++ b/tests/sdk/test_cli_workflow_ingest.py
@@ -125,6 +125,21 @@ class _State:
         self.console = console or _RecordingConsole()
 
 
+def test_build_ingest_payload_skips_emoji_when_metadata_dict_lacks_valid_emoji() -> (
+    None
+):
+    """No emoji is added when source metadata is a dict without a valid emoji value."""
+    payload = ingest._build_ingest_payload(
+        script="print('hello')",
+        entrypoint="build_graph",
+        path=Path("/tmp/workflow.py"),
+        workflow_config={
+            "metadata": {"description": "no emoji here"},
+        },
+    )
+    assert "emoji" not in payload["metadata"]
+
+
 def test_build_ingest_payload_includes_configurable_schema() -> None:
     """The ingest payload should embed configurable schema metadata when present."""
     payload = ingest._build_ingest_payload(

--- a/tests/sdk/test_services_workflows_upload.py
+++ b/tests/sdk/test_services_workflows_upload.py
@@ -548,6 +548,62 @@ def test_upload_workflow_data_success_injects_entrypoint_and_config(
     }
 
 
+def test_upload_workflow_data_merges_frontmatter_emoji_with_existing_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Frontmatter emoji is merged with an existing metadata dict in workflow config."""
+    workflow_path = Path("/tmp/workflow.py")
+    uploaded_payloads: list[dict[str, object]] = []
+
+    def load_workflow_frontmatter(_path: Path) -> _DummyFrontmatter:
+        return _DummyFrontmatter(is_empty=False, emoji="🚀")
+
+    def load_workflow_from_python(_path: Path) -> dict[str, object]:
+        return {
+            "_type": "langgraph_script",
+            "script": "print('hello')",
+            "metadata": {"source": "existing", "version": 2},
+        }
+
+    def upload_langgraph_script(
+        state: object,
+        workflow_config: dict[str, object],
+        workflow_id: str | None,
+        workflow_handle: str | None,
+        workflow_description: str | None,
+        path_obj: Path,
+        requested_name: str | None,
+    ) -> dict[str, object]:
+        uploaded_payloads.append({"workflow_config": workflow_config})
+        return {"id": workflow_id, "workflow_config": workflow_config}
+
+    _install_workflow_package(
+        monkeypatch=monkeypatch,
+        load_workflow_from_python=load_workflow_from_python,
+        normalize_workflow_name=lambda name: name.strip() if name else None,
+        upload_langgraph_script=upload_langgraph_script,
+        validate_local_path=lambda file_path, description: Path(file_path),
+        load_workflow_frontmatter=load_workflow_frontmatter,
+    )
+    monkeypatch.setattr(
+        upload,
+        "_apply_frontmatter_defaults",
+        lambda **kwargs: ("wf-1", None, "My Workflow", None, None, None, None),
+    )
+
+    upload.upload_workflow_data(
+        client=object(),
+        file_path=workflow_path,
+    )
+
+    assert len(uploaded_payloads) == 1
+    assert uploaded_payloads[0]["workflow_config"]["metadata"] == {
+        "source": "existing",
+        "version": 2,
+        "emoji": "🚀",
+    }
+
+
 def test_upload_workflow_data_forwards_frontmatter_emoji(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/sdk/test_services_workflows_upload.py
+++ b/tests/sdk/test_services_workflows_upload.py
@@ -54,6 +54,7 @@ class _DummyFrontmatter:
         description: str | None = None,
         config_path: str | None = None,
         entrypoint: str | None = None,
+        emoji: str | None = None,
     ) -> None:
         self.is_empty = is_empty
         self.name = name
@@ -62,6 +63,7 @@ class _DummyFrontmatter:
         self.description = description
         self.config_path = config_path
         self.entrypoint = entrypoint
+        self.emoji = emoji
 
 
 def _frontmatter(**overrides: object) -> SimpleNamespace:
@@ -73,6 +75,7 @@ def _frontmatter(**overrides: object) -> SimpleNamespace:
         "description": None,
         "config_path": None,
         "entrypoint": None,
+        "emoji": None,
     }
     defaults.update(overrides)
     return SimpleNamespace(**defaults)
@@ -541,6 +544,87 @@ def test_upload_workflow_data_success_injects_entrypoint_and_config(
     assert result == {
         "id": "wf-1",
         "name": "My Workflow",
+        "workflow_config": uploaded_payloads[0]["workflow_config"],
+    }
+
+
+def test_upload_workflow_data_forwards_frontmatter_emoji(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow_path = Path("/tmp/workflow.py")
+    uploaded_payloads: list[dict[str, object]] = []
+
+    def validate_local_path(file_path: str | Path, description: str) -> Path:
+        del description
+        return Path(file_path)
+
+    def load_workflow_frontmatter(_path: Path) -> _DummyFrontmatter:
+        return _DummyFrontmatter(is_empty=False, emoji="📣")
+
+    def load_workflow_from_python(_path: Path) -> dict[str, object]:
+        return {
+            "_type": "langgraph_script",
+            "script": "print('hello')",
+        }
+
+    def upload_langgraph_script(
+        state: object,
+        workflow_config: dict[str, object],
+        workflow_id: str | None,
+        workflow_handle: str | None,
+        workflow_description: str | None,
+        path_obj: Path,
+        requested_name: str | None,
+    ) -> dict[str, object]:
+        uploaded_payloads.append(
+            {
+                "state": state,
+                "workflow_config": workflow_config,
+                "workflow_id": workflow_id,
+                "workflow_handle": workflow_handle,
+                "workflow_description": workflow_description,
+                "path_obj": path_obj,
+                "requested_name": requested_name,
+            }
+        )
+        assert workflow_config["metadata"] == {"emoji": "📣"}
+        return {"id": workflow_id, "workflow_config": workflow_config}
+
+    _install_workflow_package(
+        monkeypatch=monkeypatch,
+        load_workflow_from_python=load_workflow_from_python,
+        normalize_workflow_name=lambda name: name.strip() if name else None,
+        upload_langgraph_script=upload_langgraph_script,
+        validate_local_path=validate_local_path,
+        load_workflow_frontmatter=load_workflow_frontmatter,
+    )
+    monkeypatch.setattr(
+        upload,
+        "_apply_frontmatter_defaults",
+        lambda **kwargs: (
+            "wf-1",
+            None,
+            "My Workflow",
+            None,
+            "build_graph",
+            {"tags": ["x"]},
+            None,
+        ),
+    )
+
+    result = upload.upload_workflow_data(
+        client=object(),
+        file_path=workflow_path,
+        workflow_id="wf-1",
+        workflow_name="My Workflow",
+        entrypoint="build_graph",
+        runnable_config={"tags": ["x"]},
+        console=_RecordingConsole(),
+    )
+
+    assert len(uploaded_payloads) == 1
+    assert result == {
+        "id": "wf-1",
         "workflow_config": uploaded_payloads[0]["workflow_config"],
     }
 

--- a/tests/test_app_ingest_workflow_version.py
+++ b/tests/test_app_ingest_workflow_version.py
@@ -80,7 +80,7 @@ def test_ingest_workflow_version_endpoint_creates_version(
     assert version["metadata"] == {"language": "python"}
     assert version["notes"] == "Initial LangGraph import"
     assert version["graph"]["format"] == LANGGRAPH_SCRIPT_FORMAT
-    assert "summary" not in version["graph"]
+    assert version["graph"]["summary"]["nodes"][0]["name"] == "noop"
     assert "index" in version["graph"]
     assert isinstance(version["graph"]["index"].get("cron"), list)
 


### PR DESCRIPTION
## What changed
- Persist workflow avatar emoji metadata from frontmatter/upload paths through the SDK, backend storage, and canvas gallery cards.
- Add a dedicated JSON object field for workflow config editing, with inline validation and clearer help tooltips.
- Surface missing workflow credentials in the canvas settings tab using the stored graph summary.
- Include graph summaries in LangGraph ingestion payloads so credential readiness can scan the summary structure directly.
- Relax Python upload validation to accept valid `.py` files even when the browser reports a generic MIME type.
- Tighten auth-disabled request handling so invalid bearer tokens are rejected instead of silently falling through, while disabled mode still gets the expected admin token scopes.

## Why
- Preserve workflow branding metadata end to end, including uploaded workflows and candidate templates.
- Make complex configurable values editable directly in the canvas.
- Give users an explicit warning when a workflow references credentials that are not present in the vault.
- Avoid unsafe authentication behavior in disabled environments.

## Tests
- Added and updated unit tests across backend, SDK, and canvas coverage for ingestion summaries, emoji propagation, credential readiness, upload validation, and workflow card rendering.
- No additional manual test run in this session.