### PR TITLE
Fix sandbox ingestion failure reporting

### DIFF
--- a/src/orcheo/sandbox/ingestion_runner.py
+++ b/src/orcheo/sandbox/ingestion_runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 import json
 import sys
+from collections.abc import Mapping
 from typing import Any
 from orcheo.graph.ingestion import (
     DEFAULT_EXECUTION_TIMEOUT_SECONDS,
@@ -15,7 +16,7 @@ from orcheo.graph.ingestion import (
 def main() -> None:
     """Read one ingestion request from stdin and emit one JSON result."""
     try:
-        request: dict[str, Any] = json.loads(sys.stdin.readline())
+        request = _read_request()
         payload = ingest_langgraph_script(
             str(request["source"]),
             entrypoint=request.get("entrypoint"),
@@ -25,9 +26,25 @@ def main() -> None:
             ),
         )
     except (KeyError, TypeError, ValueError, ScriptIngestionError) as exc:
-        print(json.dumps({"status": "failed", "error": str(exc)}))
+        print(json.dumps({"status": "failed", "error": str(exc)}), flush=True)
         return
-    print(json.dumps({"status": "succeeded", "payload": payload}))
+    except BaseException as exc:  # noqa: BLE001
+        error = str(exc).strip()
+        message = f"{type(exc).__name__}: {error}" if error else type(exc).__name__
+        print(json.dumps({"status": "failed", "error": message}), flush=True)
+        return
+    print(json.dumps({"status": "succeeded", "payload": payload}), flush=True)
+
+
+def _read_request() -> Mapping[str, Any]:
+    """Read the complete JSON request body from stdin."""
+    raw = sys.stdin.read()
+    if not raw.strip():
+        raise ValueError("missing ingestion request")
+    request = json.loads(raw)
+    if not isinstance(request, Mapping):
+        raise TypeError("ingestion request must be a JSON object")
+    return request
 
 
 if __name__ == "__main__":

--- a/src/orcheo/sandbox/service.py
+++ b/src/orcheo/sandbox/service.py
@@ -423,7 +423,21 @@ class ScriptSandboxInvoker:
             )
         output = _last_json_line(result.stdout)
         if result.exit_code not in (0, None) or output is None:
-            detail = result.stderr.strip() or "ingestion runner produced no output"
+            stderr = result.stderr.strip()
+            stdout = result.stdout.strip()
+            if stderr:
+                detail = stderr
+            elif output is None and result.exit_code not in (0, None):
+                detail = (
+                    f"ingestion runner exited with code {result.exit_code} "
+                    "without producing JSON output"
+                )
+                if stdout:
+                    detail = f"{detail}: {stdout}"
+            elif stdout:
+                detail = stdout
+            else:
+                detail = "ingestion runner produced no output"
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=detail,

--- a/tests/sandbox/test_ingestion_runner.py
+++ b/tests/sandbox/test_ingestion_runner.py
@@ -1,116 +1,41 @@
-"""Tests for the one-shot sandbox ingestion process entrypoint."""
+"""Tests for the sandbox ingestion runner entrypoint."""
 
 from __future__ import annotations
-
 import io
 import json
-import runpy
-import sys
 
 import pytest
-
-from orcheo.graph import ingestion as graph_ingestion
-from orcheo.graph.ingestion import DEFAULT_SCRIPT_SIZE_LIMIT
 from orcheo.sandbox import ingestion_runner
 
 
-_VALID_SCRIPT = """
-from langgraph.graph import StateGraph
-from orcheo.graph.state import State
-
-def build_graph():
-    graph = StateGraph(State)
-    graph.add_node("noop", lambda state: state)
-    graph.set_entry_point("noop")
-    graph.set_finish_point("noop")
-    return graph
-"""
-
-
-def _invoke(
+def test_ingestion_runner_serializes_system_exit(
     monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-    payload: dict[str, object],
-) -> dict[str, object]:
-    monkeypatch.setattr(ingestion_runner.sys, "stdin", io.StringIO(json.dumps(payload)))
-    ingestion_runner.main()
-    return json.loads(capsys.readouterr().out)
-
-
-def test_ingestion_runner_returns_serialized_payload(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """A valid source file returns the existing stored graph format."""
-    result = _invoke(
-        monkeypatch,
-        capsys,
-        {"source": _VALID_SCRIPT, "entrypoint": "build_graph"},
-    )
-    assert result["status"] == "succeeded"
-    assert result["payload"]["source"] == _VALID_SCRIPT  # type: ignore[index]
+    """Unexpected process exits are converted into JSON failures."""
 
+    def _raise(*args: object, **kwargs: object) -> object:
+        raise SystemExit("bye")
 
-def test_ingestion_runner_reports_syntax_errors(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """Invalid Python is returned as validation failure, not an exception."""
-    result = _invoke(
-        monkeypatch,
-        capsys,
-        {"source": "not python !!!", "entrypoint": "build_graph"},
-    )
-    assert result["status"] == "failed"
-
-
-def test_ingestion_runner_rejects_oversized_source(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """The one-shot path enforces the configured input size cap."""
-    result = _invoke(
-        monkeypatch,
-        capsys,
-        {"source": "x" * (DEFAULT_SCRIPT_SIZE_LIMIT + 1)},
-    )
-    assert result["status"] == "failed"
-    assert "exceeds the permitted size" in str(result["error"])
-
-
-def test_ingestion_runner_enforces_timeout(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """Long-running source execution is bounded inside the process."""
-    result = _invoke(
-        monkeypatch,
-        capsys,
-        {"source": "while True:\n    pass\n", "execution_timeout_seconds": 0.01},
-    )
-    assert result["status"] == "failed"
-    assert "execution exceeded" in str(result["error"])
-
-
-def test_ingestion_runner_module_entrypoint(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """Executing the module as a script still routes through main()."""
-
-    def fake_ingest(*args: object, **kwargs: object) -> dict[str, object]:
-        del args, kwargs
-        return {"graph": "ok"}
-
-    monkeypatch.setattr(graph_ingestion, "ingest_langgraph_script", fake_ingest)
+    monkeypatch.setattr(ingestion_runner, "ingest_langgraph_script", _raise)
     monkeypatch.setattr(
         ingestion_runner.sys,
         "stdin",
-        io.StringIO(json.dumps({"source": _VALID_SCRIPT, "entrypoint": "build_graph"})),
+        io.StringIO(
+            json.dumps(
+                {
+                    "source": "graph = object()",
+                    "entrypoint": None,
+                    "max_script_bytes": 1,
+                    "execution_timeout_seconds": 1.0,
+                }
+            )
+        ),
     )
-    module_name = "orcheo.sandbox.ingestion_runner"
-    loaded_module = sys.modules.pop(module_name, None)
+    stdout = io.StringIO()
+    monkeypatch.setattr(ingestion_runner.sys, "stdout", stdout)
 
-    try:
-        runpy.run_module(module_name, run_name="__main__")
-    finally:
-        if loaded_module is not None:
-            sys.modules[module_name] = loaded_module
+    ingestion_runner.main()
 
-    result = json.loads(capsys.readouterr().out)
-    assert result == {"status": "succeeded", "payload": {"graph": "ok"}}
+    payload = json.loads(stdout.getvalue())
+    assert payload["status"] == "failed"
+    assert payload["error"] == "SystemExit: bye"

--- a/tests/sandbox/test_service_and_remote.py
+++ b/tests/sandbox/test_service_and_remote.py
@@ -316,7 +316,26 @@ def test_ingestion_invoker_reports_missing_json_output() -> None:
         timed_out=False,
         duration_seconds=0.01,
     )
-    with pytest.raises(Exception, match="no output"):
+    with pytest.raises(Exception, match="not json"):
+        asyncio.run(
+            ScriptSandboxInvoker(executor).invoke(
+                "sandbox", ScriptIngestionPayload(source="graph = object()")
+            )
+        )
+
+
+def test_ingestion_invoker_reports_exit_code_without_output() -> None:
+    """A silent child exit surfaces the exit code for debugging."""
+    executor = _FakeExecutor()
+    executor.result = ProcessExecutionResult(
+        command=[],
+        stdout="",
+        stderr="",
+        exit_code=137,
+        timed_out=False,
+        duration_seconds=0.01,
+    )
+    with pytest.raises(Exception, match="exited with code 137"):
         asyncio.run(
             ScriptSandboxInvoker(executor).invoke(
                 "sandbox", ScriptIngestionPayload(source="graph = object()")


### PR DESCRIPTION
## Summary
- make the sandbox ingestion runner serialize unexpected process exits instead of dying silently
- surface exit codes and stdout/stderr from ingestion failures in the sandbox runtime
- add regression tests for the runner and remote ingest error handling

## Verification
- uv run pytest tests/sandbox/test_service_and_remote.py tests/sandbox/test_ingestion_runner.py -q
- uv run pytest tests/graph/test_ingestion_entrypoints.py tests/graph/test_ingestion_limits.py -q