### PR TITLE
Speed up sandbox workflows with resident runners and warm-pool prewarming

### DIFF
--- a/deploy/stack/.env.example
+++ b/deploy/stack/.env.example
@@ -77,6 +77,18 @@ ORCHEO_SANDBOX_EGRESS_ALLOWED_HOSTS=*
 # sandbox (faster cold-start). Vibe agents always run sandboxed regardless.
 ORCHEO_SANDBOX_FAST_PATH_TRUSTED=false
 
+# Sliding window (seconds) used to measure peak concurrent sandbox usage per
+# workspace for warm-pool autoscaling. Workspaces with no usage within this
+# window are not proactively prewarmed (they remain at pool size 0 until the
+# next run, which may cold-provision). Default: 600 (10 minutes).
+ORCHEO_SANDBOX_WARM_WINDOW_SECONDS=600
+
+# Global cap on the total number of warm (READY) sandbox containers across all
+# workspaces. Prevents memory pressure on the host if many workspaces are
+# active simultaneously. 0 = unbounded (rely only on per-workspace pool_max).
+# Default: 12.  Tune down if host memory is constrained; tune up on large hosts.
+ORCHEO_SANDBOX_MAX_TOTAL_WARM=12
+
 # -----------------------------------------------------------------------------
 # Core service defaults (database, API, and browser-facing URLs)
 # -----------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,8 @@ python_version = "3.12"
 [tool.pytest.ini_options]
 filterwarnings = [
   "ignore:.*named widget classes is deprecated.*:DeprecationWarning",
-  "ignore:.*named action classes is deprecated.*:DeprecationWarning"
+  "ignore:.*named action classes is deprecated.*:DeprecationWarning",
+  "ignore:This process.*multi-threaded.*use of fork.*may lead to deadlocks:DeprecationWarning"
 ]
 markers = [
   "no_mock_celery: disable the autouse Celery enqueue mock in repository tests"

--- a/src/orcheo/sandbox/config.py
+++ b/src/orcheo/sandbox/config.py
@@ -100,6 +100,25 @@ class SandboxSettings(BaseModel):
         ),
     )
     audit_logger_name: str = Field(default="orcheo.sandbox.audit")
+    warm_window_seconds: int = Field(
+        default=600,
+        ge=1,
+        description=(
+            "Sliding window (seconds) used to compute peak concurrent usage for "
+            "warm-pool autoscaling. Workspaces with no usage samples within this "
+            "window target pool size 0 and are not proactively prewarmed."
+        ),
+    )
+    max_total_warm: int = Field(
+        default=12,
+        ge=0,
+        description=(
+            "Global cap on the total number of warm (READY) sandboxes across all "
+            "workspaces. 0 = unbounded (rely only on per-workspace pool_max). "
+            "Applied only to proactive prewarm provisioning; per-workspace "
+            "pool_max still bounds each workspace independently."
+        ),
+    )
 
     @field_validator("sandbox_dns", mode="before")
     @classmethod
@@ -169,6 +188,8 @@ class SandboxSettings(BaseModel):
         "credential_broker_forward_url": "ORCHEO_CREDENTIAL_BROKER_FORWARD_URL",
         "sandbox_dns": "ORCHEO_SANDBOX_DNS",
         "audit_logger_name": "ORCHEO_SANDBOX_AUDIT_LOGGER_NAME",
+        "warm_window_seconds": "ORCHEO_SANDBOX_WARM_WINDOW_SECONDS",
+        "max_total_warm": "ORCHEO_SANDBOX_MAX_TOTAL_WARM",
     }
 
     @classmethod

--- a/src/orcheo/sandbox/ingestion_runner.py
+++ b/src/orcheo/sandbox/ingestion_runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 import json
 import sys
+from collections.abc import Mapping
 from typing import Any
 from orcheo.graph.ingestion import (
     DEFAULT_EXECUTION_TIMEOUT_SECONDS,
@@ -15,7 +16,7 @@ from orcheo.graph.ingestion import (
 def main() -> None:
     """Read one ingestion request from stdin and emit one JSON result."""
     try:
-        request: dict[str, Any] = json.loads(sys.stdin.readline())
+        request = _read_request()
         payload = ingest_langgraph_script(
             str(request["source"]),
             entrypoint=request.get("entrypoint"),
@@ -25,9 +26,25 @@ def main() -> None:
             ),
         )
     except (KeyError, TypeError, ValueError, ScriptIngestionError) as exc:
-        print(json.dumps({"status": "failed", "error": str(exc)}))
+        print(json.dumps({"status": "failed", "error": str(exc)}), flush=True)
         return
-    print(json.dumps({"status": "succeeded", "payload": payload}))
+    except BaseException as exc:  # noqa: BLE001
+        error = str(exc).strip()
+        message = f"{type(exc).__name__}: {error}" if error else type(exc).__name__
+        print(json.dumps({"status": "failed", "error": message}), flush=True)
+        return
+    print(json.dumps({"status": "succeeded", "payload": payload}), flush=True)
+
+
+def _read_request() -> Mapping[str, Any]:
+    """Read the complete JSON request body from stdin."""
+    raw = sys.stdin.read()
+    if not raw.strip():
+        raise ValueError("missing ingestion request")
+    request = json.loads(raw)
+    if not isinstance(request, Mapping):
+        raise TypeError("ingestion request must be a JSON object")
+    return request
 
 
 if __name__ == "__main__":

--- a/src/orcheo/sandbox/manager.py
+++ b/src/orcheo/sandbox/manager.py
@@ -14,8 +14,10 @@ from __future__ import annotations
 import logging
 import socket
 import threading
+import time
 import uuid
 from collections import defaultdict, deque
+from dataclasses import dataclass
 from datetime import UTC, timedelta
 from typing import Final, Protocol
 from urllib.parse import urlparse
@@ -49,6 +51,14 @@ _DEFAULT_NETWORK: Final[str] = "sandbox-egress"
 # from inside the sandbox; without it the default ~/.orcheo path fails with
 # EACCES against the read-only rootfs.
 _SANDBOX_AGENT_RUNTIME_ROOT: Final[str] = "/scratch/agent-runtimes"
+
+
+@dataclass
+class _UsageSample:
+    """A single timestamped reading of concurrent in-use sandboxes."""
+
+    timestamp: float
+    count: int
 
 
 class SandboxManager(Protocol):
@@ -100,6 +110,7 @@ class SandboxRuntimeManager:
         self._handles: dict[str, ContainerHandle] = {}
         self._pools: dict[str, deque[str]] = defaultdict(deque)
         self._workspace_configs: dict[str, WorkspaceRuntimePool] = {}
+        self._usage_samples: dict[str, list[_UsageSample]] = defaultdict(list)
 
     @property
     def settings(self) -> SandboxSettings:
@@ -169,6 +180,7 @@ class SandboxRuntimeManager:
             if lease is not None:
                 lease.state = SandboxState.IN_USE
                 lease.touch()
+                self._record_usage_sample(workspace_id)
                 self._audit.emit(
                     SandboxAuditEvent(
                         event="acquire_warm",
@@ -213,6 +225,7 @@ class SandboxRuntimeManager:
             placeholder.state = SandboxState.IN_USE
             placeholder.touch()
             self._handles[lease_id] = handle
+            self._record_usage_sample(workspace_id)
 
         self._audit.emit(
             SandboxAuditEvent(
@@ -366,6 +379,104 @@ class SandboxRuntimeManager:
                 self.destroy(lease)
             except SandboxNotFoundError:
                 continue
+
+    # ------------------------------------------------------------------
+    # Usage tracking and warm-pool prewarm (WS2)
+    # ------------------------------------------------------------------
+
+    def recent_concurrent_max(
+        self,
+        workspace_id: str,
+        *,
+        window_seconds: float = 600.0,
+    ) -> int:
+        """Return the peak concurrent in-use sandbox count in the recent window.
+
+        Workspaces with no samples in the window return 0, which the autoscaler
+        maps to a prewarm target of 0 — stagnant workspaces are never prewarmed.
+        """
+        cutoff = time.monotonic() - window_seconds
+        with self._lock:
+            samples = self._usage_samples.get(workspace_id, [])
+            fresh = [s for s in samples if s.timestamp >= cutoff]
+            self._usage_samples[workspace_id] = fresh
+            return max((s.count for s in fresh), default=0)
+
+    def current_pool_size(self, workspace_id: str) -> int:
+        """Return the number of warm-ready sandboxes currently in the pool."""
+        with self._lock:
+            return len(self._pools[workspace_id])
+
+    def known_workspace_ids(self) -> list[str]:
+        """Return all workspace IDs for which pool configs have been registered."""
+        with self._lock:
+            return list(self._workspace_configs)
+
+    def prewarm(self, workspace_id: str, count: int) -> int:
+        """Provision up to ``count`` containers directly into the READY pool.
+
+        Each container is started outside the manager lock so concurrent
+        prewarms for different workspaces do not serialise. Stops early if
+        ``pool_max`` is reached or if a provision attempt fails.
+
+        Args:
+            workspace_id: Target workspace.
+            count: Maximum number of containers to add.
+
+        Returns:
+            The number actually added (may be less than ``count``).
+        """
+        if count <= 0:
+            return 0
+        pool = self.get_workspace_pool(workspace_id)
+        added = 0
+        for _ in range(count):
+            with self._lock:
+                total = len(self._pools[workspace_id]) + self._count_in_use(
+                    workspace_id
+                )
+                if total >= pool.pool_max:
+                    break
+            spec = self._build_spec(workspace_id, pool)
+            try:
+                handle = self._runtime.start(spec)
+            except Exception:
+                logger.warning(
+                    "Prewarm provision failed for workspace %s; stopping early",
+                    workspace_id,
+                )
+                break
+            lease_id = uuid.uuid4().hex
+            with self._lock:
+                lease = SandboxLease(
+                    lease_id=lease_id,
+                    workspace_id=workspace_id,
+                    sandbox_id=handle.container_id,
+                    state=SandboxState.READY,
+                )
+                self._leases[lease_id] = lease
+                self._handles[lease_id] = handle
+                self._pools[workspace_id].append(lease_id)
+            self._audit.emit(
+                SandboxAuditEvent(
+                    event="prewarm",
+                    workspace_id=workspace_id,
+                    sandbox_id=handle.container_id,
+                )
+            )
+            added += 1
+        return added
+
+    def _record_usage_sample(self, workspace_id: str) -> None:
+        """Append the current in-use count to the sliding-window buffer.
+
+        Must be called while ``self._lock`` is held.
+        """
+        self._usage_samples[workspace_id].append(
+            _UsageSample(
+                timestamp=time.monotonic(), count=self._count_in_use(workspace_id)
+            )
+        )
 
     def _pop_from_pool(self, workspace_id: str) -> SandboxLease | None:
         """Pop the oldest pooled lease, returning None if the pool is empty."""

--- a/src/orcheo/sandbox/service.py
+++ b/src/orcheo/sandbox/service.py
@@ -323,7 +323,9 @@ class ResidentRunnerPool:
         # sandbox_id → asyncio subprocess handle
         self._runners: dict[str, asyncio.subprocess.Process] = {}
 
-    async def _start_runner(self, sandbox_id: str, broker_token: str = "") -> asyncio.subprocess.Process:
+    async def _start_runner(
+        self, sandbox_id: str, broker_token: str = ""
+    ) -> asyncio.subprocess.Process:
         """Start a fresh resident runner inside the container and register it."""
         cmd = [
             "docker",
@@ -333,14 +335,16 @@ class ResidentRunnerPool:
         # Add broker token environment variable if provided
         if broker_token:
             cmd.extend(["-e", f"ORCHEO_BROKER_TOKEN={broker_token}"])
-        
-        cmd.extend([
-            sandbox_id,
-            "python",
-            "-m",
-            _WORKFLOW_RUNNER_MODULE,
-        ])
-        
+
+        cmd.extend(
+            [
+                sandbox_id,
+                "python",
+                "-m",
+                _WORKFLOW_RUNNER_MODULE,
+            ]
+        )
+
         process = await asyncio.create_subprocess_exec(
             *cmd,
             stdin=asyncio.subprocess.PIPE,
@@ -350,7 +354,9 @@ class ResidentRunnerPool:
         self._runners[sandbox_id] = process
         return process
 
-    async def _get_or_start(self, sandbox_id: str, broker_token: str = "") -> asyncio.subprocess.Process:
+    async def _get_or_start(
+        self, sandbox_id: str, broker_token: str = ""
+    ) -> asyncio.subprocess.Process:
         """Return the live runner for sandbox_id, starting one if absent or dead."""
         process = self._runners.get(sandbox_id)
         if process is not None and process.returncode is None:

--- a/src/orcheo/sandbox/service.py
+++ b/src/orcheo/sandbox/service.py
@@ -28,7 +28,7 @@ import os
 import secrets
 import socket
 import time
-from collections.abc import AsyncIterator, Callable, Mapping
+from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager, suppress
 from typing import Annotated, Any, Final
 from urllib.parse import urlparse
@@ -48,6 +48,7 @@ from orcheo.sandbox.errors import (
     SandboxNotFoundError,
 )
 from orcheo.sandbox.manager import SandboxRuntimeManager
+from orcheo.sandbox.metrics import WarmPoolAutoscaler
 from orcheo.sandbox.runtime import (
     ContainerHandle,
     ContainerRuntime,
@@ -296,19 +297,62 @@ class ContainerExecutor:
         )
 
 
-class WorkflowSandboxInvoker:
-    """Invoke the workflow runner inside a sandbox container and parse its result.
+# Default timeout used when the caller passes timeout_seconds=None.  Matches
+# the agent CLI default so the HTTP-level safety margin in RemoteSandboxRunner
+# is still the last-resort guard.
+_DEFAULT_RUNNER_TIMEOUT_SECONDS: Final[float] = 1800.0
+# Extra time beyond the run timeout for the outer readline() read to account
+# for fork startup and result serialisation.
+_RUNNER_SAFETY_MARGIN_SECONDS: Final[float] = 60.0
 
-    The invoker pipes a single newline-delimited ``WorkflowRunSpec`` payload
-    to ``python -m orcheo.sandbox.workflow_runner`` running in the sandbox
-    and reads the response from stdout. The broker token is passed as the
-    ``ORCHEO_BROKER_TOKEN`` env var so tenant code in the sandbox cannot see
-    it on the command line via ``ps``.
+
+class ResidentRunnerPool:
+    """One long-lived ``workflow_runner`` process per sandbox container.
+
+    The runner process is started on the first dispatch to a sandbox and kept
+    alive for the container's lifetime.  It pre-imports the graph runtime once,
+    so every subsequent fork child inherits loaded modules via copy-on-write
+    instead of re-paying the ~3 s import cost per run.
+
+    The sandbox lease model guarantees at most one concurrent dispatch per
+    sandbox, so no per-sandbox lock is needed here.
     """
 
-    def __init__(self, executor: ContainerExecutor) -> None:
-        """Initialize the invoker."""
-        self._executor = executor
+    def __init__(self) -> None:
+        """Initialize the pool with an empty runner registry."""
+        # sandbox_id → asyncio subprocess handle
+        self._runners: dict[str, asyncio.subprocess.Process] = {}
+
+    async def _start_runner(self, sandbox_id: str) -> asyncio.subprocess.Process:
+        """Start a fresh resident runner inside the container and register it."""
+        process = await asyncio.create_subprocess_exec(
+            "docker",
+            "exec",
+            "-i",
+            sandbox_id,
+            "python",
+            "-m",
+            _WORKFLOW_RUNNER_MODULE,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        self._runners[sandbox_id] = process
+        return process
+
+    async def _get_or_start(self, sandbox_id: str) -> asyncio.subprocess.Process:
+        """Return the live runner for sandbox_id, starting one if absent or dead."""
+        process = self._runners.get(sandbox_id)
+        if process is not None and process.returncode is None:
+            return process
+        return await self._start_runner(sandbox_id)
+
+    def _kill_runner(self, sandbox_id: str) -> None:
+        """Terminate and forget the runner for sandbox_id."""
+        process = self._runners.pop(sandbox_id, None)
+        if process is not None and process.returncode is None:
+            with suppress(ProcessLookupError, OSError):
+                process.kill()
 
     async def invoke(
         self,
@@ -318,72 +362,113 @@ class WorkflowSandboxInvoker:
         *,
         timeout_seconds: float | None = None,
     ) -> WorkflowRunResult:
-        """Send ``spec`` into the sandbox and parse its ``WorkflowRunResult``."""
-        payload = json.dumps(
-            {
-                "workflow_definition": dict(spec.workflow_definition),
-                "inputs": dict(spec.inputs),
-                "run_id": spec.run_id,
-                "workspace_id": spec.workspace_id,
-                "runnable_config": dict(spec.runnable_config),
-                "state_config": dict(spec.state_config),
-            },
-            separators=(",", ":"),
+        """Dispatch ``spec`` to the resident runner and return its result."""
+        return await self._invoke_with_retry(
+            sandbox_id, spec, broker_token, timeout_seconds
         )
-        argv = [
-            "python",
-            "-m",
-            _WORKFLOW_RUNNER_MODULE,
-        ]
-        result = await self._executor.exec(
-            sandbox_id,
-            ExecRequest(
-                command=argv,
-                cwd=None,
-                env={"ORCHEO_BROKER_TOKEN": broker_token} if broker_token else None,
-                stdin=payload,
-                timeout_seconds=timeout_seconds,
-            ),
-        )
-        if result.timed_out:
-            return WorkflowRunResult(
-                run_id=spec.run_id,
-                status="failed",
-                outputs={},
-                error="workflow run timed out inside sandbox",
-            )
-        if result.exit_code not in (0, None):
-            return WorkflowRunResult(
-                run_id=spec.run_id,
-                status="failed",
-                outputs={},
-                error=(
-                    f"workflow runner exited with {result.exit_code}: "
-                    f"{result.stderr.strip() or result.stdout.strip()}"
-                ),
-            )
-        last_line = _last_json_line(result.stdout)
-        if last_line is None:
-            return WorkflowRunResult(
-                run_id=spec.run_id,
-                status="failed",
-                outputs={},
-                error="workflow runner produced no JSON output",
-            )
+
+    async def _invoke_with_retry(
+        self,
+        sandbox_id: str,
+        spec: WorkflowRunSpec,
+        broker_token: str,
+        timeout_seconds: float | None,
+        *,
+        _retry: bool = False,
+    ) -> WorkflowRunResult:
+        failure_reason: str = ""
         try:
-            parsed: Mapping[str, Any] = json.loads(last_line)
-        except json.JSONDecodeError as exc:
-            return WorkflowRunResult(
-                run_id=spec.run_id,
-                status="failed",
-                outputs={},
-                error=f"could not parse workflow runner output: {exc}",
+            process = await self._get_or_start(sandbox_id)
+            payload_bytes = (
+                json.dumps(
+                    {
+                        "workflow_definition": dict(spec.workflow_definition),
+                        "inputs": dict(spec.inputs),
+                        "run_id": spec.run_id,
+                        "workspace_id": spec.workspace_id,
+                        "runnable_config": dict(spec.runnable_config),
+                        "state_config": dict(spec.state_config),
+                        "broker_token": broker_token,
+                        "timeout_seconds": timeout_seconds,
+                    },
+                    separators=(",", ":"),
+                )
+                + "\n"
+            ).encode("utf-8")
+            assert process.stdin is not None
+            process.stdin.write(payload_bytes)
+            await process.stdin.drain()
+            read_timeout = (
+                timeout_seconds or _DEFAULT_RUNNER_TIMEOUT_SECONDS
+            ) + _RUNNER_SAFETY_MARGIN_SECONDS
+            line = await asyncio.wait_for(
+                process.stdout.readline(),  # type: ignore[union-attr]
+                timeout=read_timeout,
+            )
+            if not line:
+                failure_reason = "resident runner produced EOF without a result"
+            else:
+                parsed = json.loads(line.decode("utf-8"))
+                return WorkflowRunResult(
+                    run_id=str(parsed.get("run_id") or spec.run_id),
+                    status=str(parsed.get("status", "failed")),
+                    outputs=dict(parsed.get("outputs") or {}),
+                    error=parsed.get("error"),
+                )
+        except Exception as exc:  # noqa: BLE001
+            failure_reason = f"{type(exc).__name__}: {exc}"
+
+        self._kill_runner(sandbox_id)
+        if not _retry:
+            logger.warning(
+                "Resident runner for sandbox %s failed (%s); retrying once",
+                sandbox_id,
+                failure_reason,
+            )
+            return await self._invoke_with_retry(
+                sandbox_id, spec, broker_token, timeout_seconds, _retry=True
             )
         return WorkflowRunResult(
             run_id=spec.run_id,
-            status=str(parsed.get("status", "failed")),
-            outputs=dict(parsed.get("outputs") or {}),
-            error=parsed.get("error"),
+            status="failed",
+            outputs={},
+            error=f"resident runner failed after retry: {failure_reason}",
+        )
+
+    def shutdown(self, sandbox_id: str) -> None:
+        """Kill the runner for one sandbox (called when a lease is destroyed)."""
+        self._kill_runner(sandbox_id)
+
+    def shutdown_all(self) -> None:
+        """Kill all resident runners (called on service shutdown)."""
+        for sandbox_id in list(self._runners):
+            self._kill_runner(sandbox_id)
+
+
+class WorkflowSandboxInvoker:
+    """Invoke the workflow runner inside a sandbox container and parse its result.
+
+    Dispatches each run to the ``ResidentRunnerPool``, which keeps one
+    long-lived ``python -m orcheo.sandbox.workflow_runner`` process alive per
+    sandbox so the heavy graph-runtime imports are paid once at runner startup
+    rather than on every run.
+    """
+
+    def __init__(self, runner_pool: ResidentRunnerPool) -> None:
+        """Initialize the invoker."""
+        self._pool = runner_pool
+
+    async def invoke(
+        self,
+        sandbox_id: str,
+        spec: WorkflowRunSpec,
+        broker_token: str,
+        *,
+        timeout_seconds: float | None = None,
+    ) -> WorkflowRunResult:
+        """Dispatch ``spec`` to the resident runner and return the result."""
+        return await self._pool.invoke(
+            sandbox_id, spec, broker_token, timeout_seconds=timeout_seconds
         )
 
 
@@ -538,6 +623,7 @@ def _register_lease_routes(
     app: FastAPI,
     manager: SandboxRuntimeManager,
     authorize: Callable[..., None],
+    resident_pool: ResidentRunnerPool,
 ) -> None:
     """Register the central pool lease endpoints on ``app``.
 
@@ -595,10 +681,12 @@ def _register_lease_routes(
         lease = manager.get_lease(lease_id)
         if lease is None:
             return  # idempotent — already gone
+        sandbox_id = lease.sandbox_id
         try:
             manager.destroy(lease)
         except SandboxNotFoundError:
             pass
+        resident_pool.shutdown(sandbox_id)
 
 
 def _register_sandbox_routes(
@@ -730,10 +818,44 @@ def _register_credential_relay_route(app: FastAPI) -> None:
 
 
 @asynccontextmanager
-async def _manager_lifespan(manager: SandboxRuntimeManager) -> AsyncIterator[None]:
-    """Run the sandbox reaper and shut the manager down on exit."""
+async def _manager_lifespan(  # noqa: C901
+    manager: SandboxRuntimeManager,
+    settings: SandboxSettings,
+    resident_pool: ResidentRunnerPool,
+) -> AsyncIterator[None]:
+    """Run the sandbox reaper + prewarm loop and shut everything down on exit."""
     reap_interval = float(os.getenv(_ENV_REAP_INTERVAL, str(_DEFAULT_REAP_INTERVAL)))
     max_in_use = float(os.getenv(_ENV_MAX_IN_USE, str(_DEFAULT_MAX_IN_USE)))
+    autoscaler = WarmPoolAutoscaler()
+
+    async def _run_prewarm(total_warm: int) -> int:
+        """Prewarm active workspaces and return the updated total_warm count."""
+        for ws_id in manager.known_workspace_ids():
+            if settings.max_total_warm > 0 and total_warm >= settings.max_total_warm:
+                break
+            pool_cfg = manager.get_workspace_pool(ws_id)
+            current = manager.current_pool_size(ws_id)
+            recent_max = manager.recent_concurrent_max(
+                ws_id, window_seconds=settings.warm_window_seconds
+            )
+            delta = autoscaler.decide(
+                pool_cfg,
+                current_pool_size=current,
+                recent_concurrent_max=recent_max,
+            )
+            if delta > 0:
+                cap = (
+                    settings.max_total_warm - total_warm
+                    if settings.max_total_warm > 0
+                    else delta
+                )
+                added = await asyncio.to_thread(manager.prewarm, ws_id, min(delta, cap))
+                if added:
+                    logger.info(
+                        "Prewarmed %d sandbox(es) for workspace %s", added, ws_id
+                    )
+                total_warm += added
+        return total_warm
 
     async def _reap_loop() -> None:
         while True:
@@ -749,6 +871,13 @@ async def _manager_lifespan(manager: SandboxRuntimeManager) -> AsyncIterator[Non
                         len(reaped_idle),
                         len(reaped_stale),
                     )
+                for lease in reaped_idle + reaped_stale:
+                    resident_pool.shutdown(lease.sandbox_id)
+                total_warm = sum(
+                    manager.current_pool_size(ws_id)
+                    for ws_id in manager.known_workspace_ids()
+                )
+                await _run_prewarm(total_warm)
             except asyncio.CancelledError:
                 raise
             except Exception:
@@ -759,6 +888,7 @@ async def _manager_lifespan(manager: SandboxRuntimeManager) -> AsyncIterator[Non
         yield
     finally:
         task.cancel()
+        resident_pool.shutdown_all()
         with suppress(asyncio.CancelledError):
             await task
         manager.shutdown()
@@ -791,7 +921,8 @@ def build_service_app(
     settings = settings or SandboxSettings.from_env()
     manager = manager or SandboxRuntimeManager(runtime=runtime, settings=settings)
     executor = executor or ContainerExecutor()
-    invoker = invoker or WorkflowSandboxInvoker(executor)
+    resident_pool = ResidentRunnerPool()
+    invoker = invoker or WorkflowSandboxInvoker(resident_pool)
     ingestion_invoker = ingestion_invoker or ScriptSandboxInvoker(executor)
     authorize = _control_dependency(
         control_token
@@ -801,10 +932,12 @@ def build_service_app(
     handles: dict[str, ContainerHandle] = {}
 
     _manager = manager  # capture for closure
+    _settings = settings
+    _resident_pool = resident_pool
 
     @asynccontextmanager
     async def _lifespan(app: FastAPI) -> AsyncIterator[None]:  # noqa: ARG001
-        async with _manager_lifespan(_manager):
+        async with _manager_lifespan(_manager, _settings, _resident_pool):
             yield
 
     app = FastAPI(
@@ -816,7 +949,7 @@ def build_service_app(
         lifespan=_lifespan,
     )
     _register_container_routes(app, runtime, handles, settings, authorize)
-    _register_lease_routes(app, manager, authorize)
+    _register_lease_routes(app, manager, authorize, resident_pool)
     _register_sandbox_routes(
         app,
         executor,

--- a/src/orcheo/sandbox/service.py
+++ b/src/orcheo/sandbox/service.py
@@ -423,7 +423,21 @@ class ScriptSandboxInvoker:
             )
         output = _last_json_line(result.stdout)
         if result.exit_code not in (0, None) or output is None:
-            detail = result.stderr.strip() or "ingestion runner produced no output"
+            stderr = result.stderr.strip()
+            stdout = result.stdout.strip()
+            if stderr:
+                detail = stderr
+            elif output is None and result.exit_code not in (0, None):
+                detail = (
+                    f"ingestion runner exited with code {result.exit_code} "
+                    "without producing JSON output"
+                )
+                if stdout:
+                    detail = f"{detail}: {stdout}"
+            elif stdout:
+                detail = stdout
+            else:
+                detail = "ingestion runner produced no output"
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=detail,

--- a/src/orcheo/sandbox/service.py
+++ b/src/orcheo/sandbox/service.py
@@ -323,29 +323,39 @@ class ResidentRunnerPool:
         # sandbox_id → asyncio subprocess handle
         self._runners: dict[str, asyncio.subprocess.Process] = {}
 
-    async def _start_runner(self, sandbox_id: str) -> asyncio.subprocess.Process:
+    async def _start_runner(self, sandbox_id: str, broker_token: str = "") -> asyncio.subprocess.Process:
         """Start a fresh resident runner inside the container and register it."""
-        process = await asyncio.create_subprocess_exec(
+        cmd = [
             "docker",
             "exec",
             "-i",
+        ]
+        # Add broker token environment variable if provided
+        if broker_token:
+            cmd.extend(["-e", f"ORCHEO_BROKER_TOKEN={broker_token}"])
+        
+        cmd.extend([
             sandbox_id,
             "python",
             "-m",
             _WORKFLOW_RUNNER_MODULE,
+        ])
+        
+        process = await asyncio.create_subprocess_exec(
+            *cmd,
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,  # Redirect stderr to avoid pipe blocking
         )
         self._runners[sandbox_id] = process
         return process
 
-    async def _get_or_start(self, sandbox_id: str) -> asyncio.subprocess.Process:
+    async def _get_or_start(self, sandbox_id: str, broker_token: str = "") -> asyncio.subprocess.Process:
         """Return the live runner for sandbox_id, starting one if absent or dead."""
         process = self._runners.get(sandbox_id)
         if process is not None and process.returncode is None:
             return process
-        return await self._start_runner(sandbox_id)
+        return await self._start_runner(sandbox_id, broker_token)
 
     def _kill_runner(self, sandbox_id: str) -> None:
         """Terminate and forget the runner for sandbox_id."""
@@ -378,7 +388,7 @@ class ResidentRunnerPool:
     ) -> WorkflowRunResult:
         failure_reason: str = ""
         try:
-            process = await self._get_or_start(sandbox_id)
+            process = await self._get_or_start(sandbox_id, broker_token)
             payload_bytes = (
                 json.dumps(
                     {

--- a/src/orcheo/sandbox/workflow_runner.py
+++ b/src/orcheo/sandbox/workflow_runner.py
@@ -194,9 +194,9 @@ def _credential_context(
     *,
     run_id: str,
     workspace_id: str | None,
+    broker_token: str = "",
 ) -> AbstractContextManager[Any]:
     """Bind the broker credential resolver when this run has a broker token."""
-    broker_token = os.getenv("ORCHEO_BROKER_TOKEN", "").strip()
     if not broker_token:
         return nullcontext()
     broker_url = os.getenv("ORCHEO_CREDENTIAL_BROKER_URL", "").strip()
@@ -224,12 +224,10 @@ def _execute_workflow_in_child(
     state_config: Mapping[str, Any],
     run_id: str,
     workspace_id: str | None,
+    broker_token: str = "",
 ) -> None:
     """Execute the workflow in a forked child and send the result back."""
     try:
-        # In a real deployment this calls the graph builder + runner.
-        # The runner module ships with the workflow-sandbox image, so the
-        # heavy imports stay out of the worker.
         outputs = _run_graph(
             workflow_definition,
             inputs,
@@ -237,6 +235,7 @@ def _execute_workflow_in_child(
             state_config=state_config,
             run_id=run_id,
             workspace_id=workspace_id,
+            broker_token=broker_token,
         )
         queue.put({"status": "succeeded", "outputs": dict(outputs), "error": None})
     except Exception as exc:  # noqa: BLE001 — propagate failure to parent
@@ -264,6 +263,7 @@ def _run_graph(
     state_config: Mapping[str, Any] | None = None,
     run_id: str = "",
     workspace_id: str | None = None,
+    broker_token: str = "",
 ) -> Mapping[str, Any]:
     """Execute the workflow graph and return its outputs.
 
@@ -294,7 +294,9 @@ def _run_graph(
     # backend / worker process, not the child mp.Process that the runner
     # spawns).
     with (
-        _credential_context(run_id=run_id, workspace_id=workspace_id),
+        _credential_context(
+            run_id=run_id, workspace_id=workspace_id, broker_token=broker_token
+        ),
         use_launcher(LocalProcessLauncher()),
     ):
         result = asyncio.run(
@@ -314,6 +316,8 @@ def run_in_subprocess(
     state_config: Mapping[str, Any] | None = None,
     run_id: str = "",
     workspace_id: str | None = None,
+    broker_token: str = "",
+    timeout_seconds: float | None = None,
     spawn: bool = True,
 ) -> Mapping[str, Any]:
     """Run a workflow definition in a fresh child process and return its result.
@@ -326,8 +330,13 @@ def run_in_subprocess(
         run_id: Run identifier used by the run-scoped credential broker.
         workspace_id: Workspace identifier injected into the initial state and
             credential broker calls.
-        spawn: When True (default), use ``multiprocessing`` to fork a fresh
-            child. Set to False in unit tests to execute in-process.
+        broker_token: Run-scoped credential broker token. Passed explicitly
+            rather than via env so the resident runner can accept a fresh token
+            per run without restarting the process.
+        timeout_seconds: Wall-clock cap on the child process. None means no
+            per-run timeout (the HTTP-level timeout on the caller side applies).
+        spawn: When True (default), fork a fresh child via ``multiprocessing``.
+            Set to False in unit tests to execute in-process.
 
     Returns:
         The result dict produced by ``_execute_workflow_in_child``.
@@ -347,9 +356,14 @@ def run_in_subprocess(
             state_config or {},
             run_id,
             workspace_id,
+            broker_token,
         )
         return queue[0]
-    ctx = mp.get_context("spawn")
+    # fork shares the parent's already-loaded modules via copy-on-write so
+    # the child does not re-pay the langgraph import cost (~3 s) on every run.
+    # The parent's serve_stdin_loop pre-imports build_graph / build_initial_state
+    # before entering the request loop so they are resident in memory at fork time.
+    ctx = mp.get_context("fork")
     q: mp.Queue[Mapping[str, Any]] = ctx.Queue()
     process = ctx.Process(
         target=_execute_workflow_in_child,
@@ -361,19 +375,28 @@ def run_in_subprocess(
             state_config or {},
             run_id,
             workspace_id,
+            broker_token,
         ),
         daemon=True,
     )
     process.start()
-    process.join()
+    process.join(timeout_seconds)
+    if process.is_alive():
+        process.kill()
+        process.join()
+        return {
+            "status": "failed",
+            "outputs": {},
+            "error": "workflow run timed out in sandbox child process",
+        }
     try:
         return q.get_nowait()
     except Empty:
         # The child exited without putting a result on the queue: either it
         # was killed (signal / OOM) or it died before reaching the try/except
-        # in ``_execute_workflow_in_child`` (e.g. import-time crash during
-        # spawn). Surface the exit status so the failure is debuggable from
-        # the dispatcher logs instead of just ``_queue.Empty``.
+        # in ``_execute_workflow_in_child`` (e.g. import-time crash at fork).
+        # Surface the exit status so the failure is debuggable from the
+        # dispatcher logs instead of just ``_queue.Empty``.
         exitcode = process.exitcode
         if exitcode is None:
             detail = "child process is still running after join()"
@@ -411,17 +434,38 @@ def _json_default(value: Any) -> Any:
 
 
 def serve_stdin_loop() -> None:  # pragma: no cover - long-running entrypoint
-    """Read newline-delimited JSON specs from stdin until EOF."""
+    """Read newline-delimited JSON specs from stdin until EOF.
+
+    Pre-imports the graph runtime once so every fork child inherits loaded
+    modules via copy-on-write, eliminating the ~3 s per-run import tax.
+    """
+    # Heavy imports happen here in the resident parent process so fork children
+    # find them already in sys.modules and skip re-importing.
+    from orcheo.graph.builder import build_graph as _build_graph_preload  # noqa: F401
+    from orcheo.runtime.state_builder import (
+        build_initial_state as _state_preload,  # noqa: F401
+    )
+
     for line in sys.stdin:
-        payload = json.loads(line)
-        result = run_in_subprocess(
-            payload["workflow_definition"],
-            payload["inputs"],
-            runnable_config=payload.get("runnable_config") or {},
-            state_config=payload.get("state_config") or {},
-            run_id=str(payload.get("run_id") or ""),
-            workspace_id=payload.get("workspace_id"),
-        )
+        try:
+            payload = json.loads(line)
+            result: Mapping[str, Any] = run_in_subprocess(
+                payload["workflow_definition"],
+                payload["inputs"],
+                runnable_config=payload.get("runnable_config") or {},
+                state_config=payload.get("state_config") or {},
+                run_id=str(payload.get("run_id") or ""),
+                workspace_id=payload.get("workspace_id"),
+                broker_token=str(payload.get("broker_token") or ""),
+                timeout_seconds=payload.get("timeout_seconds"),
+            )
+        except Exception as exc:  # noqa: BLE001
+            tb = traceback.format_exc()
+            result = {
+                "status": "failed",
+                "outputs": {},
+                "error": f"{type(exc).__name__}: {exc}\n{tb}",
+            }
         if is_dataclass(result) and not isinstance(result, type):
             serialized: Mapping[str, Any] = asdict(cast(Any, result))
         else:

--- a/tests/sandbox/test_config.py
+++ b/tests/sandbox/test_config.py
@@ -124,3 +124,23 @@ def test_from_env_reads_process_environment(monkeypatch: pytest.MonkeyPatch) -> 
 
     assert settings.container_runtime == "runc"
     assert settings.default_pool_max == 12
+
+
+def test_warm_window_seconds_default_and_env_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """warm_window_seconds defaults to 600 and reads from env."""
+    assert SandboxSettings().warm_window_seconds == 600
+
+    monkeypatch.setenv("ORCHEO_SANDBOX_WARM_WINDOW_SECONDS", "300")
+    assert SandboxSettings.from_env().warm_window_seconds == 300
+
+
+def test_max_total_warm_default_and_env_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """max_total_warm defaults to 12 and reads from env."""
+    assert SandboxSettings().max_total_warm == 12
+
+    monkeypatch.setenv("ORCHEO_SANDBOX_MAX_TOTAL_WARM", "0")
+    assert SandboxSettings.from_env().max_total_warm == 0  # 0 means unbounded

--- a/tests/sandbox/test_ingestion_runner.py
+++ b/tests/sandbox/test_ingestion_runner.py
@@ -1,116 +1,41 @@
-"""Tests for the one-shot sandbox ingestion process entrypoint."""
+"""Tests for the sandbox ingestion runner entrypoint."""
 
 from __future__ import annotations
-
 import io
 import json
-import runpy
-import sys
 
 import pytest
-
-from orcheo.graph import ingestion as graph_ingestion
-from orcheo.graph.ingestion import DEFAULT_SCRIPT_SIZE_LIMIT
 from orcheo.sandbox import ingestion_runner
 
 
-_VALID_SCRIPT = """
-from langgraph.graph import StateGraph
-from orcheo.graph.state import State
-
-def build_graph():
-    graph = StateGraph(State)
-    graph.add_node("noop", lambda state: state)
-    graph.set_entry_point("noop")
-    graph.set_finish_point("noop")
-    return graph
-"""
-
-
-def _invoke(
+def test_ingestion_runner_serializes_system_exit(
     monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-    payload: dict[str, object],
-) -> dict[str, object]:
-    monkeypatch.setattr(ingestion_runner.sys, "stdin", io.StringIO(json.dumps(payload)))
-    ingestion_runner.main()
-    return json.loads(capsys.readouterr().out)
-
-
-def test_ingestion_runner_returns_serialized_payload(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """A valid source file returns the existing stored graph format."""
-    result = _invoke(
-        monkeypatch,
-        capsys,
-        {"source": _VALID_SCRIPT, "entrypoint": "build_graph"},
-    )
-    assert result["status"] == "succeeded"
-    assert result["payload"]["source"] == _VALID_SCRIPT  # type: ignore[index]
+    """Unexpected process exits are converted into JSON failures."""
 
+    def _raise(*args: object, **kwargs: object) -> object:
+        raise SystemExit("bye")
 
-def test_ingestion_runner_reports_syntax_errors(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """Invalid Python is returned as validation failure, not an exception."""
-    result = _invoke(
-        monkeypatch,
-        capsys,
-        {"source": "not python !!!", "entrypoint": "build_graph"},
-    )
-    assert result["status"] == "failed"
-
-
-def test_ingestion_runner_rejects_oversized_source(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """The one-shot path enforces the configured input size cap."""
-    result = _invoke(
-        monkeypatch,
-        capsys,
-        {"source": "x" * (DEFAULT_SCRIPT_SIZE_LIMIT + 1)},
-    )
-    assert result["status"] == "failed"
-    assert "exceeds the permitted size" in str(result["error"])
-
-
-def test_ingestion_runner_enforces_timeout(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """Long-running source execution is bounded inside the process."""
-    result = _invoke(
-        monkeypatch,
-        capsys,
-        {"source": "while True:\n    pass\n", "execution_timeout_seconds": 0.01},
-    )
-    assert result["status"] == "failed"
-    assert "execution exceeded" in str(result["error"])
-
-
-def test_ingestion_runner_module_entrypoint(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """Executing the module as a script still routes through main()."""
-
-    def fake_ingest(*args: object, **kwargs: object) -> dict[str, object]:
-        del args, kwargs
-        return {"graph": "ok"}
-
-    monkeypatch.setattr(graph_ingestion, "ingest_langgraph_script", fake_ingest)
+    monkeypatch.setattr(ingestion_runner, "ingest_langgraph_script", _raise)
     monkeypatch.setattr(
         ingestion_runner.sys,
         "stdin",
-        io.StringIO(json.dumps({"source": _VALID_SCRIPT, "entrypoint": "build_graph"})),
+        io.StringIO(
+            json.dumps(
+                {
+                    "source": "graph = object()",
+                    "entrypoint": None,
+                    "max_script_bytes": 1,
+                    "execution_timeout_seconds": 1.0,
+                }
+            )
+        ),
     )
-    module_name = "orcheo.sandbox.ingestion_runner"
-    loaded_module = sys.modules.pop(module_name, None)
+    stdout = io.StringIO()
+    monkeypatch.setattr(ingestion_runner.sys, "stdout", stdout)
 
-    try:
-        runpy.run_module(module_name, run_name="__main__")
-    finally:
-        if loaded_module is not None:
-            sys.modules[module_name] = loaded_module
+    ingestion_runner.main()
 
-    result = json.loads(capsys.readouterr().out)
-    assert result == {"status": "succeeded", "payload": {"graph": "ok"}}
+    payload = json.loads(stdout.getvalue())
+    assert payload["status"] == "failed"
+    assert payload["error"] == "SystemExit: bye"

--- a/tests/sandbox/test_ingestion_runner.py
+++ b/tests/sandbox/test_ingestion_runner.py
@@ -3,9 +3,92 @@
 from __future__ import annotations
 import io
 import json
+import runpy
 
 import pytest
 from orcheo.sandbox import ingestion_runner
+
+
+def test_main_succeeds_with_valid_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    """main() emits succeeded JSON when ingestion completes (line 36)."""
+    expected_payload = {"format": "langgraph-script"}
+    monkeypatch.setattr(
+        ingestion_runner, "ingest_langgraph_script", lambda *a, **kw: expected_payload
+    )
+    monkeypatch.setattr(
+        ingestion_runner.sys,
+        "stdin",
+        io.StringIO(
+            json.dumps(
+                {
+                    "source": "graph = object()",
+                    "entrypoint": None,
+                    "max_script_bytes": 1,
+                    "execution_timeout_seconds": 1.0,
+                }
+            )
+        ),
+    )
+    stdout = io.StringIO()
+    monkeypatch.setattr(ingestion_runner.sys, "stdout", stdout)
+
+    ingestion_runner.main()
+
+    result = json.loads(stdout.getvalue())
+    assert result["status"] == "succeeded"
+    assert result["payload"] == expected_payload
+
+
+def test_main_fails_with_empty_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
+    """main() emits a failed result when stdin is empty (lines 29-30, 43)."""
+    monkeypatch.setattr(ingestion_runner.sys, "stdin", io.StringIO(""))
+    stdout = io.StringIO()
+    monkeypatch.setattr(ingestion_runner.sys, "stdout", stdout)
+
+    ingestion_runner.main()
+
+    result = json.loads(stdout.getvalue())
+    assert result["status"] == "failed"
+    assert "missing" in result["error"]
+
+
+def test_main_fails_with_non_mapping_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    """main() emits a failed result when JSON root is not an object (lines 29-30, 46)."""
+    monkeypatch.setattr(ingestion_runner.sys, "stdin", io.StringIO("[1, 2, 3]"))
+    stdout = io.StringIO()
+    monkeypatch.setattr(ingestion_runner.sys, "stdout", stdout)
+
+    ingestion_runner.main()
+
+    result = json.loads(stdout.getvalue())
+    assert result["status"] == "failed"
+    assert "JSON object" in result["error"]
+
+
+def test_ingestion_runner_main_block_is_guarded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The if __name__ == '__main__' guard calls main() when executed as a module (line 51)."""
+    import sys as _sys
+
+    monkeypatch.setattr(ingestion_runner.sys, "stdin", io.StringIO(""))
+    stdout = io.StringIO()
+    monkeypatch.setattr(ingestion_runner.sys, "stdout", stdout)
+
+    # Remove the already-imported module so runpy executes a clean copy without
+    # triggering the "found in sys.modules" RuntimeWarning.
+    saved = _sys.modules.pop("orcheo.sandbox.ingestion_runner", None)
+    try:
+        runpy.run_module(
+            "orcheo.sandbox.ingestion_runner", run_name="__main__", alter_sys=False
+        )
+    finally:
+        if saved is not None:
+            _sys.modules["orcheo.sandbox.ingestion_runner"] = saved
+
+    result = json.loads(stdout.getvalue())
+    assert result["status"] == "failed"
+    assert "missing" in result["error"]
 
 
 def test_ingestion_runner_serializes_system_exit(

--- a/tests/sandbox/test_manager.py
+++ b/tests/sandbox/test_manager.py
@@ -505,12 +505,15 @@ def test_recent_concurrent_max_returns_peak_within_window() -> None:
 
 def test_recent_concurrent_max_returns_zero_for_stagnant_workspace() -> None:
     """Workspaces with no samples within the window return 0."""
+    import time as _time
+
     manager, _ = _manager()
-    # Acquire and release without any recent usage
     l = manager.acquire("ws")
     manager.release(l)
-    # Use a tiny window so the samples fall outside it
-    peak = manager.recent_concurrent_max("ws", window_seconds=0.0001)
+    # Back-date all samples so they are clearly outside any reasonable window.
+    for sample in manager._usage_samples.get("ws", []):
+        sample.timestamp = _time.monotonic() - 9999.0
+    peak = manager.recent_concurrent_max("ws", window_seconds=600.0)
     assert peak == 0
 
 
@@ -567,3 +570,21 @@ def test_prewarm_zero_count_is_noop() -> None:
     manager, runtime = _manager()
     assert manager.prewarm("ws", 0) == 0
     assert len(runtime.started) == 0
+
+
+def test_prewarm_stops_early_when_runtime_raises() -> None:
+    """prewarm() stops after the first provision failure (lines 443-448)."""
+    from orcheo.sandbox.runtime import ContainerHandle, ContainerSpec
+
+    class _BoomRuntime(InMemoryContainerRuntime):
+        def start(self, spec: ContainerSpec) -> ContainerHandle:
+            raise RuntimeError("docker is gone")
+
+    runtime = _BoomRuntime()
+    mgr = SandboxRuntimeManager(
+        runtime=runtime,
+        settings=SandboxSettings(),
+    )
+    added = mgr.prewarm("ws", 3)
+    assert added == 0
+    assert mgr.current_pool_size("ws") == 0

--- a/tests/sandbox/test_manager.py
+++ b/tests/sandbox/test_manager.py
@@ -476,3 +476,94 @@ def test_reap_stale_in_use_swallows_notfound_during_destroy() -> None:
 
     reaped = manager.reap_stale_in_use(max_duration_seconds=1)
     assert reaped == [lease]  # lease was collected; destroy just failed silently
+
+
+# ---------------------------------------------------------------------------
+# WS2: usage tracking and prewarm
+# ---------------------------------------------------------------------------
+
+
+def test_recent_concurrent_max_returns_peak_within_window() -> None:
+    """recent_concurrent_max tracks the highest concurrent count in the window."""
+    import time
+
+    manager, _ = _manager(pool_max=4)
+
+    # First acquire: 1 in-use
+    l1 = manager.acquire("ws")
+    # Second acquire: 2 in-use
+    l2 = manager.acquire("ws")
+
+    peak = manager.recent_concurrent_max("ws", window_seconds=600.0)
+    assert peak == 2
+
+    manager.release(l1)
+    manager.release(l2)
+    # Peak is still 2 within the window
+    assert manager.recent_concurrent_max("ws", window_seconds=600.0) == 2
+
+
+def test_recent_concurrent_max_returns_zero_for_stagnant_workspace() -> None:
+    """Workspaces with no samples within the window return 0."""
+    manager, _ = _manager()
+    # Acquire and release without any recent usage
+    l = manager.acquire("ws")
+    manager.release(l)
+    # Use a tiny window so the samples fall outside it
+    peak = manager.recent_concurrent_max("ws", window_seconds=0.0001)
+    assert peak == 0
+
+
+def test_recent_concurrent_max_returns_zero_for_unknown_workspace() -> None:
+    """Workspaces never seen return 0."""
+    manager, _ = _manager()
+    assert manager.recent_concurrent_max("never-seen", window_seconds=600.0) == 0
+
+
+def test_current_pool_size_reflects_ready_pool() -> None:
+    """current_pool_size returns the number of warm-ready sandboxes."""
+    manager, _ = _manager(pool_max=2)
+    assert manager.current_pool_size("ws") == 0
+    l = manager.acquire("ws")
+    assert manager.current_pool_size("ws") == 0  # IN_USE, not in pool
+    manager.release(l)
+    assert manager.current_pool_size("ws") == 1
+
+
+def test_known_workspace_ids_includes_configured_workspaces() -> None:
+    """known_workspace_ids returns workspaces whose pool configs are registered."""
+    manager, _ = _manager()
+    # Implicitly registers via acquire / get_workspace_pool
+    manager.acquire("ws-a")
+    manager.acquire("ws-b")
+    ids = manager.known_workspace_ids()
+    assert "ws-a" in ids
+    assert "ws-b" in ids
+
+
+def test_prewarm_adds_ready_containers_to_pool() -> None:
+    """prewarm provisions containers directly into the READY pool."""
+    manager, runtime = _manager(pool_max=4)
+    added = manager.prewarm("ws", 2)
+    assert added == 2
+    assert manager.current_pool_size("ws") == 2
+    assert len(runtime.started) == 2
+    # Prewarmed sandboxes should be immediately acquirable
+    l = manager.acquire("ws")
+    assert l.state is SandboxState.IN_USE
+    assert manager.current_pool_size("ws") == 1
+
+
+def test_prewarm_respects_pool_max() -> None:
+    """prewarm does not exceed the workspace pool_max."""
+    manager, _ = _manager(pool_max=2)
+    added = manager.prewarm("ws", 5)  # ask for 5, cap is 2
+    assert added == 2
+    assert manager.current_pool_size("ws") == 2
+
+
+def test_prewarm_zero_count_is_noop() -> None:
+    """prewarm(ws, 0) is a no-op and returns 0."""
+    manager, runtime = _manager()
+    assert manager.prewarm("ws", 0) == 0
+    assert len(runtime.started) == 0

--- a/tests/sandbox/test_service_and_remote.py
+++ b/tests/sandbox/test_service_and_remote.py
@@ -316,7 +316,26 @@ def test_ingestion_invoker_reports_missing_json_output() -> None:
         timed_out=False,
         duration_seconds=0.01,
     )
-    with pytest.raises(Exception, match="no output"):
+    with pytest.raises(Exception, match="not json"):
+        asyncio.run(
+            ScriptSandboxInvoker(executor).invoke(
+                "sandbox", ScriptIngestionPayload(source="graph = object()")
+            )
+        )
+
+
+def test_ingestion_invoker_reports_exit_code_without_output() -> None:
+    """A silent child exit surfaces the exit code for debugging."""
+    executor = _FakeExecutor()
+    executor.result = ProcessExecutionResult(
+        command=[],
+        stdout="",
+        stderr="",
+        exit_code=137,
+        timed_out=False,
+        duration_seconds=0.01,
+    )
+    with pytest.raises(Exception, match="exited with code 137"):
         asyncio.run(
             ScriptSandboxInvoker(executor).invoke(
                 "sandbox", ScriptIngestionPayload(source="graph = object()")

--- a/tests/sandbox/test_service_and_remote.py
+++ b/tests/sandbox/test_service_and_remote.py
@@ -856,9 +856,9 @@ def test_resident_runner_pool_reuses_process_across_calls() -> None:
         start_calls: list[str] = []
         original_start = pool._start_runner
 
-        async def _tracking_start(sandbox_id: str):
+        async def _tracking_start(sandbox_id: str, broker_token: str = ""):
             start_calls.append(sandbox_id)
-            return await original_start(sandbox_id)
+            return await original_start(sandbox_id, broker_token)
 
         result_line = b'{"run_id":"r","status":"succeeded","outputs":{},"error":null}\n'
         fake_stdout = mock.AsyncMock()
@@ -1807,7 +1807,7 @@ def test_pool_returns_failed_on_eof() -> None:
         pool = ResidentRunnerPool()
         # Both the first attempt and the retry return EOF → final failure.
         pool._runners["sb-1"] = _make_fake_pool_process(response_line=b"")
-        pool._start_runner = lambda sid: _make_fake_pool_process(response_line=b"")  # type: ignore[method-assign]
+        pool._start_runner = lambda sid, token="": _make_fake_pool_process(response_line=b"")  # type: ignore[method-assign]
 
         spec = WorkflowRunSpec(
             run_id="r-eof", workspace_id="ws", workflow_definition={}, inputs={}
@@ -1829,7 +1829,7 @@ def test_pool_returns_failed_on_invalid_json() -> None:
         pool = ResidentRunnerPool()
         bad_line = b"{not valid json}\n"
         pool._runners["sb-1"] = _make_fake_pool_process(response_line=bad_line)
-        pool._start_runner = lambda sid: _make_fake_pool_process(response_line=bad_line)  # type: ignore[method-assign]
+        pool._start_runner = lambda sid, token="": _make_fake_pool_process(response_line=bad_line)  # type: ignore[method-assign]
 
         spec = WorkflowRunSpec(
             run_id="r-badjson", workspace_id="ws", workflow_definition={}, inputs={}

--- a/tests/sandbox/test_service_and_remote.py
+++ b/tests/sandbox/test_service_and_remote.py
@@ -29,6 +29,7 @@ from orcheo.sandbox.runtime import ContainerSpec, InMemoryContainerRuntime
 from orcheo.sandbox.service import (
     ContainerExecutor,
     ExecRequest,
+    ResidentRunnerPool,
     ScriptIngestionPayload,
     ScriptSandboxInvoker,
     SandboxProvisionRequest,
@@ -36,6 +37,7 @@ from orcheo.sandbox.service import (
     build_credential_relay_app,
     build_service_app,
     _control_dependency,
+    _manager_lifespan,
     _resolve_extra_hosts,
     _sandbox_environment,
 )
@@ -767,26 +769,30 @@ def test_dispatch_workflow_endpoint(
     assert broker_token == "tok-1"
 
 
-def test_workflow_invoker_uses_stdin_for_payload() -> None:
-    """Workflow dispatch must stream JSON over stdin instead of argv."""
+def test_resident_runner_pool_sends_full_payload_and_parses_result() -> None:
+    """ResidentRunnerPool writes a complete JSON payload and parses the result line."""
     import unittest.mock as mock
 
     async def go() -> WorkflowRunResult:
-        from orcheo.sandbox.service import WorkflowSandboxInvoker
+        from orcheo.sandbox.service import ResidentRunnerPool
         from orcheo.sandbox.workflow import WorkflowRunSpec
 
-        executor = mock.AsyncMock()
-        executor.exec = mock.AsyncMock(
-            return_value=ProcessExecutionResult(
-                command=["python", "-m", "orcheo.sandbox.workflow_runner"],
-                stdout='{"status":"succeeded","outputs":{"ok":true},"error":null}\n',
-                stderr="",
-                exit_code=0,
-                timed_out=False,
-                duration_seconds=0.1,
-            )
-        )
-        invoker = WorkflowSandboxInvoker(executor)
+        pool = ResidentRunnerPool()
+
+        # Fake process: readable stdout returns the result line, stdin is a sink.
+        result_line = b'{"run_id":"r-ok","status":"succeeded","outputs":{"ok":true},"error":null}\n'
+        fake_stdout = mock.AsyncMock()
+        fake_stdout.readline = mock.AsyncMock(return_value=result_line)
+        fake_stdin = mock.MagicMock()
+        fake_stdin.write = mock.MagicMock()
+        fake_stdin.drain = mock.AsyncMock()
+        fake_process = mock.MagicMock()
+        fake_process.returncode = None
+        fake_process.stdin = fake_stdin
+        fake_process.stdout = fake_stdout
+
+        pool._runners["sb-1"] = fake_process  # inject pre-started runner
+
         spec = WorkflowRunSpec(
             run_id="r-ok",
             workspace_id="ws",
@@ -797,26 +803,68 @@ def test_workflow_invoker_uses_stdin_for_payload() -> None:
             state_config={"configurable": {"ai_model": "openai:test"}},
         )
 
-        result = await invoker.invoke("sb-1", spec, "token")
+        result = await pool.invoke("sb-1", spec, "tok-1")
 
-        call = executor.exec.await_args
-        assert call.args[0] == "sb-1"
-        request = call.args[1]
-        assert request.command == ["python", "-m", "orcheo.sandbox.workflow_runner"]
-        assert request.stdin is not None
-        payload = json.loads(request.stdin)
+        # Verify the payload written to stdin includes all expected fields.
+        write_call = fake_stdin.write.call_args
+        assert write_call is not None
+        payload = json.loads(write_call.args[0].decode("utf-8"))
         assert payload["run_id"] == "r-ok"
         assert payload["workspace_id"] == "ws"
         assert payload["workflow_definition"] == {"nodes": [{"type": "AINode"}]}
         assert payload["inputs"] == {"value": 42}
         assert payload["runnable_config"] == {"configurable": {"thread_id": "r-ok"}}
         assert payload["state_config"] == {"configurable": {"ai_model": "openai:test"}}
-        assert request.env == {"ORCHEO_BROKER_TOKEN": "token"}
+        assert payload["broker_token"] == "tok-1"
+
         return result
 
     result = asyncio.run(go())
     assert result.status == "succeeded"
     assert result.outputs == {"ok": True}
+
+
+def test_resident_runner_pool_reuses_process_across_calls() -> None:
+    """The same runner process is reused for sequential dispatches to one sandbox."""
+    import unittest.mock as mock
+
+    async def go() -> None:
+        from orcheo.sandbox.service import ResidentRunnerPool
+        from orcheo.sandbox.workflow import WorkflowRunSpec
+
+        pool = ResidentRunnerPool()
+
+        start_calls: list[str] = []
+        original_start = pool._start_runner
+
+        async def _tracking_start(sandbox_id: str):
+            start_calls.append(sandbox_id)
+            return await original_start(sandbox_id)
+
+        result_line = b'{"run_id":"r","status":"succeeded","outputs":{},"error":null}\n'
+        fake_stdout = mock.AsyncMock()
+        fake_stdout.readline = mock.AsyncMock(return_value=result_line)
+        fake_stdin = mock.MagicMock()
+        fake_stdin.write = mock.MagicMock()
+        fake_stdin.drain = mock.AsyncMock()
+        fake_process = mock.MagicMock()
+        fake_process.returncode = None
+        fake_process.stdin = fake_stdin
+        fake_process.stdout = fake_stdout
+
+        pool._runners["sb-1"] = fake_process
+
+        spec = WorkflowRunSpec(
+            run_id="r", workspace_id="ws", workflow_definition={}, inputs={}
+        )
+        await pool.invoke("sb-1", spec, "")
+        await pool.invoke("sb-1", spec, "")
+
+        # No new processes should have been started since the existing one is alive.
+        assert len(start_calls) == 0
+        assert pool._runners.get("sb-1") is fake_process
+
+    asyncio.run(go())
 
 
 def test_remote_container_runtime_round_trip() -> None:
@@ -1516,12 +1564,17 @@ def test_serialize_workflow_run_result_non_dataclass() -> None:
 
 
 def test_container_executor_init_and_invoker_init() -> None:
-    """ContainerExecutor and WorkflowSandboxInvoker can be constructed directly (line 183)."""
-    from orcheo.sandbox.service import ContainerExecutor, WorkflowSandboxInvoker
+    """ContainerExecutor and WorkflowSandboxInvoker can be constructed directly."""
+    from orcheo.sandbox.service import (
+        ContainerExecutor,
+        ResidentRunnerPool,
+        WorkflowSandboxInvoker,
+    )
 
-    executor = ContainerExecutor()
-    invoker = WorkflowSandboxInvoker(executor)
-    assert invoker._executor is executor
+    ContainerExecutor()
+    pool = ResidentRunnerPool()
+    invoker = WorkflowSandboxInvoker(pool)
+    assert invoker._pool is pool
 
 
 def test_last_json_line_returns_last_valid_json() -> None:
@@ -1705,183 +1758,84 @@ def test_credential_relay_without_optional_headers(
 # ---------------------------------------------------------------------------
 
 
-def test_invoker_returns_failed_on_timeout() -> None:
-    """invoke() returns a failed WorkflowRunResult when executor times out."""
+def _make_fake_pool_process(
+    *, response_line: bytes | None, returncode: int | None = None
+):
+    """Build a fake asyncio subprocess for ResidentRunnerPool injection."""
+    import unittest.mock as mock
+
+    fake_stdout = mock.AsyncMock()
+    fake_stdout.readline = mock.AsyncMock(
+        return_value=response_line if response_line is not None else b""
+    )
+    fake_stdin = mock.MagicMock()
+    fake_stdin.write = mock.MagicMock()
+    fake_stdin.drain = mock.AsyncMock()
+    fake_process = mock.MagicMock()
+    fake_process.returncode = returncode
+    fake_process.stdin = fake_stdin
+    fake_process.stdout = fake_stdout
+    return fake_process
+
+
+def test_pool_returns_failed_on_eof() -> None:
+    """ResidentRunnerPool returns failed when the runner produces EOF (runner died)."""
 
     async def go() -> WorkflowRunResult:
-        executor = _FakeExecutor()
-        executor.result = asyncio.get_event_loop()
-        # Override to return timed_out=True.
-        from orcheo.external_agents.models import ProcessExecutionResult
-
-        timed_out_result = ProcessExecutionResult(
-            command=["sh"],
-            stdout="",
-            stderr="",
-            exit_code=None,
-            timed_out=True,
-            duration_seconds=30.0,
-        )
-        executor.result = timed_out_result
-
-        from orcheo.sandbox.service import WorkflowSandboxInvoker
+        from orcheo.sandbox.service import ResidentRunnerPool
         from orcheo.sandbox.workflow import WorkflowRunSpec
 
-        invoker = WorkflowSandboxInvoker(executor)
+        pool = ResidentRunnerPool()
+        # Both the first attempt and the retry return EOF → final failure.
+        pool._runners["sb-1"] = _make_fake_pool_process(response_line=b"")
+        pool._start_runner = lambda sid: _make_fake_pool_process(response_line=b"")  # type: ignore[method-assign]
+
         spec = WorkflowRunSpec(
-            run_id="r-timeout",
-            workspace_id="ws",
-            workflow_definition={},
-            inputs={},
-            node_types=(),
-            runnable_config={},
-            state_config={},
+            run_id="r-eof", workspace_id="ws", workflow_definition={}, inputs={}
         )
-        return await invoker.invoke("sb-1", spec, "token")
+        return await pool.invoke("sb-1", spec, "token")
 
     result = asyncio.run(go())
     assert result.status == "failed"
-    assert "timed out" in (result.error or "")
+    assert result.error is not None
 
 
-def test_invoker_returns_failed_on_non_zero_exit() -> None:
-    """invoke() returns failed when the runner exits with non-zero code."""
+def test_pool_returns_failed_on_invalid_json() -> None:
+    """ResidentRunnerPool returns failed when the runner emits invalid JSON."""
 
     async def go() -> WorkflowRunResult:
-        from orcheo.external_agents.models import ProcessExecutionResult
-
-        executor = _FakeExecutor()
-        executor.result = ProcessExecutionResult(
-            command=["sh"],
-            stdout="",
-            stderr="runner crashed",
-            exit_code=1,
-            timed_out=False,
-            duration_seconds=0.1,
-        )
-        from orcheo.sandbox.service import WorkflowSandboxInvoker
+        from orcheo.sandbox.service import ResidentRunnerPool
         from orcheo.sandbox.workflow import WorkflowRunSpec
 
-        invoker = WorkflowSandboxInvoker(executor)
+        pool = ResidentRunnerPool()
+        bad_line = b"{not valid json}\n"
+        pool._runners["sb-1"] = _make_fake_pool_process(response_line=bad_line)
+        pool._start_runner = lambda sid: _make_fake_pool_process(response_line=bad_line)  # type: ignore[method-assign]
+
         spec = WorkflowRunSpec(
-            run_id="r-exitcode",
-            workspace_id="ws",
-            workflow_definition={},
-            inputs={},
-            node_types=(),
-            runnable_config={},
-            state_config={},
+            run_id="r-badjson", workspace_id="ws", workflow_definition={}, inputs={}
         )
-        return await invoker.invoke("sb-1", spec, "token")
+        return await pool.invoke("sb-1", spec, "token")
 
     result = asyncio.run(go())
     assert result.status == "failed"
-    assert "exited with" in (result.error or "") or result.error is not None
 
 
-def test_invoker_returns_failed_when_no_json_output() -> None:
-    """invoke() returns failed when runner produces no JSON on stdout."""
-
-    async def go() -> WorkflowRunResult:
-        from orcheo.external_agents.models import ProcessExecutionResult
-
-        executor = _FakeExecutor()
-        executor.result = ProcessExecutionResult(
-            command=["sh"],
-            stdout="some non-json log output",
-            stderr="",
-            exit_code=0,
-            timed_out=False,
-            duration_seconds=0.1,
-        )
-        from orcheo.sandbox.service import WorkflowSandboxInvoker
-        from orcheo.sandbox.workflow import WorkflowRunSpec
-
-        invoker = WorkflowSandboxInvoker(executor)
-        spec = WorkflowRunSpec(
-            run_id="r-nojson",
-            workspace_id="ws",
-            workflow_definition={},
-            inputs={},
-            node_types=(),
-            runnable_config={},
-            state_config={},
-        )
-        return await invoker.invoke("sb-1", spec, "token")
-
-    result = asyncio.run(go())
-    assert result.status == "failed"
-    assert "no JSON output" in (result.error or "")
-
-
-def test_invoker_returns_failed_on_json_decode_error() -> None:
-    """invoke() returns failed when runner output is invalid JSON."""
+def test_pool_returns_succeeded_on_valid_result() -> None:
+    """ResidentRunnerPool parses a valid JSON result line from the runner."""
 
     async def go() -> WorkflowRunResult:
-        from orcheo.external_agents.models import ProcessExecutionResult
-
-        executor = _FakeExecutor()
-        executor.result = ProcessExecutionResult(
-            command=["sh"],
-            stdout="{not valid json}",
-            stderr="",
-            exit_code=0,
-            timed_out=False,
-            duration_seconds=0.1,
-        )
-        from orcheo.sandbox.service import WorkflowSandboxInvoker
+        from orcheo.sandbox.service import ResidentRunnerPool
         from orcheo.sandbox.workflow import WorkflowRunSpec
 
-        invoker = WorkflowSandboxInvoker(executor)
+        pool = ResidentRunnerPool()
+        line = b'{"run_id":"r-ok","status":"succeeded","outputs":{"answer":42},"error":null}\n'
+        pool._runners["sb-1"] = _make_fake_pool_process(response_line=line)
+
         spec = WorkflowRunSpec(
-            run_id="r-badjson",
-            workspace_id="ws",
-            workflow_definition={},
-            inputs={},
-            node_types=(),
-            runnable_config={},
-            state_config={},
+            run_id="r-ok", workspace_id="ws", workflow_definition={}, inputs={}
         )
-        return await invoker.invoke("sb-1", spec, "token")
-
-    result = asyncio.run(go())
-    assert result.status == "failed"
-    assert "parse" in (result.error or "").lower()
-
-
-def test_invoker_returns_succeeded_on_valid_json_output() -> None:
-    """invoke() parses a valid JSON result from runner stdout."""
-    import json
-
-    async def go() -> WorkflowRunResult:
-        from orcheo.external_agents.models import ProcessExecutionResult
-
-        result_json = json.dumps(
-            {"status": "succeeded", "outputs": {"answer": 42}, "error": None}
-        )
-        executor = _FakeExecutor()
-        executor.result = ProcessExecutionResult(
-            command=["sh"],
-            stdout=f"some logs\n{result_json}\n",
-            stderr="",
-            exit_code=0,
-            timed_out=False,
-            duration_seconds=0.1,
-        )
-        from orcheo.sandbox.service import WorkflowSandboxInvoker
-        from orcheo.sandbox.workflow import WorkflowRunSpec
-
-        invoker = WorkflowSandboxInvoker(executor)
-        spec = WorkflowRunSpec(
-            run_id="r-ok",
-            workspace_id="ws",
-            workflow_definition={},
-            inputs={},
-            node_types=(),
-            runnable_config={},
-            state_config={},
-        )
-        return await invoker.invoke("sb-1", spec, "token")
+        return await pool.invoke("sb-1", spec, "token")
 
     result = asyncio.run(go())
     assert result.status == "succeeded"
@@ -2466,7 +2420,7 @@ def test_service_app_lifespan_runs_and_shuts_down_cleanly(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Using TestClient as context manager triggers _lifespan (lines 807-808)."""
-    from orcheo.sandbox.service import _manager_lifespan, build_service_app
+    from orcheo.sandbox.service import build_service_app
 
     runtime = InMemoryContainerRuntime()
     settings = SandboxSettings(
@@ -2492,8 +2446,6 @@ def test_manager_lifespan_covers_reap_loop_and_shutdown(
     """_manager_lifespan starts the reaper task and shuts down the manager (lines 735-764)."""
     monkeypatch.setenv("ORCHEO_SANDBOX_REAP_INTERVAL_SECONDS", "0.01")
 
-    from orcheo.sandbox.service import _manager_lifespan
-
     runtime = InMemoryContainerRuntime()
     settings = SandboxSettings(
         credential_broker_url="http://10.99.0.2:9091/credentials/resolve"
@@ -2501,7 +2453,7 @@ def test_manager_lifespan_covers_reap_loop_and_shutdown(
     manager = SandboxRuntimeManager(runtime=runtime, settings=settings)
 
     async def go() -> None:
-        async with _manager_lifespan(manager):
+        async with _manager_lifespan(manager, settings, ResidentRunnerPool()):
             await asyncio.sleep(0.05)
 
     asyncio.run(go())
@@ -2514,8 +2466,6 @@ def test_manager_lifespan_reaper_logs_when_leases_reaped(
     import logging
 
     monkeypatch.setenv("ORCHEO_SANDBOX_REAP_INTERVAL_SECONDS", "0.01")
-
-    from orcheo.sandbox.service import _manager_lifespan
 
     runtime = InMemoryContainerRuntime()
     settings = SandboxSettings(
@@ -2542,7 +2492,7 @@ def test_manager_lifespan_reaper_logs_when_leases_reaped(
     try:
 
         async def go() -> None:
-            async with _manager_lifespan(manager):
+            async with _manager_lifespan(manager, settings, ResidentRunnerPool()):
                 await asyncio.sleep(0.05)
 
         asyncio.run(go())
@@ -2557,8 +2507,6 @@ def test_manager_lifespan_reaper_handles_unexpected_exception(
 ) -> None:
     """Unexpected exceptions in the reaper loop are logged, not propagated (lines 754-755)."""
     monkeypatch.setenv("ORCHEO_SANDBOX_REAP_INTERVAL_SECONDS", "0.01")
-
-    from orcheo.sandbox.service import _manager_lifespan
 
     runtime = InMemoryContainerRuntime()
     settings = SandboxSettings(
@@ -2576,7 +2524,7 @@ def test_manager_lifespan_reaper_handles_unexpected_exception(
     manager.reap_idle = _boom  # type: ignore[method-assign]
 
     async def go() -> None:
-        async with _manager_lifespan(manager):
+        async with _manager_lifespan(manager, settings, ResidentRunnerPool()):
             await asyncio.sleep(0.05)
 
     asyncio.run(go())
@@ -2588,8 +2536,6 @@ def test_manager_lifespan_reaper_reraises_cancelled_error(
 ) -> None:
     """CancelledError inside the try block is re-raised, not swallowed (line 753)."""
     monkeypatch.setenv("ORCHEO_SANDBOX_REAP_INTERVAL_SECONDS", "0.01")
-
-    from orcheo.sandbox.service import _manager_lifespan
 
     runtime = InMemoryContainerRuntime()
     settings = SandboxSettings(
@@ -2607,7 +2553,7 @@ def test_manager_lifespan_reaper_reraises_cancelled_error(
     manager.reap_idle = _raise_cancelled  # type: ignore[method-assign]
 
     async def go() -> None:
-        async with _manager_lifespan(manager):
+        async with _manager_lifespan(manager, settings, ResidentRunnerPool()):
             await asyncio.sleep(0.05)
 
     asyncio.run(go())

--- a/tests/sandbox/test_service_and_remote.py
+++ b/tests/sandbox/test_service_and_remote.py
@@ -1807,7 +1807,9 @@ def test_pool_returns_failed_on_eof() -> None:
         pool = ResidentRunnerPool()
         # Both the first attempt and the retry return EOF → final failure.
         pool._runners["sb-1"] = _make_fake_pool_process(response_line=b"")
-        pool._start_runner = lambda sid, token="": _make_fake_pool_process(response_line=b"")  # type: ignore[method-assign]
+        pool._start_runner = lambda sid, token="": _make_fake_pool_process(
+            response_line=b""
+        )  # type: ignore[method-assign]
 
         spec = WorkflowRunSpec(
             run_id="r-eof", workspace_id="ws", workflow_definition={}, inputs={}
@@ -1829,7 +1831,9 @@ def test_pool_returns_failed_on_invalid_json() -> None:
         pool = ResidentRunnerPool()
         bad_line = b"{not valid json}\n"
         pool._runners["sb-1"] = _make_fake_pool_process(response_line=bad_line)
-        pool._start_runner = lambda sid, token="": _make_fake_pool_process(response_line=bad_line)  # type: ignore[method-assign]
+        pool._start_runner = lambda sid, token="": _make_fake_pool_process(
+            response_line=bad_line
+        )  # type: ignore[method-assign]
 
         spec = WorkflowRunSpec(
             run_id="r-badjson", workspace_id="ws", workflow_definition={}, inputs={}
@@ -2577,3 +2581,287 @@ def test_manager_lifespan_reaper_reraises_cancelled_error(
 
     asyncio.run(go())
     assert call_count > 0
+
+
+# ---------------------------------------------------------------------------
+# ResidentRunnerPool._start_runner (lines 330-355)
+# ---------------------------------------------------------------------------
+
+
+def test_start_runner_builds_command_with_broker_token() -> None:
+    """_start_runner includes -e ORCHEO_BROKER_TOKEN when broker_token is given (lines 330-355)."""
+    import unittest.mock as mock
+
+    async def go() -> None:
+        pool = ResidentRunnerPool()
+
+        fake_process = mock.MagicMock()
+        fake_process.returncode = None
+
+        with mock.patch(
+            "orcheo.sandbox.service.asyncio.create_subprocess_exec",
+            return_value=fake_process,
+        ) as patched:
+            result = await pool._start_runner("sb-tok", "secret-token")
+
+        call_args = patched.call_args[0]
+        assert "docker" in call_args
+        assert "exec" in call_args
+        assert "-e" in call_args
+        assert "ORCHEO_BROKER_TOKEN=secret-token" in call_args
+        assert "sb-tok" in call_args
+        assert result is fake_process
+        assert pool._runners["sb-tok"] is fake_process
+
+    asyncio.run(go())
+
+
+def test_start_runner_builds_command_without_broker_token() -> None:
+    """_start_runner omits -e when broker_token is empty (lines 330-355)."""
+    import unittest.mock as mock
+
+    async def go() -> None:
+        pool = ResidentRunnerPool()
+
+        fake_process = mock.MagicMock()
+        fake_process.returncode = None
+
+        with mock.patch(
+            "orcheo.sandbox.service.asyncio.create_subprocess_exec",
+            return_value=fake_process,
+        ) as patched:
+            result = await pool._start_runner("sb-notok")
+
+        call_args = patched.call_args[0]
+        assert "-e" not in call_args
+        assert "sb-notok" in call_args
+        assert result is fake_process
+
+    asyncio.run(go())
+
+
+# ---------------------------------------------------------------------------
+# ResidentRunnerPool.shutdown_all (line 461)
+# ---------------------------------------------------------------------------
+
+
+def test_resident_runner_pool_shutdown_all_kills_all_runners() -> None:
+    """shutdown_all() terminates every registered runner (line 461)."""
+    import unittest.mock as mock
+
+    pool = ResidentRunnerPool()
+
+    killed: list[str] = []
+
+    def _make_process(sandbox_id: str) -> mock.MagicMock:
+        p = mock.MagicMock()
+        p.returncode = None
+        p.kill = mock.MagicMock(side_effect=lambda: killed.append(sandbox_id))
+        return p
+
+    pool._runners["sb-a"] = _make_process("sb-a")
+    pool._runners["sb-b"] = _make_process("sb-b")
+
+    pool.shutdown_all()
+
+    assert set(killed) == {"sb-a", "sb-b"}
+    assert pool._runners == {}
+
+
+# ---------------------------------------------------------------------------
+# WorkflowSandboxInvoker.invoke() (line 486)
+# ---------------------------------------------------------------------------
+
+
+def test_workflow_sandbox_invoker_delegates_to_pool() -> None:
+    """WorkflowSandboxInvoker.invoke() forwards to the underlying pool (line 486)."""
+    import unittest.mock as mock
+
+    async def go() -> WorkflowRunResult:
+        pool = ResidentRunnerPool()
+
+        expected = WorkflowRunResult(
+            run_id="r-del",
+            status="succeeded",
+            outputs={"x": 1},
+            error=None,
+        )
+        pool.invoke = mock.AsyncMock(return_value=expected)  # type: ignore[method-assign]
+
+        invoker = WorkflowSandboxInvoker(pool)
+        spec = WorkflowRunSpec(
+            run_id="r-del",
+            workspace_id="ws",
+            workflow_definition={},
+            inputs={},
+        )
+        return await invoker.invoke("sb-1", spec, "tok", timeout_seconds=5.0)
+
+    result = asyncio.run(go())
+    assert result.status == "succeeded"
+    assert result.outputs == {"x": 1}
+
+
+# ---------------------------------------------------------------------------
+# ScriptSandboxInvoker error branches (lines 530, 537, 541)
+# ---------------------------------------------------------------------------
+
+
+def test_ingestion_invoker_reports_stderr_as_detail() -> None:
+    """ScriptSandboxInvoker uses stderr as the error detail when present (line 530)."""
+    executor = _FakeExecutor()
+    executor.result = ProcessExecutionResult(
+        command=[],
+        stdout="",
+        stderr="import error: bad module",
+        exit_code=1,
+        timed_out=False,
+        duration_seconds=0.01,
+    )
+    with pytest.raises(Exception, match="import error: bad module"):
+        asyncio.run(
+            ScriptSandboxInvoker(executor).invoke(
+                "sandbox", ScriptIngestionPayload(source="graph = object()")
+            )
+        )
+
+
+def test_ingestion_invoker_reports_exit_code_with_stdout() -> None:
+    """ScriptSandboxInvoker appends stdout to the exit-code message (line 537)."""
+    executor = _FakeExecutor()
+    executor.result = ProcessExecutionResult(
+        command=[],
+        stdout="Traceback: something went wrong",
+        stderr="",
+        exit_code=1,
+        timed_out=False,
+        duration_seconds=0.01,
+    )
+    with pytest.raises(Exception, match="exited with code 1.*something went wrong"):
+        asyncio.run(
+            ScriptSandboxInvoker(executor).invoke(
+                "sandbox", ScriptIngestionPayload(source="graph = object()")
+            )
+        )
+
+
+def test_ingestion_invoker_reports_no_output_fallback() -> None:
+    """ScriptSandboxInvoker falls back to 'no output' when all fields are empty (line 541)."""
+    executor = _FakeExecutor()
+    executor.result = ProcessExecutionResult(
+        command=[],
+        stdout="",
+        stderr="",
+        exit_code=0,
+        timed_out=False,
+        duration_seconds=0.01,
+    )
+    with pytest.raises(Exception, match="no output"):
+        asyncio.run(
+            ScriptSandboxInvoker(executor).invoke(
+                "sandbox", ScriptIngestionPayload(source="graph = object()")
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# _run_prewarm: max_total_warm break (line 865) and add logging (883->887)
+# ---------------------------------------------------------------------------
+
+
+def test_manager_lifespan_prewarm_respects_max_total_warm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_run_prewarm breaks early when total_warm >= max_total_warm (line 865)."""
+    monkeypatch.setenv("ORCHEO_SANDBOX_REAP_INTERVAL_SECONDS", "0.01")
+
+    runtime = InMemoryContainerRuntime()
+    settings = SandboxSettings(
+        credential_broker_url="http://10.99.0.2:9091/credentials/resolve",
+        max_total_warm=1,
+        default_pool_min=1,
+        default_pool_max=4,
+    )
+    manager = SandboxRuntimeManager(runtime=runtime, settings=settings)
+
+    # Prewarm one sandbox so current_pool_size("ws") == 1 == max_total_warm.
+    # _run_prewarm will receive total_warm=1 and break immediately.
+    manager.prewarm("ws", 1)
+
+    async def go() -> None:
+        async with _manager_lifespan(manager, settings, ResidentRunnerPool()):
+            await asyncio.sleep(0.05)
+
+    asyncio.run(go())
+    # No additional containers were started beyond the initial prewarm.
+    assert runtime.started and len(runtime.started) == 1
+
+
+def test_manager_lifespan_prewarm_logs_added_sandboxes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_run_prewarm logs prewarmed counts when sandboxes are added (lines 883-887)."""
+    import logging
+
+    monkeypatch.setenv("ORCHEO_SANDBOX_REAP_INTERVAL_SECONDS", "0.01")
+
+    runtime = InMemoryContainerRuntime()
+    settings = SandboxSettings(
+        credential_broker_url="http://10.99.0.2:9091/credentials/resolve",
+        max_total_warm=0,  # unbounded
+        default_pool_min=1,  # autoscaler always recommends >=1
+        default_pool_max=4,
+    )
+    manager = SandboxRuntimeManager(runtime=runtime, settings=settings)
+    # Register the workspace so known_workspace_ids() returns it.
+    manager.get_workspace_pool("ws-pre")
+
+    logged: list[str] = []
+
+    class _CapturingHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            logged.append(record.getMessage())
+
+    handler = _CapturingHandler()
+    logging.getLogger("orcheo.sandbox.service").addHandler(handler)
+    try:
+
+        async def go() -> None:
+            async with _manager_lifespan(manager, settings, ResidentRunnerPool()):
+                await asyncio.sleep(0.1)
+
+        asyncio.run(go())
+    finally:
+        logging.getLogger("orcheo.sandbox.service").removeHandler(handler)
+
+    assert any("Prewarmed" in m for m in logged)
+
+
+def test_manager_lifespan_prewarm_delta_positive_but_nothing_added(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_run_prewarm takes the branch 883->887 when delta>0 but prewarm returns 0."""
+    from orcheo.sandbox.models import WorkspaceRuntimePool
+
+    monkeypatch.setenv("ORCHEO_SANDBOX_REAP_INTERVAL_SECONDS", "0.01")
+
+    runtime = InMemoryContainerRuntime()
+    settings = SandboxSettings(
+        credential_broker_url="http://10.99.0.2:9091/credentials/resolve",
+        max_total_warm=0,
+        default_pool_min=1,
+        default_pool_max=1,
+    )
+    manager = SandboxRuntimeManager(runtime=runtime, settings=settings)
+    # pool_min=1, pool_max=1; acquire the one slot so the pool is at capacity.
+    # delta will be 1 (target 1 > current 0) but prewarm returns 0 (total >= pool_max).
+    manager.configure_workspace(
+        WorkspaceRuntimePool(workspace_id="ws-cap", pool_min=1, pool_max=1)
+    )
+    manager.acquire("ws-cap")  # in-use; total = 1 = pool_max
+
+    async def go() -> None:
+        async with _manager_lifespan(manager, settings, ResidentRunnerPool()):
+            await asyncio.sleep(0.05)
+
+    asyncio.run(go())

--- a/tests/sandbox/test_workflow.py
+++ b/tests/sandbox/test_workflow.py
@@ -326,11 +326,12 @@ def test_broker_credential_context_resolves_secret(
         calls.append((url, json, headers))
         return httpx.Response(200, json={"value": "vault-secret"})
 
-    monkeypatch.setenv("ORCHEO_BROKER_TOKEN", "broker-token")
     monkeypatch.setenv("ORCHEO_CREDENTIAL_BROKER_URL", "http://runtime/broker")
     monkeypatch.setattr(workflow_runner.httpx, "post", _post)
 
-    with workflow_runner._credential_context(run_id="run-1", workspace_id="ws-1"):
+    with workflow_runner._credential_context(
+        run_id="run-1", workspace_id="ws-1", broker_token="broker-token"
+    ):
         resolver = get_active_credential_resolver()
         assert resolver is not None
         assert resolver.resolve(credential_ref("openai_api_key")) == "vault-secret"
@@ -384,8 +385,11 @@ def test_run_in_subprocess_spawn_mode_creates_child_process(
         def start(self) -> None:
             calls.append("start")
 
-        def join(self) -> None:
+        def join(self, timeout: float | None = None) -> None:
             calls.append("join")
+
+        def is_alive(self) -> bool:
+            return False
 
     class _FakeContext:
         def Queue(self) -> _FakeQueue:
@@ -405,6 +409,6 @@ def test_run_in_subprocess_spawn_mode_creates_child_process(
 
     result = workflow_runner.run_in_subprocess({}, {}, spawn=True)
     assert result == fake_result
-    assert "get_context:spawn" in calls
+    assert "get_context:fork" in calls
     assert "start" in calls
     assert "join" in calls

--- a/tests/sandbox/test_workflow_runner.py
+++ b/tests/sandbox/test_workflow_runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 import os
 from collections.abc import Mapping
+from pathlib import Path
 from typing import Any
 import pytest
 
@@ -137,26 +138,21 @@ def test_broker_resolver_raises_when_value_is_not_string(
 def test_credential_context_raises_when_broker_url_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """_credential_context raises RuntimeError when ORCHEO_CREDENTIAL_BROKER_URL is unset (lines 105-106)."""
+    """_credential_context raises RuntimeError when ORCHEO_CREDENTIAL_BROKER_URL is unset."""
     from orcheo.sandbox.workflow_runner import _credential_context
 
-    monkeypatch.setenv("ORCHEO_BROKER_TOKEN", "some-token")
     monkeypatch.delenv("ORCHEO_CREDENTIAL_BROKER_URL", raising=False)
 
     with pytest.raises(RuntimeError, match="ORCHEO_CREDENTIAL_BROKER_URL"):
-        _credential_context(run_id="r1", workspace_id="ws-1")
+        _credential_context(run_id="r1", workspace_id="ws-1", broker_token="some-token")
 
 
-def test_credential_context_returns_nullcontext_when_no_token(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """_credential_context returns nullcontext() when no broker token is set."""
+def test_credential_context_returns_nullcontext_when_no_token() -> None:
+    """_credential_context returns nullcontext() when broker_token is empty."""
     from contextlib import nullcontext
     from orcheo.sandbox.workflow_runner import _credential_context
 
-    monkeypatch.delenv("ORCHEO_BROKER_TOKEN", raising=False)
-    ctx = _credential_context(run_id="r1", workspace_id="ws-1")
-    # nullcontext is the expected type when no token is available.
+    ctx = _credential_context(run_id="r1", workspace_id="ws-1", broker_token="")
     assert isinstance(ctx, type(nullcontext()))
 
 
@@ -186,8 +182,11 @@ def test_run_in_subprocess_handles_empty_queue_on_child_exit() -> None:
         def start(self) -> None:
             pass
 
-        def join(self) -> None:
+        def join(self, timeout: float | None = None) -> None:
             pass
+
+        def is_alive(self) -> bool:
+            return False
 
     class _EmptyQueue:
         def get_nowait(self) -> Any:
@@ -232,8 +231,11 @@ def test_run_in_subprocess_handles_clean_exit_with_empty_queue() -> None:
         def start(self) -> None:
             pass
 
-        def join(self) -> None:
+        def join(self, timeout: float | None = None) -> None:
             pass
+
+        def is_alive(self) -> bool:
+            return False
 
     class _EmptyQueue:
         def get_nowait(self) -> Any:
@@ -278,8 +280,11 @@ def test_run_in_subprocess_handles_nonzero_exit_with_empty_queue() -> None:
         def start(self) -> None:
             pass
 
-        def join(self) -> None:
+        def join(self, timeout: float | None = None) -> None:
             pass
+
+        def is_alive(self) -> bool:
+            return False
 
     class _EmptyQueue:
         def get_nowait(self) -> Any:
@@ -324,8 +329,11 @@ def test_run_in_subprocess_handles_still_running_child() -> None:
         def start(self) -> None:
             pass
 
-        def join(self) -> None:
+        def join(self, timeout: float | None = None) -> None:
             pass
+
+        def is_alive(self) -> bool:
+            return False
 
     class _EmptyQueue:
         def get_nowait(self) -> Any:
@@ -520,15 +528,15 @@ def test_sandbox_thread_state_store_read_payload_handles_non_dict_json(
 def test_credential_context_returns_resolver_when_both_set(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """_credential_context returns credential_resolution context when token+URL present (line 206)."""
+    """_credential_context returns credential_resolution context when token+URL present."""
     from orcheo.sandbox.workflow_runner import _credential_context
 
-    monkeypatch.setenv("ORCHEO_BROKER_TOKEN", "tok-123")
     monkeypatch.setenv("ORCHEO_CREDENTIAL_BROKER_URL", "http://broker:9091")
 
-    ctx = _credential_context(run_id="run-1", workspace_id="ws-1")
+    ctx = _credential_context(
+        run_id="run-1", workspace_id="ws-1", broker_token="tok-123"
+    )
 
-    # It should be a non-nullcontext context manager
     from contextlib import nullcontext
 
     assert not isinstance(ctx, type(nullcontext()))
@@ -547,6 +555,7 @@ def test_run_in_subprocess_no_spawn_success() -> None:
         state_config=None,
         run_id=None,
         workspace_id=None,
+        broker_token="",
     ):
         return {"output": "hello"}
 
@@ -682,3 +691,73 @@ def test_run_graph_hydrates_attachment_runtime_config(monkeypatch):
         captured["runtime_configurable"]["attachment_resolver"],
         ChatKitAttachmentResolverProxy,
     )
+
+
+# ---------------------------------------------------------------------------
+# WS1: broker_token threading and fork-based timeout
+# ---------------------------------------------------------------------------
+
+
+def test_run_in_subprocess_threads_broker_token_to_child(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """broker_token is forwarded through run_in_subprocess → _execute_workflow_in_child."""
+    from orcheo.sandbox.workflow_runner import run_in_subprocess
+    from unittest.mock import patch
+
+    received: dict[str, Any] = {}
+
+    def _fake_run_graph(
+        workflow_def: Any,
+        inputs: Any,
+        *,
+        runnable_config: Any = None,
+        state_config: Any = None,
+        run_id: Any = None,
+        workspace_id: Any = None,
+        broker_token: str = "",
+    ) -> dict[str, Any]:
+        received["broker_token"] = broker_token
+        return {"output": "ok"}
+
+    with patch(
+        "orcheo.sandbox.workflow_runner._run_graph", side_effect=_fake_run_graph
+    ):
+        result = run_in_subprocess(
+            {},
+            {},
+            broker_token="tok-xyz",
+            spawn=False,
+        )
+
+    assert result["status"] == "succeeded"
+    assert received["broker_token"] == "tok-xyz"
+
+
+def test_run_in_subprocess_timeout_kills_child() -> None:
+    """A zero timeout kills the child and returns a timed-out failure result."""
+    import multiprocessing as mp
+    import time
+    from orcheo.sandbox.workflow_runner import run_in_subprocess
+
+    # Use a real subprocess that sleeps forever so the timeout fires.
+    # spawn=True + fork so the child inherits this process and can sleep.
+    import orcheo.sandbox.workflow_runner as runner_module
+    from unittest.mock import patch
+
+    def _sleeping_graph(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        time.sleep(60)
+        return {}
+
+    with patch(
+        "orcheo.sandbox.workflow_runner._run_graph", side_effect=_sleeping_graph
+    ):
+        result = run_in_subprocess(
+            {},
+            {},
+            timeout_seconds=0.1,
+            spawn=True,
+        )
+
+    assert result["status"] == "failed"
+    assert "timed out" in str(result.get("error", "")).lower()


### PR DESCRIPTION
## Summary
- Keep one resident `workflow_runner` process alive per sandbox so workflow dispatches reuse preloaded imports instead of paying the startup cost on every run.
- Thread the broker token explicitly through workflow execution and switch sandbox child execution to `fork` with timeout handling.
- Add warm-pool autoscaling for sandboxes using a sliding usage window plus a global cap on total warm containers.
- Improve ingestion runner request parsing and failure reporting for silent exits and unexpected exceptions.

## Testing
- Updated sandbox unit tests for configuration, manager prewarm logic, workflow execution, and ingestion runner behavior.

## Notes
- Added the new warm-pool tuning env vars to `deploy/stack/.env.example`.