### PR TITLE
Fix candidate config normalization

### DIFF
--- a/apps/backend/src/orcheo_backend/app/routers/candidates.py
+++ b/apps/backend/src/orcheo_backend/app/routers/candidates.py
@@ -75,6 +75,21 @@ def _build_version_metadata(candidate: CandidateItem) -> dict[str, Any]:
     return metadata
 
 
+def _merge_configurable_schema(
+    existing: Any,
+    inline: dict[str, Any],
+) -> dict[str, Any]:
+    """Merge inline schema declarations with authored schema metadata.
+
+    Candidate metadata can include a ``configurable_schema`` map authored from
+    frontmatter or a sibling schema file. Preserve those explicit definitions
+    and only fill in fields discovered from inline config annotations.
+    """
+    if isinstance(existing, dict):
+        return {**inline, **existing}
+    return inline
+
+
 def _resolve_candidate_runnable_config(
     candidate: CandidateItem,
     metadata: dict[str, Any],
@@ -112,7 +127,9 @@ def _resolve_candidate_runnable_config(
     if inline_schema:
         metadata = {
             **metadata,
-            "configurable_schema": inline_schema,
+            "configurable_schema": _merge_configurable_schema(
+                metadata.get("configurable_schema"), inline_schema
+            ),
         }
         runnable_config = runnable_config.model_copy(
             update={"configurable": resolved_configurable}

--- a/apps/backend/src/orcheo_backend/app/routers/candidates.py
+++ b/apps/backend/src/orcheo_backend/app/routers/candidates.py
@@ -4,9 +4,14 @@ from __future__ import annotations
 import logging
 from typing import Any
 from fastapi import APIRouter, HTTPException, status
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from orcheo.graph.ingestion import ScriptIngestionError, ingest_langgraph_script
 from orcheo.models import Workflow, WorkflowDraftAccess
+from orcheo.runtime.configurable_schema import (
+    ConfigurableSchemaError,
+    split_configurable,
+)
+from orcheo.runtime.runnable_config import RunnableConfigModel
 from orcheo.workflow.mermaid import render_mermaid_from_graph_payload_full_env
 from orcheo_backend.app.candidates_service import CandidateFetchError, get_candidates
 from orcheo_backend.app.dependencies import RepositoryDep
@@ -68,6 +73,59 @@ def _build_version_metadata(candidate: CandidateItem) -> dict[str, Any]:
     if candidate.subtitle:
         metadata.setdefault("subtitle", candidate.subtitle)
     return metadata
+
+
+def _resolve_candidate_runnable_config(
+    candidate: CandidateItem,
+    metadata: dict[str, Any],
+) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+    """Normalize candidate config.json before version creation."""
+    if candidate.config is None:
+        return None, metadata
+
+    try:
+        runnable_config = RunnableConfigModel.model_validate(candidate.config)
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Candidate config.json is not a valid runnable config.",
+        ) from exc
+
+    serialized_config = runnable_config.model_dump(
+        mode="json",
+        exclude_defaults=True,
+        exclude_none=True,
+    )
+    if not runnable_config.configurable:
+        return serialized_config, metadata
+
+    try:
+        resolved_configurable, inline_schema = split_configurable(
+            runnable_config.configurable
+        )
+    except ConfigurableSchemaError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+    if inline_schema:
+        metadata = {
+            **metadata,
+            "configurable_schema": inline_schema,
+        }
+        runnable_config = runnable_config.model_copy(
+            update={"configurable": resolved_configurable}
+        )
+
+    return (
+        runnable_config.model_dump(
+            mode="json",
+            exclude_defaults=True,
+            exclude_none=True,
+        ),
+        metadata,
+    )
 
 
 def _raise_for_missing_required_plugins(metadata: dict[str, Any]) -> None:
@@ -157,6 +215,7 @@ async def onboard_candidate(
 
     metadata = _build_version_metadata(candidate)
     _raise_for_missing_required_plugins(metadata)
+    runnable_config, metadata = _resolve_candidate_runnable_config(candidate, metadata)
 
     try:
         graph_payload = ingest_langgraph_script(
@@ -215,7 +274,7 @@ async def onboard_candidate(
         metadata=metadata,
         notes=candidate.notes,
         created_by="onboard",
-        runnable_config=candidate.config,
+        runnable_config=runnable_config,
     )
 
     logger.info(

--- a/tests/backend/test_routers_candidates.py
+++ b/tests/backend/test_routers_candidates.py
@@ -286,6 +286,81 @@ async def test_onboard_candidate_resolves_inline_configurable_schema(
 
 
 @pytest.mark.asyncio()
+async def test_onboard_candidate_merges_existing_configurable_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Authored configurable schema metadata wins over inline annotations."""
+
+    candidate_with_schema = _SAMPLE.model_copy(
+        update={
+            "metadata": {
+                "configurable_schema": {
+                    "ai_model": {
+                        "type": "string",
+                        "title": "Authored Model",
+                        "default": "openai:gpt-5.4-mini",
+                    },
+                    "region": {
+                        "type": "string",
+                        "title": "Region",
+                        "default": "us-east-1",
+                    },
+                }
+            },
+            "config": {
+                "configurable": {
+                    "ai_model": {
+                        "type": "string",
+                        "title": "Inline Model",
+                        "default": "openai:gpt-4.1-mini",
+                    },
+                    "temperature": {
+                        "type": "number",
+                        "default": 0.2,
+                    },
+                }
+            },
+        }
+    )
+
+    async def fake_get_candidates() -> list[CandidateItem]:
+        return [candidate_with_schema]
+
+    monkeypatch.setattr(candidates_router, "get_candidates", fake_get_candidates)
+
+    repo = _Repository()
+    await onboard_candidate(
+        CandidateOnboardRequest(id="insight-analyst"),
+        repo,  # type: ignore[arg-type]
+        _MOCK_WORKSPACE,  # type: ignore[arg-type]
+    )
+
+    assert repo.last_runnable_config == {
+        "configurable": {
+            "ai_model": "openai:gpt-4.1-mini",
+            "temperature": 0.2,
+        }
+    }
+    assert repo.last_metadata is not None
+    assert repo.last_metadata["configurable_schema"] == {
+        "ai_model": {
+            "type": "string",
+            "title": "Authored Model",
+            "default": "openai:gpt-5.4-mini",
+        },
+        "region": {
+            "type": "string",
+            "title": "Region",
+            "default": "us-east-1",
+        },
+        "temperature": {
+            "type": "number",
+            "default": 0.2,
+        },
+    }
+
+
+@pytest.mark.asyncio()
 async def test_onboard_candidate_rejects_missing_required_plugins(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/backend/test_routers_candidates.py
+++ b/tests/backend/test_routers_candidates.py
@@ -103,6 +103,7 @@ class _Repository:
         self._existing = existing_workflow
         self.created_workflow: Workflow | None = None
         self.versions_created: int = 0
+        self.last_metadata: dict | None = None
         self.last_version_graph: dict | None = None
         self.last_runnable_config: dict | None = None
 
@@ -141,6 +142,7 @@ class _Repository:
         from orcheo.models import WorkflowVersion
 
         self.versions_created += 1
+        self.last_metadata = metadata
         self.last_version_graph = graph
         self.last_runnable_config = runnable_config
         return WorkflowVersion(
@@ -228,6 +230,59 @@ async def test_onboard_candidate_passes_runnable_config(
     )
 
     assert repo.last_runnable_config == {"configurable": {"model": "gpt-4o"}}
+
+
+@pytest.mark.asyncio()
+async def test_onboard_candidate_resolves_inline_configurable_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Inline schema declarations are resolved before version creation."""
+
+    candidate_with_schema = _SAMPLE.model_copy(
+        update={
+            "config": {
+                "configurable": {
+                    "ai_model": {
+                        "type": "string",
+                        "enum": [
+                            "openai:gpt-4.1-mini",
+                            "openai:gpt-5.4-mini",
+                        ],
+                        "title": "Model",
+                        "default": "openai:gpt-4.1-mini",
+                    }
+                }
+            }
+        }
+    )
+
+    async def fake_get_candidates() -> list[CandidateItem]:
+        return [candidate_with_schema]
+
+    monkeypatch.setattr(candidates_router, "get_candidates", fake_get_candidates)
+
+    repo = _Repository()
+    await onboard_candidate(
+        CandidateOnboardRequest(id="insight-analyst"),
+        repo,  # type: ignore[arg-type]
+        _MOCK_WORKSPACE,  # type: ignore[arg-type]
+    )
+
+    assert repo.last_runnable_config == {
+        "configurable": {"ai_model": "openai:gpt-4.1-mini"}
+    }
+    assert repo.last_metadata is not None
+    assert repo.last_metadata["configurable_schema"] == {
+        "ai_model": {
+            "type": "string",
+            "enum": [
+                "openai:gpt-4.1-mini",
+                "openai:gpt-5.4-mini",
+            ],
+            "title": "Model",
+            "default": "openai:gpt-4.1-mini",
+        }
+    }
 
 
 @pytest.mark.asyncio()

--- a/tests/backend/test_routers_candidates.py
+++ b/tests/backend/test_routers_candidates.py
@@ -232,6 +232,56 @@ async def test_onboard_candidate_passes_runnable_config(
     assert repo.last_runnable_config == {"configurable": {"model": "gpt-4o"}}
 
 
+def test_resolve_candidate_runnable_config_rejects_invalid_config() -> None:
+    """Invalid runnable config payloads are rejected with HTTP 400."""
+    candidate = _SAMPLE.model_copy(update={"config": {"configurable": "not-a-mapping"}})
+    metadata = {"source": "candidate-onboard", "candidate_id": candidate.id}
+
+    with pytest.raises(HTTPException) as exc_info:
+        candidates_router._resolve_candidate_runnable_config(candidate, metadata)
+
+    assert exc_info.value.status_code == 400
+    assert "valid runnable config" in str(exc_info.value.detail)
+
+
+def test_resolve_candidate_runnable_config_returns_serialized_config_when_plain() -> (
+    None
+):
+    """Runnable configs without inline schema annotations are returned unchanged."""
+    candidate = _SAMPLE.model_copy(update={"config": {}})
+    metadata = {"source": "candidate-onboard", "candidate_id": candidate.id}
+
+    runnable_config, returned_metadata = (
+        candidates_router._resolve_candidate_runnable_config(
+            candidate,
+            metadata,
+        )
+    )
+
+    assert runnable_config == {}
+    assert returned_metadata == metadata
+
+
+def test_resolve_candidate_runnable_config_rejects_invalid_inline_schema() -> None:
+    """Inline schema declarations without a runtime default are rejected."""
+    candidate = _SAMPLE.model_copy(
+        update={
+            "config": {
+                "configurable": {
+                    "mode": {"type": "string", "enum": []},
+                }
+            }
+        }
+    )
+    metadata = {"source": "candidate-onboard", "candidate_id": candidate.id}
+
+    with pytest.raises(HTTPException) as exc_info:
+        candidates_router._resolve_candidate_runnable_config(candidate, metadata)
+
+    assert exc_info.value.status_code == 400
+    assert "no runtime default" in str(exc_info.value.detail)
+
+
 @pytest.mark.asyncio()
 async def test_onboard_candidate_resolves_inline_configurable_schema(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Normalize candidate config.json during onboarding so inline configurable schemas are resolved before persistence.

Validation:
- uv run pytest tests/backend/test_routers_candidates.py -q
- uv run pytest tests/backend/test_workflow_router_helpers.py -q
- uv run ruff check apps/backend/src/orcheo_backend/app/routers/candidates.py tests/backend/test_routers_candidates.py