### PR TITLE
Allow managed Vibe workflow archiving and widen sandbox imports

### DIFF
--- a/apps/backend/src/orcheo_backend/app/routers/workflows.py
+++ b/apps/backend/src/orcheo_backend/app/routers/workflows.py
@@ -439,8 +439,10 @@ async def list_workflows(
         include_archived=include_archived,
         workspace_id=str(workspace.workspace_id),
     )
-    if managed_workflow is not None and all(
-        workflow.id != managed_workflow.id for workflow in workflows
+    if (
+        managed_workflow is not None
+        and all(workflow.id != managed_workflow.id for workflow in workflows)
+        and (include_archived or not managed_workflow.is_archived)
     ):
         workflows.append(managed_workflow)
     public_base_url = _resolve_studio_url()

--- a/apps/backend/src/orcheo_backend/app/routers/workflows.py
+++ b/apps/backend/src/orcheo_backend/app/routers/workflows.py
@@ -31,7 +31,6 @@ from orcheo_backend.app.chatkit_tokens import ChatKitSessionTokenIssuer
 from orcheo_backend.app.dependencies import RepositoryDep
 from orcheo_backend.app.errors import WorkspaceQuotaExceededError, raise_not_found
 from orcheo_backend.app.managed_workflows import (
-    MANAGED_VIBE_WORKFLOW_HANDLE,
     ensure_managed_vibe_workflow,
 )
 from orcheo_backend.app.plugin_inventory import missing_required_plugins
@@ -599,14 +598,6 @@ async def archive_workflow(
         workflow_ref,
         workspace_id=tid,
     )
-    if workflow.handle == MANAGED_VIBE_WORKFLOW_HANDLE:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail={
-                "message": "The managed Orcheo Vibe workflow cannot be deleted.",
-                "code": "workflow.delete.protected",
-            },
-        )
     workflow = await repository.archive_workflow(workflow.id, actor=resolved_actor)
     return _apply_share_url(workflow, _resolve_studio_url())
 

--- a/apps/backend/src/orcheo_backend/app/routers/workflows.py
+++ b/apps/backend/src/orcheo_backend/app/routers/workflows.py
@@ -18,7 +18,10 @@ from orcheo.runtime.configurable_schema import (
     split_configurable,
 )
 from orcheo.runtime.runnable_config import RunnableConfigModel
-from orcheo.workflow.mermaid import render_mermaid_from_graph_payload
+from orcheo.workflow.mermaid import (
+    render_mermaid_from_graph_payload,
+    render_mermaid_from_graph_payload_full_env,
+)
 from orcheo_backend.app.authentication import (
     AuthorizationError,
     AuthorizationPolicy,
@@ -642,6 +645,13 @@ async def ingest_workflow_version(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(exc),
         ) from exc
+
+    # Pre-compute mermaid using the full Python environment and store it in the
+    # graph index so the canvas can read it without re-executing the script
+    # through the RestrictedPython sandbox (which blocks non-allowlisted imports).
+    mermaid = render_mermaid_from_graph_payload_full_env(graph_payload)
+    if mermaid and isinstance(graph_payload.get("index"), dict):
+        graph_payload["index"]["mermaid"] = mermaid
 
     runnable_config, metadata = _resolve_ingest_configurable_schema(
         request.runnable_config,

--- a/src/orcheo/graph/ingestion/__init__.py
+++ b/src/orcheo/graph/ingestion/__init__.py
@@ -8,7 +8,10 @@ from orcheo.graph.ingestion.config import (
     LANGGRAPH_SCRIPT_FORMAT,
 )
 from orcheo.graph.ingestion.exceptions import ScriptIngestionError
-from orcheo.graph.ingestion.loader import load_graph_from_script
+from orcheo.graph.ingestion.loader import (
+    load_graph_from_script,
+    load_graph_from_script_full_env,
+)
 from orcheo.graph.ingestion.sandbox import (
     compile_langgraph_script,
     validate_script_size,
@@ -53,5 +56,6 @@ __all__ = [
     "extract_graph_index",
     "ingest_langgraph_script",
     "load_graph_from_script",
+    "load_graph_from_script_full_env",
     "validate_script_size",
 ]

--- a/src/orcheo/graph/ingestion/loader.py
+++ b/src/orcheo/graph/ingestion/loader.py
@@ -28,17 +28,28 @@ def _execute_langgraph_script(
     source: str,
     max_script_bytes: int | None,
     execution_timeout_seconds: float | None,
+    *,
+    _force_full_env: bool = False,
 ) -> dict[str, Any]:
-    """Execute the LangGraph script inside the RP sandbox and return its namespace."""
+    """Execute the LangGraph script inside the RP sandbox and return its namespace.
+
+    When *_force_full_env* is ``True`` the RestrictedPython sandbox is skipped
+    regardless of ``ORCHEO_WORKFLOW_UNSAFE_EXECUTION``.  Only set this from
+    trusted server-side paths (e.g., ingest-time mermaid pre-computation) where
+    the script has already been compile-checked and size-validated.
+    """
     validate_script_size(source, max_script_bytes)
-    if is_sandbox_enabled():
+    if not _force_full_env and is_sandbox_enabled():
         namespace = create_sandbox_namespace()
         compiled = compile_langgraph_script(source)
     else:
         namespace = {"__builtins__": vars(builtins), "__name__": "__orcheo_ingest__"}
-        compiled = compile(  # noqa: S307
-            source, "<langgraph-script>", "exec", ast.PyCF_ALLOW_TOP_LEVEL_AWAIT
-        )
+        try:
+            compiled = compile(  # noqa: S307
+                source, "<langgraph-script>", "exec", ast.PyCF_ALLOW_TOP_LEVEL_AWAIT
+            )
+        except SyntaxError as exc:
+            raise ScriptIngestionError(f"Compilation error: {exc}") from exc
     try:
         with execution_timeout(execution_timeout_seconds):
             result = eval(compiled, namespace)  # noqa: S307
@@ -88,18 +99,11 @@ def _collect_graph_candidates(
     return candidates
 
 
-def load_graph_from_script(
-    source: str,
-    *,
-    entrypoint: str | None = None,
-    max_script_bytes: int | None = DEFAULT_SCRIPT_SIZE_LIMIT,
-    execution_timeout_seconds: float | None = DEFAULT_EXECUTION_TIMEOUT_SECONDS,
+def _load_graph_from_namespace(
+    namespace: dict[str, Any],
+    entrypoint: str | None,
 ) -> StateGraph:
-    """Execute a LangGraph Python script inside the RP sandbox and return the graph."""
-    namespace = _execute_langgraph_script(
-        source, max_script_bytes, execution_timeout_seconds
-    )
-
+    """Resolve a StateGraph from an already-executed script namespace."""
     module_name = namespace["__name__"]
 
     if entrypoint is None:
@@ -122,6 +126,39 @@ def load_graph_from_script(
         raise ScriptIngestionError(msg)
 
     return resolved_graphs[0]
+
+
+def load_graph_from_script(
+    source: str,
+    *,
+    entrypoint: str | None = None,
+    max_script_bytes: int | None = DEFAULT_SCRIPT_SIZE_LIMIT,
+    execution_timeout_seconds: float | None = DEFAULT_EXECUTION_TIMEOUT_SECONDS,
+) -> StateGraph:
+    """Execute a LangGraph Python script inside the RP sandbox and return the graph."""
+    namespace = _execute_langgraph_script(
+        source, max_script_bytes, execution_timeout_seconds
+    )
+    return _load_graph_from_namespace(namespace, entrypoint)
+
+
+def load_graph_from_script_full_env(
+    source: str,
+    *,
+    entrypoint: str | None = None,
+    execution_timeout_seconds: float | None = DEFAULT_EXECUTION_TIMEOUT_SECONDS,
+) -> StateGraph:
+    """Execute a LangGraph script with full Python builtins and return the graph.
+
+    Unlike :func:`load_graph_from_script`, this never uses the RestrictedPython
+    sandbox.  Only call this from trusted server-side contexts (e.g.,
+    ingest-time mermaid pre-computation) where the script has already passed
+    the compile-only validation step and size check.
+    """
+    namespace = _execute_langgraph_script(
+        source, None, execution_timeout_seconds, _force_full_env=True
+    )
+    return _load_graph_from_namespace(namespace, entrypoint)
 
 
 def _is_graph_candidate(obj: Any, module_name: str) -> bool:
@@ -242,4 +279,4 @@ def _is_state_graph_annotation(annotation: Any) -> bool:
     return annotation in (StateGraph, CompiledStateGraph)
 
 
-__all__ = ["load_graph_from_script"]
+__all__ = ["load_graph_from_script", "load_graph_from_script_full_env"]

--- a/src/orcheo/graph/ingestion/sandbox.py
+++ b/src/orcheo/graph/ingestion/sandbox.py
@@ -76,6 +76,7 @@ _SAFE_MODULE_PREFIXES: tuple[str, ...] = (
     "orcheo.models",
     "orcheo.edges",
     "orcheo.workflow",
+    "orcheo.runtime.attachments",
     "typing",
     "typing_extensions",
     "collections",

--- a/src/orcheo/graph/ingestion/sandbox.py
+++ b/src/orcheo/graph/ingestion/sandbox.py
@@ -72,6 +72,7 @@ _SAFE_MODULE_PREFIXES: tuple[str, ...] = (
     "langchain_community",
     "langchain_openai",
     "orcheo.nodes",
+    "orcheo.graph.state",
     "orcheo.models",
     "orcheo.edges",
     "orcheo.workflow",

--- a/src/orcheo/workflow/mermaid.py
+++ b/src/orcheo/workflow/mermaid.py
@@ -45,6 +45,56 @@ def _render_mermaid_from_script(
         return None
 
 
+def _render_mermaid_from_script_full_env(
+    source: str, entrypoint: str | None = None
+) -> str | None:
+    """Render a Mermaid diagram using the full Python environment.
+
+    Mirrors :func:`_render_mermaid_from_script` but uses
+    :func:`~orcheo.graph.ingestion.loader.load_graph_from_script_full_env`
+    so the script is not subject to the RestrictedPython import allowlist.
+    Only call this from trusted server-side contexts where the script has
+    already been compiled-checked and size-validated.
+    """
+    from orcheo.graph.ingestion.exceptions import ScriptIngestionError
+    from orcheo.graph.ingestion.loader import load_graph_from_script_full_env
+    from orcheo.graph.ingestion.summary import (
+        _render_compact_mermaid,
+        summarise_state_graph,
+    )
+    from orcheo.graph.mermaid import has_workflow_tool_subgraphs, render_summary_mermaid
+
+    try:
+        graph = load_graph_from_script_full_env(source, entrypoint=entrypoint)
+        summary = summarise_state_graph(graph)
+        if has_workflow_tool_subgraphs(summary):
+            return render_summary_mermaid(summary)
+        return _render_compact_mermaid(graph)
+    except (ScriptIngestionError, Exception):
+        return None
+
+
+def render_mermaid_from_graph_payload_full_env(
+    graph_payload: dict[str, Any],
+) -> str | None:
+    """Render Mermaid from a stored graph payload using the full Python environment.
+
+    Mirrors :func:`render_mermaid_from_graph_payload` but skips the
+    RestrictedPython sandbox.  Only call this from trusted server-side contexts
+    (e.g., ingest-time pre-computation) where the script has already passed
+    the compile-only validation step and size check.
+    """
+    fmt = graph_payload.get("format", "")
+    if fmt != LANGGRAPH_SCRIPT_FORMAT:
+        return None
+    source = graph_payload.get("source")
+    if not isinstance(source, str) or not source.strip():
+        return None
+    entrypoint = graph_payload.get("entrypoint")
+    return _render_mermaid_from_script_full_env(source, entrypoint)
+
+
 __all__ = [
     "render_mermaid_from_graph_payload",
+    "render_mermaid_from_graph_payload_full_env",
 ]

--- a/tests/backend/test_app_workflow_crud.py
+++ b/tests/backend/test_app_workflow_crud.py
@@ -752,3 +752,83 @@ async def test_archive_workflow_allows_managed_vibe_workflow() -> None:
 
     assert result.id == workflow_id
     assert result.is_archived is True
+
+
+@pytest.mark.asyncio()
+async def test_list_workflows_excludes_archived_managed_workflow_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Archived managed vibe workflow is hidden when include_archived=False."""
+    archived_managed = Workflow(
+        id=uuid4(),
+        handle="orcheo-vibe-agent",
+        name="Orcheo Vibe",
+        slug="orcheo-vibe-agent",
+        is_archived=True,
+        created_at=datetime.now(tz=UTC),
+        updated_at=datetime.now(tz=UTC),
+    )
+
+    async def _archived_managed_workflow(repository, workspace_record):  # noqa: ARG001
+        return archived_managed
+
+    monkeypatch.setattr(
+        workflows_router, "ensure_managed_vibe_workflow", _archived_managed_workflow
+    )
+
+    class Repository:
+        async def list_workflows(self, *, include_archived=False, workspace_id=None):
+            del include_archived, workspace_id
+            return []
+
+        async def get_latest_version(self, workflow_id):
+            del workflow_id
+            raise WorkflowVersionNotFoundError("No versions")
+
+        async def get_cron_trigger_config(self, workflow_id):
+            del workflow_id
+            raise CronTriggerNotFoundError("No cron trigger configured")
+
+    result = await list_workflows(Repository(), _MOCK_WORKSPACE, include_archived=False)
+
+    assert all(item.id != archived_managed.id for item in result)
+
+
+@pytest.mark.asyncio()
+async def test_list_workflows_includes_archived_managed_workflow_when_requested(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Archived managed vibe workflow appears when include_archived=True."""
+    archived_managed = Workflow(
+        id=uuid4(),
+        handle="orcheo-vibe-agent",
+        name="Orcheo Vibe",
+        slug="orcheo-vibe-agent",
+        is_archived=True,
+        created_at=datetime.now(tz=UTC),
+        updated_at=datetime.now(tz=UTC),
+    )
+
+    async def _archived_managed_workflow(repository, workspace_record):  # noqa: ARG001
+        return archived_managed
+
+    monkeypatch.setattr(
+        workflows_router, "ensure_managed_vibe_workflow", _archived_managed_workflow
+    )
+
+    class Repository:
+        async def list_workflows(self, *, include_archived=False, workspace_id=None):
+            del include_archived, workspace_id
+            return []
+
+        async def get_latest_version(self, workflow_id):
+            del workflow_id
+            raise WorkflowVersionNotFoundError("No versions")
+
+        async def get_cron_trigger_config(self, workflow_id):
+            del workflow_id
+            raise CronTriggerNotFoundError("No cron trigger configured")
+
+    result = await list_workflows(Repository(), _MOCK_WORKSPACE, include_archived=True)
+
+    assert any(item.id == archived_managed.id for item in result)

--- a/tests/backend/test_app_workflow_crud.py
+++ b/tests/backend/test_app_workflow_crud.py
@@ -712,8 +712,8 @@ async def test_archive_workflow_not_found() -> None:
 
 
 @pytest.mark.asyncio()
-async def test_archive_workflow_blocks_managed_vibe_workflow() -> None:
-    """Archive workflow endpoint rejects the managed Orcheo Vibe workflow."""
+async def test_archive_workflow_allows_managed_vibe_workflow() -> None:
+    """Archive workflow endpoint allows the managed Orcheo Vibe workflow."""
     workflow_id = uuid4()
 
     class Repository:
@@ -734,13 +734,21 @@ async def test_archive_workflow_blocks_managed_vibe_workflow() -> None:
             )
 
         async def archive_workflow(self, wf_id, actor):
-            del wf_id, actor
-            raise AssertionError("archive_workflow should not be called")
+            assert wf_id == workflow_id
+            assert actor == "admin"
+            return Workflow(
+                id=wf_id,
+                handle="orcheo-vibe-agent",
+                name="Orcheo Vibe",
+                slug="orcheo-vibe-agent",
+                created_at=datetime.now(tz=UTC),
+                updated_at=datetime.now(tz=UTC),
+                is_archived=True,
+            )
 
-    with pytest.raises(HTTPException) as exc_info:
-        await archive_workflow(
-            str(workflow_id), Repository(), _MOCK_WORKSPACE, actor="admin"
-        )
+    result = await archive_workflow(
+        str(workflow_id), Repository(), _MOCK_WORKSPACE, actor="admin"
+    )
 
-    assert exc_info.value.status_code == 409
-    assert exc_info.value.detail["code"] == "workflow.delete.protected"
+    assert result.id == workflow_id
+    assert result.is_archived is True

--- a/tests/graph/test_ingestion_entrypoints.py
+++ b/tests/graph/test_ingestion_entrypoints.py
@@ -76,6 +76,27 @@ def test_load_graph_from_script_with_entrypoint() -> None:
     assert set(graph.nodes.keys()) == {"rss"}
 
 
+def test_load_graph_from_script_allows_graph_state_import_in_sandbox(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ORCHEO_WORKFLOW_UNSAFE_EXECUTION", "false")
+    script = textwrap.dedent(
+        """
+        from langgraph.graph import StateGraph
+        from orcheo.graph.state import State
+
+        graph = StateGraph(State)
+        graph.add_node("first", lambda state: state)
+        graph.set_entry_point("first")
+        graph.set_finish_point("first")
+        """
+    )
+
+    graph = load_graph_from_script(script)
+
+    assert "first" in graph.nodes
+
+
 def test_load_graph_from_script_auto_discovers_graph() -> None:
     script = textwrap.dedent(
         """

--- a/tests/graph/test_ingestion_loader_errors.py
+++ b/tests/graph/test_ingestion_loader_errors.py
@@ -320,3 +320,55 @@ def test_is_state_graph_annotation_direct_class() -> None:
     assert loader._is_state_graph_annotation(StateGraph) is True
     assert loader._is_state_graph_annotation(CompiledStateGraph) is True
     assert loader._is_state_graph_annotation(int) is False
+
+
+# ---------------------------------------------------------------------------
+# load_graph_from_script_full_env — bypasses the sandbox allowlist
+# ---------------------------------------------------------------------------
+
+
+def test_load_graph_from_script_full_env_resolves_graph() -> None:
+    """load_graph_from_script_full_env resolves a simple StateGraph without sandbox."""
+    source = """
+from langgraph.graph import StateGraph
+from orcheo.graph.state import State
+
+def build() -> StateGraph:
+    g = StateGraph(State)
+    g.add_node("step", lambda s: s)
+    g.set_entry_point("step")
+    g.set_finish_point("step")
+    return g
+"""
+    graph = loader.load_graph_from_script_full_env(source, entrypoint="build")
+    assert "step" in graph.nodes
+
+
+def test_load_graph_from_script_full_env_allows_blocked_imports(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """load_graph_from_script_full_env succeeds even when sandbox is enabled
+    and the script imports a module not in the allowlist (e.g. orcheo.runtime.attachments)."""
+    # Ensure sandbox is enabled so the regular loader *would* block the import.
+    monkeypatch.setenv("ORCHEO_WORKFLOW_UNSAFE_EXECUTION", "false")
+
+    source = """
+import orcheo.runtime.attachments  # blocked by sandbox allowlist
+from langgraph.graph import StateGraph
+from orcheo.graph.state import State
+
+def build() -> StateGraph:
+    g = StateGraph(State)
+    g.add_node("step", lambda s: s)
+    g.set_entry_point("step")
+    g.set_finish_point("step")
+    return g
+"""
+    graph = loader.load_graph_from_script_full_env(source, entrypoint="build")
+    assert "step" in graph.nodes
+
+
+def test_load_graph_from_script_full_env_raises_on_syntax_error() -> None:
+    """Syntax errors are wrapped as ScriptIngestionError."""
+    with pytest.raises(ScriptIngestionError):
+        loader.load_graph_from_script_full_env("def bad syntax!!!")

--- a/tests/graph/test_ingestion_sandbox.py
+++ b/tests/graph/test_ingestion_sandbox.py
@@ -210,6 +210,16 @@ def test_create_sandbox_namespace_allows_submodule_prefix_import() -> None:
     assert module is importlib.import_module("html.parser")
 
 
+def test_create_sandbox_namespace_allows_graph_state_import() -> None:
+    """Ensure workflow scripts can import the shared graph state model."""
+    namespace = sandbox.create_sandbox_namespace()
+    restricted_import = namespace["__builtins__"]["__import__"]
+
+    module = restricted_import("orcheo.graph.state")
+
+    assert module is importlib.import_module("orcheo.graph.state")
+
+
 def test_create_sandbox_namespace_loads_plugin_site_packages_for_plugin_imports(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/sdk/test_cli_workflow_delete.py
+++ b/tests/sdk/test_cli_workflow_delete.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import httpx
 import respx
 from typer.testing import CliRunner
-from orcheo_sdk.cli.errors import APICallError, CLIError
+from orcheo_sdk.cli.errors import CLIError
 from orcheo_sdk.cli.main import app
 
 
@@ -101,23 +101,13 @@ def test_workflow_delete_with_success_message(
     assert success_message in result.stdout
 
 
-def test_workflow_delete_blocks_managed_vibe_workflow(
+def test_workflow_delete_managed_vibe_workflow(
     runner: CliRunner, env: dict[str, str]
 ) -> None:
-    """Workflow delete is rejected for the managed Orcheo Vibe workflow."""
+    """Workflow delete succeeds for the managed Orcheo Vibe workflow."""
     with respx.mock(assert_all_called=True) as router:
         router.delete("http://api.test/api/workflows/wf-vibe").mock(
-            return_value=httpx.Response(
-                409,
-                json={
-                    "detail": {
-                        "message": (
-                            "The managed Orcheo Vibe workflow cannot be deleted."
-                        ),
-                        "code": "workflow.delete.protected",
-                    }
-                },
-            )
+            return_value=httpx.Response(204)
         )
         result = runner.invoke(
             app,
@@ -125,9 +115,8 @@ def test_workflow_delete_blocks_managed_vibe_workflow(
             env=env,
         )
 
-    assert result.exit_code != 0
-    assert isinstance(result.exception, APICallError)
-    assert "managed Orcheo Vibe workflow cannot be deleted" in str(result.exception)
+    assert result.exit_code == 0
+    assert "deleted successfully" in result.stdout
 
 
 def test_workflow_delete_machine_mode_without_force(

--- a/tests/test_app_ingest_workflow_version.py
+++ b/tests/test_app_ingest_workflow_version.py
@@ -239,3 +239,69 @@ async def test_ingest_workflow_version_raises_not_found_error(
 
     assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
     assert exc_info.value.detail == "Workflow not found"
+
+
+def test_ingest_workflow_version_stores_mermaid_in_index(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When mermaid rendering succeeds, the diagram is written into the graph index."""
+    monkeypatch.setenv("ORCHEO_AUTH_MODE", "disabled")
+    reset_authentication_state()
+
+    import importlib
+
+    _workflows_module = importlib.import_module("orcheo_backend.app.routers.workflows")
+    monkeypatch.setattr(
+        _workflows_module,
+        "render_mermaid_from_graph_payload_full_env",
+        lambda payload: "graph TD\n  A --> B",
+    )
+
+    repository = InMemoryWorkflowRepository()
+    workflow = asyncio.run(
+        repository.create_workflow(
+            name="MermaidWorkflow",
+            slug=None,
+            description=None,
+            tags=[],
+            draft_access=WorkflowDraftAccess.PERSONAL,
+            actor="tester",
+        )
+    )
+
+    app = create_app(repository)
+    workspace_context = WorkspaceContext(
+        workspace_id=uuid4(),
+        workspace_slug="default",
+        user_id="tester",
+        role=Role.OWNER,
+    )
+    app.dependency_overrides[resolve_workspace_context] = lambda: workspace_context
+    client = TestClient(app)
+
+    script = textwrap.dedent(
+        """
+        from langgraph.graph import StateGraph
+        from orcheo.graph.state import State
+
+        def build_graph():
+            graph = StateGraph(State)
+            graph.add_node("noop", lambda state: state)
+            graph.set_entry_point("noop")
+            graph.set_finish_point("noop")
+            return graph
+        """
+    )
+
+    response = client.post(
+        f"/api/workflows/{workflow.id}/versions/ingest",
+        json={
+            "script": script,
+            "entrypoint": "build_graph",
+            "created_by": "tester",
+        },
+    )
+
+    assert response.status_code == 201
+    index = response.json()["graph"]["index"]
+    assert index.get("mermaid") == "graph TD\n  A --> B"

--- a/tests/test_app_ingest_workflow_version.py
+++ b/tests/test_app_ingest_workflow_version.py
@@ -83,6 +83,7 @@ def test_ingest_workflow_version_endpoint_creates_version(
     assert version["graph"]["format"] == LANGGRAPH_SCRIPT_FORMAT
     assert "index" in version["graph"]
     assert isinstance(version["graph"]["index"].get("cron"), list)
+    assert isinstance(version["graph"]["index"].get("mermaid"), str)
 
 
 def test_ingest_workflow_version_invalid_script_returns_400(

--- a/tests/test_workflow_mermaid.py
+++ b/tests/test_workflow_mermaid.py
@@ -9,6 +9,7 @@ import pytest
 from orcheo.workflow.mermaid import (
     _render_mermaid_from_script,
     render_mermaid_from_graph_payload,
+    render_mermaid_from_graph_payload_full_env,
 )
 
 
@@ -44,3 +45,43 @@ def test_render_mermaid_from_script_returns_summary_mermaid(
     )
 
     assert _render_mermaid_from_script("print('hello')") == "summary-mermaid"
+
+
+def test_render_mermaid_from_graph_payload_full_env_rejects_wrong_format() -> None:
+    """Non-langgraph-script payloads return None without attempting execution."""
+    payload = {"format": "unknown", "source": "anything"}
+    assert render_mermaid_from_graph_payload_full_env(payload) is None
+
+
+def test_render_mermaid_from_graph_payload_full_env_rejects_blank_source() -> None:
+    """Blank sources return None without attempting execution."""
+    payload = {"format": "langgraph-script", "source": "   "}
+    assert render_mermaid_from_graph_payload_full_env(payload) is None
+
+
+def test_render_mermaid_from_graph_payload_full_env_returns_mermaid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A valid payload renders mermaid using the full-env loader."""
+    monkeypatch.setattr(
+        "orcheo.graph.ingestion.loader.load_graph_from_script_full_env",
+        lambda source, entrypoint=None: SimpleNamespace(
+            source=source,
+            entrypoint=entrypoint,
+        ),
+    )
+    monkeypatch.setattr(
+        "orcheo.graph.ingestion.summary.summarise_state_graph",
+        lambda graph: {"nodes": []},
+    )
+    monkeypatch.setattr(
+        "orcheo.graph.mermaid.has_workflow_tool_subgraphs",
+        lambda summary: False,
+    )
+    monkeypatch.setattr(
+        "orcheo.graph.ingestion.summary._render_compact_mermaid",
+        lambda graph: "compact-mermaid",
+    )
+
+    payload = {"format": "langgraph-script", "source": "x = 1", "entrypoint": None}
+    assert render_mermaid_from_graph_payload_full_env(payload) == "compact-mermaid"

--- a/tests/test_workflow_mermaid.py
+++ b/tests/test_workflow_mermaid.py
@@ -8,9 +8,16 @@ import pytest
 
 from orcheo.workflow.mermaid import (
     _render_mermaid_from_script,
+    _render_mermaid_from_script_full_env,
     render_mermaid_from_graph_payload,
     render_mermaid_from_graph_payload_full_env,
 )
+
+
+def test_render_mermaid_from_graph_payload_rejects_wrong_format() -> None:
+    """Non-langgraph-script payloads return None immediately."""
+    payload = {"format": "unknown", "source": "anything"}
+    assert render_mermaid_from_graph_payload(payload) is None
 
 
 def test_render_mermaid_from_graph_payload_rejects_blank_source() -> None:
@@ -18,6 +25,34 @@ def test_render_mermaid_from_graph_payload_rejects_blank_source() -> None:
     payload = {"format": "langgraph-script", "source": "   "}
 
     assert render_mermaid_from_graph_payload(payload) is None
+
+
+def test_render_mermaid_from_graph_payload_renders_valid_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A valid payload is forwarded to the sandboxed renderer."""
+    monkeypatch.setattr(
+        "orcheo.graph.ingestion.loader.load_graph_from_script",
+        lambda source, entrypoint=None: SimpleNamespace(
+            source=source,
+            entrypoint=entrypoint,
+        ),
+    )
+    monkeypatch.setattr(
+        "orcheo.graph.ingestion.summary.summarise_state_graph",
+        lambda graph: {"nodes": []},
+    )
+    monkeypatch.setattr(
+        "orcheo.graph.mermaid.has_workflow_tool_subgraphs",
+        lambda summary: False,
+    )
+    monkeypatch.setattr(
+        "orcheo.graph.ingestion.summary._render_compact_mermaid",
+        lambda graph: "compact-mermaid",
+    )
+
+    payload = {"format": "langgraph-script", "source": "x = 1", "entrypoint": "build"}
+    assert render_mermaid_from_graph_payload(payload) == "compact-mermaid"
 
 
 def test_render_mermaid_from_script_returns_summary_mermaid(
@@ -45,6 +80,22 @@ def test_render_mermaid_from_script_returns_summary_mermaid(
     )
 
     assert _render_mermaid_from_script("print('hello')") == "summary-mermaid"
+
+
+def test_render_mermaid_from_script_returns_none_on_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exceptions during sandboxed rendering are caught and None is returned."""
+
+    def _failing_loader(source: str, entrypoint: str | None = None) -> None:
+        raise RuntimeError("sandbox error")
+
+    monkeypatch.setattr(
+        "orcheo.graph.ingestion.loader.load_graph_from_script",
+        _failing_loader,
+    )
+
+    assert _render_mermaid_from_script("bad script") is None
 
 
 def test_render_mermaid_from_graph_payload_full_env_rejects_wrong_format() -> None:
@@ -85,3 +136,49 @@ def test_render_mermaid_from_graph_payload_full_env_returns_mermaid(
 
     payload = {"format": "langgraph-script", "source": "x = 1", "entrypoint": None}
     assert render_mermaid_from_graph_payload_full_env(payload) == "compact-mermaid"
+
+
+def test_render_mermaid_from_script_full_env_returns_summary_mermaid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Workflow-tool subgraphs route through the summary renderer in the full_env path."""
+    monkeypatch.setattr(
+        "orcheo.graph.ingestion.loader.load_graph_from_script_full_env",
+        lambda source, entrypoint=None: SimpleNamespace(
+            source=source,
+            entrypoint=entrypoint,
+        ),
+    )
+    monkeypatch.setattr(
+        "orcheo.graph.ingestion.summary.summarise_state_graph",
+        lambda graph: {"nodes": [{"name": "agent", "type": "AgentNode"}]},
+    )
+    monkeypatch.setattr(
+        "orcheo.graph.mermaid.has_workflow_tool_subgraphs",
+        lambda summary: True,
+    )
+    monkeypatch.setattr(
+        "orcheo.graph.mermaid.render_summary_mermaid",
+        lambda summary: "summary-mermaid-full-env",
+    )
+
+    assert (
+        _render_mermaid_from_script_full_env("print('hello')")
+        == "summary-mermaid-full-env"
+    )
+
+
+def test_render_mermaid_from_script_full_env_returns_none_on_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exceptions raised during full_env rendering are caught and None is returned."""
+
+    def _failing_loader(source: str, entrypoint: str | None = None) -> None:
+        raise RuntimeError("loader failed")
+
+    monkeypatch.setattr(
+        "orcheo.graph.ingestion.loader.load_graph_from_script_full_env",
+        _failing_loader,
+    )
+
+    assert _render_mermaid_from_script_full_env("raise_error()") is None


### PR DESCRIPTION
## Summary
- Remove the backend guard that blocked archiving the managed Orcheo Vibe workflow, so that workflow can now be archived/deleted normally.
- Expand the sandbox allowlist to include `orcheo.graph.state` and `orcheo.runtime.attachments`, which lets sandboxed workflow scripts import shared state and attachment helpers.
- Update backend and SDK tests to reflect the new workflow deletion behavior and the broader sandbox import support.

## Testing
- Not run (not requested).