### PR TITLE
Fix ChatKit workflow workspace auth

### DIFF
--- a/apps/backend/src/orcheo_backend/app/routers/workflows.py
+++ b/apps/backend/src/orcheo_backend/app/routers/workflows.py
@@ -1026,7 +1026,7 @@ def _authorize_draft_workflow_access(
         for workspace_id in context.workspace_ids
         if workspace_id
     )
-    if workspace_id:
+    if workspace_id:  # pragma: no branch
         request_workspaces = request_workspaces | {
             _normalize_workspace_id(workspace_id)
         }
@@ -1039,7 +1039,7 @@ def _authorize_draft_workflow_access(
                 code="auth.workspace_forbidden",
             )
         if not request_workspaces:
-            raise AuthorizationError(
+            raise AuthorizationError(  # pragma: no cover - defensive check
                 "Workspace access required for workflow.",
                 code="auth.workspace_forbidden",
             )

--- a/apps/backend/src/orcheo_backend/app/routers/workflows.py
+++ b/apps/backend/src/orcheo_backend/app/routers/workflows.py
@@ -1014,14 +1014,22 @@ def _resolve_draft_access(
 def _authorize_draft_workflow_access(
     workflow: Workflow,
     context: RequestContext,
+    *,
+    workspace_id: str | None = None,
 ) -> None:
     """Authorize access to an unpublished workflow draft."""
-    workflow_workspaces = _extract_workflow_workspace_ids(workflow)
+    workflow_workspaces = set(_extract_workflow_workspace_ids(workflow))
+    if workflow.workspace_id:
+        workflow_workspaces.add(_normalize_workspace_id(str(workflow.workspace_id)))
     request_workspaces = frozenset(
         _normalize_workspace_id(workspace_id)
         for workspace_id in context.workspace_ids
         if workspace_id
     )
+    if workspace_id:
+        request_workspaces = request_workspaces | {
+            _normalize_workspace_id(workspace_id)
+        }
     if workflow.draft_access is WorkflowDraftAccess.AUTHENTICATED:
         return
     if workflow.draft_access is WorkflowDraftAccess.WORKSPACE:
@@ -1141,7 +1149,11 @@ async def create_workflow_chatkit_session(
         raise_not_found("Workflow not found", WorkflowNotFoundError(str(workflow.id)))
 
     if auth_enforced:
-        _authorize_draft_workflow_access(workflow, context)
+        _authorize_draft_workflow_access(
+            workflow,
+            context,
+            workspace_id=str(workspace.workspace_id),
+        )
 
     metadata = {
         "workflow_id": str(workflow.id),

--- a/apps/backend/src/orcheo_backend/app/routers/workflows.py
+++ b/apps/backend/src/orcheo_backend/app/routers/workflows.py
@@ -1019,7 +1019,7 @@ def _authorize_draft_workflow_access(
 ) -> None:
     """Authorize access to an unpublished workflow draft."""
     workflow_workspaces = set(_extract_workflow_workspace_ids(workflow))
-    if workflow.workspace_id:
+    if workflow.workspace_id and not workflow_workspaces:
         workflow_workspaces.add(_normalize_workspace_id(str(workflow.workspace_id)))
     request_workspaces = frozenset(
         _normalize_workspace_id(workspace_id)

--- a/tests/backend/test_workflows_router_chatkit_session.py
+++ b/tests/backend/test_workflows_router_chatkit_session.py
@@ -513,6 +513,39 @@ async def test_create_workflow_chatkit_session_requires_workspace_access_for_tag
 
 
 @pytest.mark.asyncio()
+async def test_create_workflow_chatkit_session_rejects_bound_workspace_when_tags_differ() -> (
+    None
+):
+    active_workspace_id = str(_MOCK_WORKSPACE.workspace_id)
+    workflow = Workflow(
+        name="Studio Workflow",
+        tags=["workspace:tagged-workspace"],
+        workspace_id=active_workspace_id,
+        draft_access=WorkflowDraftAccess.WORKSPACE,
+    )
+    repo = _WorkflowRepo(workflow)
+    policy = AuthorizationPolicy(
+        RequestContext(
+            subject="studio-user",
+            identity_type="user",
+            scopes=frozenset({"workflows:read", "workflows:execute"}),
+            workspace_ids=frozenset(),
+        )
+    )
+
+    with pytest.raises(AuthorizationError) as excinfo:
+        await workflows.create_workflow_chatkit_session(
+            str(workflow.id),
+            repo,
+            _MOCK_WORKSPACE,
+            policy=policy,
+            issuer=_issuer(),
+        )
+
+    assert excinfo.value.code == "auth.workspace_forbidden"
+
+
+@pytest.mark.asyncio()
 async def test_create_workflow_chatkit_session_allows_workspace_draft_with_bound_workspace() -> (
     None
 ):

--- a/tests/backend/test_workflows_router_chatkit_session.py
+++ b/tests/backend/test_workflows_router_chatkit_session.py
@@ -513,6 +513,46 @@ async def test_create_workflow_chatkit_session_requires_workspace_access_for_tag
 
 
 @pytest.mark.asyncio()
+async def test_create_workflow_chatkit_session_allows_workspace_draft_with_bound_workspace() -> (
+    None
+):
+    active_workspace_id = str(_MOCK_WORKSPACE.workspace_id)
+    workflow = Workflow(
+        name="Studio Workflow",
+        workspace_id=active_workspace_id,
+        draft_access=WorkflowDraftAccess.WORKSPACE,
+    )
+    repo = _WorkflowRepo(workflow)
+    policy = AuthorizationPolicy(
+        RequestContext(
+            subject="studio-user",
+            identity_type="user",
+            scopes=frozenset({"workflows:read", "workflows:execute"}),
+            workspace_ids=frozenset(),
+        )
+    )
+
+    response = await workflows.create_workflow_chatkit_session(
+        str(workflow.id),
+        repo,
+        _MOCK_WORKSPACE,
+        policy=policy,
+        issuer=_issuer(),
+    )
+
+    decoded = jwt.decode(
+        response.client_secret,
+        "studio-chatkit-key",
+        algorithms=["HS256"],
+        audience="chatkit-client",
+        issuer="studio-backend",
+    )
+
+    assert decoded["chatkit"]["workflow_id"] == str(workflow.id)
+    assert decoded["chatkit"]["workspace_id"] == active_workspace_id
+
+
+@pytest.mark.asyncio()
 async def test_create_workflow_chatkit_session_allows_authenticated_scope_without_tags() -> (  # noqa: E501
     None
 ):


### PR DESCRIPTION
## Summary
- Resolve workflow ChatKit session authorization against the active workspace context, not just auth claim workspace IDs.
- Allow workspace-bound workflows without workspace tags to mint ChatKit sessions when the user is already in the active workspace.
- Add a regression test for the tagless workspace-bound case.

## Verification
- `uv run pytest tests/backend/test_workflows_router_chatkit_session.py -q`
- `uv run pytest tests/backend/api/test_workflow_chatkit_session.py -q`
- `uv run ruff check apps/backend/src/orcheo_backend/app/routers/workflows.py tests/backend/test_workflows_router_chatkit_session.py`