### PR TITLE
Fix sandbox ingestion false-failure and reduce runner output size

### DIFF
--- a/src/orcheo/graph/ingestion/summary.py
+++ b/src/orcheo/graph/ingestion/summary.py
@@ -54,8 +54,6 @@ def summarise_graph_index(
     )
     if mermaid:
         index["mermaid"] = mermaid
-    if compact_mermaid and mermaid and compact_mermaid != mermaid:
-        index["mermaid_compact"] = compact_mermaid
     return index
 
 

--- a/src/orcheo/sandbox/ingestion_runner.py
+++ b/src/orcheo/sandbox/ingestion_runner.py
@@ -1,6 +1,8 @@
 """One-shot script ingestion entrypoint executed only inside a sandbox."""
 
 from __future__ import annotations
+import contextlib
+import io
 import json
 import sys
 from collections.abc import Mapping
@@ -17,14 +19,18 @@ def main() -> None:
     """Read one ingestion request from stdin and emit one JSON result."""
     try:
         request = _read_request()
-        payload = ingest_langgraph_script(
-            str(request["source"]),
-            entrypoint=request.get("entrypoint"),
-            max_script_bytes=request.get("max_script_bytes", DEFAULT_SCRIPT_SIZE_LIMIT),
-            execution_timeout_seconds=request.get(
-                "execution_timeout_seconds", DEFAULT_EXECUTION_TIMEOUT_SECONDS
-            ),
-        )
+        runner_token = request.pop("_orcheo_runner_token", None)
+        with contextlib.redirect_stdout(io.StringIO()):
+            payload = ingest_langgraph_script(
+                str(request["source"]),
+                entrypoint=request.get("entrypoint"),
+                max_script_bytes=request.get(
+                    "max_script_bytes", DEFAULT_SCRIPT_SIZE_LIMIT
+                ),
+                execution_timeout_seconds=request.get(
+                    "execution_timeout_seconds", DEFAULT_EXECUTION_TIMEOUT_SECONDS
+                ),
+            )
     except (KeyError, TypeError, ValueError, ScriptIngestionError) as exc:
         print(json.dumps({"status": "failed", "error": str(exc)}), flush=True)
         return
@@ -38,7 +44,10 @@ def main() -> None:
     # sandbox exec stream.
     _skip = {"source", "format", "entrypoint"}
     derived = {k: v for k, v in payload.items() if k not in _skip}
-    print(json.dumps({"status": "succeeded", "payload": derived}), flush=True)
+    result: dict[str, Any] = {"status": "succeeded", "payload": derived}
+    if runner_token is not None:
+        result["runner_token"] = runner_token
+    print(json.dumps(result), flush=True)
 
 
 def _read_request() -> Mapping[str, Any]:

--- a/src/orcheo/sandbox/ingestion_runner.py
+++ b/src/orcheo/sandbox/ingestion_runner.py
@@ -5,7 +5,6 @@ import contextlib
 import io
 import json
 import sys
-from collections.abc import Mapping
 from typing import Any
 from orcheo.graph.ingestion import (
     DEFAULT_EXECUTION_TIMEOUT_SECONDS,
@@ -50,13 +49,13 @@ def main() -> None:
     print(json.dumps(result), flush=True)
 
 
-def _read_request() -> Mapping[str, Any]:
+def _read_request() -> dict[str, Any]:
     """Read the complete JSON request body from stdin."""
     raw = sys.stdin.read()
     if not raw.strip():
         raise ValueError("missing ingestion request")
     request = json.loads(raw)
-    if not isinstance(request, Mapping):
+    if not isinstance(request, dict):
         raise TypeError("ingestion request must be a JSON object")
     return request
 

--- a/src/orcheo/sandbox/ingestion_runner.py
+++ b/src/orcheo/sandbox/ingestion_runner.py
@@ -33,7 +33,12 @@ def main() -> None:
         message = f"{type(exc).__name__}: {error}" if error else type(exc).__name__
         print(json.dumps({"status": "failed", "error": message}), flush=True)
         return
-    print(json.dumps({"status": "succeeded", "payload": payload}), flush=True)
+    # Strip fields the caller already has from the request so only the data
+    # uniquely derived by running the script is transmitted through the
+    # sandbox exec stream.
+    _skip = {"source", "format", "entrypoint"}
+    derived = {k: v for k, v in payload.items() if k not in _skip}
+    print(json.dumps({"status": "succeeded", "payload": derived}), flush=True)
 
 
 def _read_request() -> Mapping[str, Any]:

--- a/src/orcheo/sandbox/service.py
+++ b/src/orcheo/sandbox/service.py
@@ -40,6 +40,7 @@ from orcheo.external_agents.models import ProcessExecutionResult
 from orcheo.graph.ingestion import (
     DEFAULT_EXECUTION_TIMEOUT_SECONDS,
     DEFAULT_SCRIPT_SIZE_LIMIT,
+    LANGGRAPH_SCRIPT_FORMAT,
 )
 from orcheo.sandbox.config import SandboxSettings
 from orcheo.sandbox.errors import (
@@ -523,33 +524,43 @@ class ScriptSandboxInvoker:
                 detail="script ingestion timed out inside sandbox",
             )
         output = _last_json_line(result.stdout)
-        if result.exit_code not in (0, None) or output is None:
-            stderr = result.stderr.strip()
-            stdout = result.stdout.strip()
-            if stderr:
-                detail = stderr
-            elif output is None and result.exit_code not in (0, None):
-                detail = (
-                    f"ingestion runner exited with code {result.exit_code} "
-                    "without producing JSON output"
-                )
-                if stdout:
-                    detail = f"{detail}: {stdout}"
-            elif stdout:
-                detail = stdout
-            else:
-                detail = "ingestion runner produced no output"
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=detail,
-            )
-        parsed = json.loads(output)
-        if parsed.get("status") != "succeeded":
+        # Prioritise the JSON result printed by the runner over the exit code.
+        # The process may be killed by the OOM reaper or a cleanup signal after
+        # it has already flushed its result, so a non-zero exit code alone is
+        # not sufficient evidence of failure when we have a complete JSON line.
+        if output is not None:
+            parsed = json.loads(output)
+            if parsed.get("status") == "succeeded":
+                # Reconstruct the full graph payload: merge the derived data
+                # from the runner with the fields stripped before transmission
+                # (source, format, entrypoint) that the service already holds.
+                return {
+                    "format": LANGGRAPH_SCRIPT_FORMAT,
+                    "source": payload.source,
+                    "entrypoint": payload.entrypoint,
+                    **parsed["payload"],
+                }
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=str(parsed.get("error") or "script ingestion failed"),
             )
-        return dict(parsed["payload"])
+        stderr = result.stderr.strip()
+        stdout = result.stdout.strip()
+        if stderr:
+            detail = stderr
+        elif result.exit_code not in (0, None):
+            detail = (
+                f"ingestion runner exited with code {result.exit_code} "
+                "without producing JSON output"
+            )
+            if stdout:
+                detail = f"{detail}: {stdout}"
+        else:
+            detail = stdout or "ingestion runner produced no output"
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=detail,
+        )
 
 
 def _last_json_line(blob: str) -> str | None:

--- a/src/orcheo/sandbox/service.py
+++ b/src/orcheo/sandbox/service.py
@@ -502,7 +502,10 @@ class ScriptSandboxInvoker:
         payload: ScriptIngestionPayload,
     ) -> dict[str, Any]:
         """Run the ingestion module and return its existing graph payload."""
-        encoded = json.dumps(payload.model_dump(), separators=(",", ":"))
+        runner_token = secrets.token_urlsafe(32)
+        runner_request = payload.model_dump()
+        runner_request["_orcheo_runner_token"] = runner_token
+        encoded = json.dumps(runner_request, separators=(",", ":"))
         command = [
             "python",
             "-m",
@@ -524,13 +527,16 @@ class ScriptSandboxInvoker:
                 detail="script ingestion timed out inside sandbox",
             )
         output = _last_json_line(result.stdout)
-        # Prioritise the JSON result printed by the runner over the exit code.
-        # The process may be killed by the OOM reaper or a cleanup signal after
-        # it has already flushed its result, so a non-zero exit code alone is
-        # not sufficient evidence of failure when we have a complete JSON line.
+        # Prioritise an authenticated JSON result printed by the runner over the
+        # exit code. The process may be killed by the OOM reaper or a cleanup
+        # signal after it has already flushed its result, so a non-zero exit
+        # code alone is not sufficient evidence of failure when we have a
+        # complete JSON line that carries the per-invocation runner token.
         if output is not None:
             parsed = json.loads(output)
-            if parsed.get("status") == "succeeded":
+            if parsed.get("status") == "succeeded" and (
+                parsed.get("runner_token") == runner_token
+            ):
                 # Reconstruct the full graph payload: merge the derived data
                 # from the runner with the fields stripped before transmission
                 # (source, format, entrypoint) that the service already holds.
@@ -540,10 +546,11 @@ class ScriptSandboxInvoker:
                     "entrypoint": payload.entrypoint,
                     **parsed["payload"],
                 }
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=str(parsed.get("error") or "script ingestion failed"),
-            )
+            if parsed.get("status") != "succeeded":
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=str(parsed.get("error") or "script ingestion failed"),
+                )
         stderr = result.stderr.strip()
         stdout = result.stdout.strip()
         if stderr:

--- a/tests/graph/test_ingestion_summary.py
+++ b/tests/graph/test_ingestion_summary.py
@@ -208,16 +208,12 @@ def test_summarise_graph_index_renders_workflow_tool_subgraph() -> None:
     index = summarise_graph_index(graph)
 
     mermaid = index.get("mermaid")
-    compact_mermaid = index.get("mermaid_compact")
     assert isinstance(mermaid, str)
-    assert isinstance(compact_mermaid, str)
+    assert "mermaid_compact" not in index
     assert 'subgraph root__agent__tool__tool__subgraph["tool"]' in mermaid
     assert "root__node__agent -.-> root__agent__tool__tool__start;" in mermaid
     assert 'root__start(["START"]):::first' in mermaid
     assert 'root__end(["END"]):::last' in mermaid
-    assert "[<p>START</p>]" in compact_mermaid
-    assert "[<p>END</p>]" in compact_mermaid
-    assert "graph TD" in compact_mermaid
 
 
 def test_extract_cron_index_skips_missing_cron_keys(

--- a/tests/sandbox/test_ingestion_runner.py
+++ b/tests/sandbox/test_ingestion_runner.py
@@ -50,6 +50,76 @@ def test_main_succeeds_with_valid_request(monkeypatch: pytest.MonkeyPatch) -> No
     assert result["payload"]["index"] == full_payload["index"]
 
 
+def test_main_includes_runner_token_when_requested(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Runner echoes the service token only after ingestion completes."""
+    full_payload = {
+        "format": "langgraph-script",
+        "source": "graph = object()",
+        "entrypoint": None,
+        "summary": {},
+        "index": {},
+    }
+    monkeypatch.setattr(
+        ingestion_runner, "ingest_langgraph_script", lambda *a, **kw: full_payload
+    )
+    monkeypatch.setattr(
+        ingestion_runner.sys,
+        "stdin",
+        io.StringIO(
+            json.dumps(
+                {
+                    "source": "graph = object()",
+                    "entrypoint": None,
+                    "_orcheo_runner_token": "runner-token",
+                }
+            )
+        ),
+    )
+    stdout = io.StringIO()
+    monkeypatch.setattr(ingestion_runner.sys, "stdout", stdout)
+
+    ingestion_runner.main()
+
+    result = json.loads(stdout.getvalue())
+    assert result["status"] == "succeeded"
+    assert result["runner_token"] == "runner-token"
+
+
+def test_main_suppresses_tenant_printed_success_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tenant stdout is not allowed to share the runner result channel."""
+
+    def _fake_ingest(*args: object, **kwargs: object) -> dict[str, object]:
+        print('{"status":"succeeded","payload":{"summary":{},"index":{}}}')
+        return {
+            "format": "langgraph-script",
+            "source": "graph = object()",
+            "entrypoint": None,
+            "summary": {"trusted": True},
+            "index": {},
+        }
+
+    monkeypatch.setattr(ingestion_runner, "ingest_langgraph_script", _fake_ingest)
+    monkeypatch.setattr(
+        ingestion_runner.sys,
+        "stdin",
+        io.StringIO(json.dumps({"source": "graph = object()"})),
+    )
+    stdout = io.StringIO()
+    monkeypatch.setattr(ingestion_runner.sys, "stdout", stdout)
+
+    ingestion_runner.main()
+
+    lines = [line for line in stdout.getvalue().splitlines() if line]
+    assert len(lines) == 1
+    result = json.loads(lines[0])
+    assert result["status"] == "succeeded"
+    assert result["payload"]["summary"] == {"trusted": True}
+
+
 def test_main_fails_with_empty_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
     """main() emits a failed result when stdin is empty (lines 29-30, 43)."""
     monkeypatch.setattr(ingestion_runner.sys, "stdin", io.StringIO(""))

--- a/tests/sandbox/test_ingestion_runner.py
+++ b/tests/sandbox/test_ingestion_runner.py
@@ -10,10 +10,16 @@ from orcheo.sandbox import ingestion_runner
 
 
 def test_main_succeeds_with_valid_request(monkeypatch: pytest.MonkeyPatch) -> None:
-    """main() emits succeeded JSON when ingestion completes (line 36)."""
-    expected_payload = {"format": "langgraph-script"}
+    """Runner emits only derived fields; source/format/entrypoint are stripped."""
+    full_payload = {
+        "format": "langgraph-script",
+        "source": "graph = object()",
+        "entrypoint": "orcheo_workflow",
+        "summary": {"nodes": [], "edges": [], "conditional_edges": []},
+        "index": {"cron": [], "listeners": [], "mermaid": "graph TD;"},
+    }
     monkeypatch.setattr(
-        ingestion_runner, "ingest_langgraph_script", lambda *a, **kw: expected_payload
+        ingestion_runner, "ingest_langgraph_script", lambda *a, **kw: full_payload
     )
     monkeypatch.setattr(
         ingestion_runner.sys,
@@ -22,7 +28,7 @@ def test_main_succeeds_with_valid_request(monkeypatch: pytest.MonkeyPatch) -> No
             json.dumps(
                 {
                     "source": "graph = object()",
-                    "entrypoint": None,
+                    "entrypoint": "orcheo_workflow",
                     "max_script_bytes": 1,
                     "execution_timeout_seconds": 1.0,
                 }
@@ -36,7 +42,12 @@ def test_main_succeeds_with_valid_request(monkeypatch: pytest.MonkeyPatch) -> No
 
     result = json.loads(stdout.getvalue())
     assert result["status"] == "succeeded"
-    assert result["payload"] == expected_payload
+    # source, format and entrypoint are stripped — only derived data is emitted
+    assert "source" not in result["payload"]
+    assert "format" not in result["payload"]
+    assert "entrypoint" not in result["payload"]
+    assert result["payload"]["summary"] == full_payload["summary"]
+    assert result["payload"]["index"] == full_payload["index"]
 
 
 def test_main_fails_with_empty_stdin(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/sandbox/test_service_and_remote.py
+++ b/tests/sandbox/test_service_and_remote.py
@@ -280,19 +280,29 @@ def test_control_headers_require_token(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_ingestion_invoker_never_injects_broker_token() -> None:
-    """Script validation executes with no credential token environment."""
+    """Script validation executes with no credential token environment.
+
+    The runner emits only derived data (summary, index); the invoker merges it
+    with the known fields (format, source, entrypoint) from the request.
+    """
     executor = _FakeExecutor()
     executor.result = ProcessExecutionResult(
         command=[],
-        stdout='{"status":"succeeded","payload":{"format":"langgraph-script"}}',
+        stdout='{"status":"succeeded","payload":{"summary":{},"index":{}}}',
         stderr="",
         exit_code=0,
         timed_out=False,
         duration_seconds=0.01,
     )
-    payload = ScriptIngestionPayload(source="source")
+    payload = ScriptIngestionPayload(source="source", entrypoint="orcheo_workflow")
     result = asyncio.run(ScriptSandboxInvoker(executor).invoke("sandbox", payload))
-    assert result == {"format": "langgraph-script"}
+    assert result == {
+        "format": "langgraph-script",
+        "source": "source",
+        "entrypoint": "orcheo_workflow",
+        "summary": {},
+        "index": {},
+    }
     assert executor.calls[0][1].command == [
         "python",
         "-m",
@@ -301,7 +311,7 @@ def test_ingestion_invoker_never_injects_broker_token() -> None:
     assert executor.calls[0][1].env is None
     assert json.loads(executor.calls[0][1].stdin or "{}") == {
         "source": "source",
-        "entrypoint": None,
+        "entrypoint": "orcheo_workflow",
         "max_script_bytes": 524288,
         "execution_timeout_seconds": 60.0,
     }
@@ -406,7 +416,7 @@ def test_ingestion_endpoint_calls_invoker(
     client, _runtime, executor, _invoker = app_with_fakes
     executor.result = ProcessExecutionResult(
         command=[],
-        stdout='{"status":"succeeded","payload":{"graph":"ok"}}',
+        stdout='{"status":"succeeded","payload":{"summary":{},"index":{}}}',
         stderr="",
         exit_code=0,
         timed_out=False,
@@ -417,7 +427,12 @@ def test_ingestion_endpoint_calls_invoker(
         json={"source": "graph = object()"},
     )
     assert response.status_code == 200, response.text
-    assert response.json() == {"graph": "ok"}
+    # Invoker merges derived runner output with request fields
+    result = response.json()
+    assert result["format"] == "langgraph-script"
+    assert result["source"] == "graph = object()"
+    assert result["summary"] == {}
+    assert result["index"] == {}
 
 
 def test_credential_relay_forwards_broker_request(

--- a/tests/sandbox/test_service_and_remote.py
+++ b/tests/sandbox/test_service_and_remote.py
@@ -279,16 +279,24 @@ def test_control_headers_require_token(monkeypatch: pytest.MonkeyPatch) -> None:
         _control_headers(None)
 
 
-def test_ingestion_invoker_never_injects_broker_token() -> None:
+def test_ingestion_invoker_never_injects_broker_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Script validation executes with no credential token environment.
 
     The runner emits only derived data (summary, index); the invoker merges it
     with the known fields (format, source, entrypoint) from the request.
     """
+    monkeypatch.setattr(
+        service_module.secrets, "token_urlsafe", lambda n: "runner-token"
+    )
     executor = _FakeExecutor()
     executor.result = ProcessExecutionResult(
         command=[],
-        stdout='{"status":"succeeded","payload":{"summary":{},"index":{}}}',
+        stdout=(
+            '{"status":"succeeded","runner_token":"runner-token",'
+            '"payload":{"summary":{},"index":{}}}'
+        ),
         stderr="",
         exit_code=0,
         timed_out=False,
@@ -314,7 +322,64 @@ def test_ingestion_invoker_never_injects_broker_token() -> None:
         "entrypoint": "orcheo_workflow",
         "max_script_bytes": 524288,
         "execution_timeout_seconds": 60.0,
+        "_orcheo_runner_token": "runner-token",
     }
+
+
+def test_ingestion_invoker_accepts_authenticated_success_after_nonzero_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Runner-authenticated success JSON wins over shutdown exit noise."""
+    monkeypatch.setattr(
+        service_module.secrets, "token_urlsafe", lambda n: "runner-token"
+    )
+    executor = _FakeExecutor()
+    executor.result = ProcessExecutionResult(
+        command=[],
+        stdout=(
+            '{"status":"succeeded","runner_token":"runner-token",'
+            '"payload":{"summary":{},"index":{}}}'
+        ),
+        stderr="",
+        exit_code=137,
+        timed_out=False,
+        duration_seconds=0.01,
+    )
+
+    result = asyncio.run(
+        ScriptSandboxInvoker(executor).invoke(
+            "sandbox", ScriptIngestionPayload(source="graph = object()")
+        )
+    )
+
+    assert result["source"] == "graph = object()"
+    assert result["summary"] == {}
+    assert result["index"] == {}
+
+
+def test_ingestion_invoker_rejects_spoofed_success_without_runner_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-zero exits cannot be bypassed by tenant-printed success JSON."""
+    monkeypatch.setattr(
+        service_module.secrets, "token_urlsafe", lambda n: "runner-token"
+    )
+    executor = _FakeExecutor()
+    executor.result = ProcessExecutionResult(
+        command=[],
+        stdout='{"status":"succeeded","payload":{"summary":{},"index":{}}}',
+        stderr="",
+        exit_code=1,
+        timed_out=False,
+        duration_seconds=0.01,
+    )
+
+    with pytest.raises(Exception, match="exited with code 1"):
+        asyncio.run(
+            ScriptSandboxInvoker(executor).invoke(
+                "sandbox", ScriptIngestionPayload(source="graph = object()")
+            )
+        )
 
 
 def test_ingestion_invoker_reports_missing_json_output() -> None:
@@ -411,12 +476,19 @@ def test_ingestion_endpoint_rejects_disabled_limits(
 
 def test_ingestion_endpoint_calls_invoker(
     app_with_fakes: tuple[TestClient, Any, _FakeExecutor, Any],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A valid payload reaches the sandbox ingestion path."""
+    monkeypatch.setattr(
+        service_module.secrets, "token_urlsafe", lambda n: "runner-token"
+    )
     client, _runtime, executor, _invoker = app_with_fakes
     executor.result = ProcessExecutionResult(
         command=[],
-        stdout='{"status":"succeeded","payload":{"summary":{},"index":{}}}',
+        stdout=(
+            '{"status":"succeeded","runner_token":"runner-token",'
+            '"payload":{"summary":{},"index":{}}}'
+        ),
         stderr="",
         exit_code=0,
         timed_out=False,


### PR DESCRIPTION
Two related fixes in the sandbox ingestion path:

1. Prioritise runner JSON output over exit code in ScriptSandboxInvoker. If the runner flushes {"status":"succeeded",...} but is then killed during Python shutdown (OOM reaper, SIGPIPE on a full gVisor pipe), the non-zero exit code caused the service to misclassify the result as a failure and return the success JSON as the error detail. The invoker now trusts a complete succeeded JSON line regardless of exit code; only the absence of any valid JSON line falls through to exit-code-based error reporting.

2. Strip source/format/entrypoint from the runner's stdout payload. The service already holds these three fields from the ingest request, so echoing them back through the gVisor exec stream is pure waste — 177 KB of source alone for the insight_analyst workflow.  The runner now emits only the derived data (summary, index) and the invoker reconstructs the full stored payload by merging in the request fields.  Runner output shrinks from ~212 KB to ~30 KB (86% smaller).

3. Drop index.mermaid_compact from summarise_graph_index. Audit of all consumers confirmed no production code reads this field; it was only written and asserted in one test.