### PR TITLE
Add native ChatKit widget tools and simplify workflow config

### DIFF
--- a/apps/studio/src/features/workflow/pages/workflow/components/workflow-config-sheet.tsx
+++ b/apps/studio/src/features/workflow/pages/workflow/components/workflow-config-sheet.tsx
@@ -29,73 +29,17 @@ const baseWorkflowConfigSchema: RJSFSchema = {
       additionalProperties: true,
       default: {},
     },
-    run_name: {
-      type: "string",
-      title: "Run name",
-    },
-    tags: {
-      type: "array",
-      title: "Tags",
-      items: {
-        type: "string",
-      },
-    },
-    metadata: {
-      type: "object",
-      title: "Metadata",
-      additionalProperties: true,
-      default: {},
-    },
-    callbacks: {
-      type: "array",
-      title: "Callbacks",
-      items: {
-        type: ["object", "array", "string", "number", "integer", "boolean"],
-      },
-    },
     recursion_limit: {
       type: "integer",
       title: "Recursion limit",
       minimum: 1,
+      description: "Maximum graph recursion depth allowed for this run.",
     },
     max_concurrency: {
       type: "integer",
       title: "Max concurrency",
       minimum: 1,
-    },
-    prompts: {
-      type: "object",
-      title: "Prompts",
-      additionalProperties: {
-        type: "object",
-        properties: {
-          template: {
-            type: "string",
-            title: "Template",
-          },
-          input_variables: {
-            type: "array",
-            title: "Input variables",
-            items: {
-              type: "string",
-            },
-          },
-          optional_variables: {
-            type: "array",
-            title: "Optional variables",
-            items: {
-              type: "string",
-            },
-          },
-          partial_variables: {
-            type: "object",
-            title: "Partial variables",
-            additionalProperties: true,
-          },
-        },
-        required: ["template", "input_variables"],
-      },
-      default: {},
+      description: "Maximum number of concurrent tasks allowed for this run.",
     },
   },
 };
@@ -104,14 +48,6 @@ const workflowConfigUiSchema: UiSchema = {
   configurable: {
     fields: {
       "ui:field": "jsonObject",
-    },
-  },
-  run_name: {
-    "ui:placeholder": "Optional run label",
-  },
-  tags: {
-    "ui:options": {
-      orderable: false,
     },
   },
 };

--- a/apps/studio/src/features/workflow/pages/workflow/components/workflow-config-sheet.utils.test.ts
+++ b/apps/studio/src/features/workflow/pages/workflow/components/workflow-config-sheet.utils.test.ts
@@ -8,76 +8,60 @@ import {
 } from "@features/workflow/pages/workflow/components/workflow-config-sheet.utils";
 
 describe("workflow-config-sheet utils", () => {
-  it("preserves upload-time runnable config fields", () => {
+  it("preserves only runtime limit fields", () => {
     const formData = {
       configurable: { workspace: "acme", region: "us-east-1" },
-      run_name: "  nightly-run  ",
-      tags: ["prod", " prod ", "nightly"],
-      metadata: { owner: "search-team" },
-      callbacks: [{ type: "log" }],
       recursion_limit: 7,
       max_concurrency: 3,
-      prompts: {
-        summary_prompt: {
-          template: "Summarize {topic}",
-          input_variables: ["topic"],
-          partial_variables: { tone: "brief" },
-        },
-      },
     } satisfies Record<string, unknown>;
 
     expect(toWorkflowConfig(formData)).toEqual({
       configurable: { workspace: "acme", region: "us-east-1" },
-      run_name: "nightly-run",
-      tags: ["prod", "nightly"],
-      metadata: { owner: "search-team" },
-      callbacks: [{ type: "log" }],
       recursion_limit: 7,
       max_concurrency: 3,
-      prompts: {
-        summary_prompt: {
-          template: "Summarize {topic}",
-          input_variables: ["topic"],
-          partial_variables: { tone: "brief" },
-        },
-      },
     });
   });
 
-  it("keeps all runnable config fields when hydrating form data", () => {
+  it("keeps only runtime limit fields when hydrating form data", () => {
     const config = {
       configurable: { organization: "acme" },
-      run_name: "upload-run",
-      tags: ["upload"],
-      metadata: { source: "cli" },
-      callbacks: ["callback-a"],
       recursion_limit: 5,
       max_concurrency: 2,
-      prompts: {
-        review_prompt: {
-          template: "Review {text}",
-          input_variables: ["text"],
-          optional_variables: ["style"],
-        },
-      },
     };
 
     expect(toFormData(config)).toEqual({
       configurable: { organization: "acme" },
-      run_name: "upload-run",
-      tags: ["upload"],
-      metadata: { source: "cli" },
-      callbacks: ["callback-a"],
       recursion_limit: 5,
       max_concurrency: 2,
-      prompts: {
-        review_prompt: {
-          template: "Review {text}",
-          input_variables: ["text"],
-          optional_variables: ["style"],
+    });
+  });
+
+  it("adds descriptions to the runtime limit fields for tooltips", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        recursion_limit: {
+          type: "integer",
+          title: "Recursion limit",
+          minimum: 1,
+          description: "Maximum graph recursion depth allowed for this run.",
+        },
+        max_concurrency: {
+          type: "integer",
+          title: "Max concurrency",
+          minimum: 1,
+          description:
+            "Maximum number of concurrent tasks allowed for this run.",
         },
       },
-    });
+    } satisfies RJSFSchema;
+
+    expect(schema.properties?.recursion_limit?.description).toBe(
+      "Maximum graph recursion depth allowed for this run.",
+    );
+    expect(schema.properties?.max_concurrency?.description).toBe(
+      "Maximum number of concurrent tasks allowed for this run.",
+    );
   });
 
   it("infers array item schemas for configurable fields", () => {

--- a/apps/studio/src/features/workflow/pages/workflow/components/workflow-config-sheet.utils.ts
+++ b/apps/studio/src/features/workflow/pages/workflow/components/workflow-config-sheet.utils.ts
@@ -208,37 +208,6 @@ export const toWorkflowConfig = (
     next.configurable = formData.configurable;
   }
 
-  if (typeof formData.run_name === "string") {
-    const runName = formData.run_name.trim();
-    if (runName.length > 0) {
-      next.run_name = runName;
-    }
-  }
-
-  if (Array.isArray(formData.tags)) {
-    const tags = formData.tags
-      .filter((item): item is string => typeof item === "string")
-      .map((item) => item.trim())
-      .filter(
-        (item, index, array) =>
-          item.length > 0 && array.indexOf(item) === index,
-      );
-    if (tags.length > 0) {
-      next.tags = tags;
-    }
-  }
-
-  if (
-    isRecord(formData.metadata) &&
-    Object.keys(formData.metadata).length > 0
-  ) {
-    next.metadata = formData.metadata;
-  }
-
-  if (Array.isArray(formData.callbacks) && formData.callbacks.length > 0) {
-    next.callbacks = formData.callbacks;
-  }
-
   const recursionLimit = toPositiveInteger(formData.recursion_limit);
   if (recursionLimit) {
     next.recursion_limit = recursionLimit;
@@ -247,10 +216,6 @@ export const toWorkflowConfig = (
   const maxConcurrency = toPositiveInteger(formData.max_concurrency);
   if (maxConcurrency) {
     next.max_concurrency = maxConcurrency;
-  }
-
-  if (isRecord(formData.prompts) && Object.keys(formData.prompts).length > 0) {
-    next.prompts = formData.prompts;
   }
 
   return Object.keys(next).length > 0 ? next : null;
@@ -265,11 +230,6 @@ export const toFormData = (
   config: WorkflowRunnableConfig | null,
 ): Record<string, unknown> => ({
   configurable: config?.configurable ?? {},
-  run_name: config?.run_name ?? "",
-  tags: config?.tags ?? [],
-  metadata: config?.metadata ?? {},
-  callbacks: config?.callbacks ?? [],
   recursion_limit: config?.recursion_limit,
   max_concurrency: config?.max_concurrency,
-  prompts: config?.prompts ?? {},
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       - orcheo_data:/data
       - backend_venv:/app/.venv
       - uv_cache:/data/cache/uv
+      - ./deploy/stack/chatkit_widgets:/app/examples/chatkit_widgets/widgets:ro
     environment:
       HOME: /data/home
       CODEX_HOME: /data/home/.codex
@@ -84,6 +85,7 @@ services:
       - orcheo_data:/data
       - worker_venv:/app/.venv
       - uv_cache:/data/cache/uv
+      - ./deploy/stack/chatkit_widgets:/app/examples/chatkit_widgets/widgets:ro
     environment:
       HOME: /data/home
       CODEX_HOME: /data/home/.codex
@@ -124,6 +126,7 @@ services:
       - orcheo_data:/data
       - celery_venv:/app/.venv
       - uv_cache:/data/cache/uv
+      - ./deploy/stack/chatkit_widgets:/app/examples/chatkit_widgets/widgets:ro
     environment:
       HOME: /data/home
       CODEX_HOME: /data/home/.codex

--- a/src/orcheo/nodes/ai/__init__.py
+++ b/src/orcheo/nodes/ai/__init__.py
@@ -19,6 +19,7 @@ from orcheo.tracing.model_metadata import (
     infer_chat_result_model_name,
     infer_model_name_from_instance,
 )
+from orcheo.widgets.chatkit import build_chatkit_widget_tools
 from .agent import (
     AgentNode,
     AgentReplyExtractorNode,
@@ -44,6 +45,7 @@ __all__ = [
     "ProviderStrategy",
     "create_agent",
     "init_chat_model",
+    "build_chatkit_widget_tools",
     "tool_registry",
     "tool_execution_context",
     "tool_progress_context",

--- a/src/orcheo/nodes/ai/agent.py
+++ b/src/orcheo/nodes/ai/agent.py
@@ -334,6 +334,10 @@ class AgentNode(AINode):
     """Tool names predefined by Orcheo."""
     workflow_tools: list[WorkflowTool] = Field(default_factory=list)
     """Workflows to be used as tools."""
+    use_chatkit_widget_tools: bool = False
+    """Enable local ChatKit widget definitions as tools."""
+    chatkit_widgets_dir: str | None = "/app/examples/chatkit_widgets/widgets"
+    """Curated directory containing .widget files to project as tools."""
     mcp_servers: dict[str, Any] = Field(default_factory=dict)
     """MCP servers to be used as tools (Connection from langchain_mcp_adapters)."""
     response_format: dict | type[BaseModel] | None = None
@@ -481,6 +485,11 @@ class AgentNode(AINode):
                 return_direct=wf_tool_def.return_direct,
             )
             tools.append(tool)
+
+        if self.use_chatkit_widget_tools:
+            tools.extend(
+                _ai_attr("build_chatkit_widget_tools")(self.chatkit_widgets_dir)
+            )
 
         # Get MCP tools
         mcp_client = _ai_attr("MultiServerMCPClient")(connections=self.mcp_servers)

--- a/src/orcheo/widgets/__init__.py
+++ b/src/orcheo/widgets/__init__.py
@@ -1,0 +1,7 @@
+"""ChatKit widget helpers."""
+
+from __future__ import annotations
+from orcheo.widgets.chatkit import build_chatkit_widget_tools
+
+
+__all__ = ["build_chatkit_widget_tools"]

--- a/src/orcheo/widgets/chatkit.py
+++ b/src/orcheo/widgets/chatkit.py
@@ -1,0 +1,337 @@
+"""Helpers for loading and projecting ChatKit widgets as tools."""
+
+from __future__ import annotations
+import json
+import logging
+from dataclasses import dataclass
+from functools import cache
+from pathlib import Path
+from typing import Any
+from chatkit.widgets import WidgetRoot, WidgetTemplate
+from langchain_core.tools import BaseTool, StructuredTool
+from pydantic import BaseModel, ConfigDict, create_model
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class WidgetDefinition:
+    """Represent a loaded ChatKit widget definition."""
+
+    name: str
+    version: str
+    json_schema: dict[str, Any]
+    output_json_preview: dict[str, Any]
+    template: str
+    encoded_widget: str | None
+    file_path: Path
+
+
+def _sanitize_tool_name(widget_name: str) -> str:
+    """Convert widget names into safe snake_case identifiers."""
+    sanitized = widget_name.lower().replace(" ", "_").replace("-", "_")
+    sanitized = "".join(c for c in sanitized if c.isalnum() or c == "_")
+    if sanitized and sanitized[0].isdigit():
+        sanitized = "_" + sanitized
+    return sanitized
+
+
+def _to_camel_case(snake_str: str) -> str:
+    """Convert a snake_case string into CamelCase."""
+    components = snake_str.split("_")
+    return "".join(x.title() for x in components)
+
+
+def _to_title_case(snake_or_lower: str) -> str:
+    """Convert a string to TitleCase."""
+    if "_" in snake_or_lower:
+        components = snake_or_lower.split("_")
+        return "".join(component.title() for component in components)
+    return snake_or_lower.capitalize()
+
+
+def _get_type_map() -> dict[str, type]:
+    """Return mapping from JSON Schema types to Python types."""
+    return {
+        "string": str,
+        "integer": int,
+        "number": float,
+        "boolean": bool,
+        "array": list,
+        "object": dict,
+    }
+
+
+def _resolve_array_type(
+    field_schema: dict[str, Any], model_name: str, field_name: str
+) -> Any:
+    """Resolve Python type for array field schema."""
+    items_schema = field_schema.get("items")
+    if not isinstance(items_schema, dict):
+        return list[Any]
+
+    item_type = items_schema.get("type")
+    if item_type == "object":
+        item_model_name = f"{model_name}{_to_title_case(field_name)}Item"
+        item_model = json_schema_to_pydantic(items_schema, item_model_name)
+        return list[item_model]  # type: ignore[valid-type]
+    if item_type == "array":
+        return list[Any]
+
+    type_map = _get_type_map()
+    mapped_type = type_map.get(item_type or "", Any)
+    return list[mapped_type]  # type: ignore[valid-type]
+
+
+def _resolve_field_type(
+    field_schema: dict[str, Any], model_name: str, field_name: str
+) -> Any:
+    """Resolve Python type for a field based on its schema."""
+    field_type = field_schema.get("type")
+
+    if field_type == "object":
+        nested_model_name = f"{model_name}{_to_title_case(field_name)}"
+        return json_schema_to_pydantic(field_schema, nested_model_name)
+    if field_type == "array":
+        return _resolve_array_type(field_schema, model_name, field_name)
+
+    type_map = _get_type_map()
+    return type_map.get(field_type or "", Any)
+
+
+def _build_field_definitions(
+    properties: dict[str, Any], required_fields: set[str], model_name: str
+) -> dict[str, Any]:
+    """Build field definitions dict for Pydantic model creation."""
+    field_definitions: dict[str, Any] = {}
+
+    for field_name, field_schema in properties.items():
+        python_type = _resolve_field_type(field_schema, model_name, field_name)
+
+        if field_name not in required_fields:
+            python_type = python_type | None
+            field_definitions[field_name] = (python_type, None)
+        else:
+            field_definitions[field_name] = (python_type, ...)
+
+    return field_definitions
+
+
+def _build_model_config(
+    schema: dict[str, Any], schema_title: str | None
+) -> dict[str, Any]:
+    """Build configuration kwargs for Pydantic model."""
+    config_kwargs: dict[str, Any] = {}
+    if schema_title:
+        config_kwargs["title"] = schema_title
+    if schema.get("additionalProperties") is False:
+        config_kwargs["extra"] = "forbid"
+    return config_kwargs
+
+
+def json_schema_to_pydantic(
+    schema: dict[str, Any],
+    model_name: str = "DynamicModel",
+    schema_title: str | None = None,
+) -> type[BaseModel]:
+    """Convert a JSON schema to a Pydantic model."""
+    if schema.get("type") != "object":
+        raise ValueError("Root schema must be of type 'object'")
+
+    properties = schema.get("properties", {})
+    required_fields = set(schema.get("required", []))
+
+    field_definitions = _build_field_definitions(
+        properties, required_fields, model_name
+    )
+    config_kwargs = _build_model_config(schema, schema_title)
+
+    if config_kwargs:
+        config = ConfigDict(**config_kwargs)  # type: ignore[typeddict-item]
+        return create_model(model_name, __config__=config, **field_definitions)
+
+    return create_model(model_name, **field_definitions)
+
+
+def _model_metadata(widget_name: str) -> tuple[str, str]:
+    """Return consistent Pydantic metadata derived from a widget name."""
+    camel_name = _to_camel_case(_sanitize_tool_name(widget_name))
+    return f"{camel_name}Model", f"{camel_name}Arguments"
+
+
+@cache
+def _build_pydantic_model(schema_dump: str, widget_name: str) -> type[BaseModel]:
+    """Return a cached Pydantic model class for the given schema snapshot."""
+    schema = json.loads(schema_dump)
+    model_name, schema_title = _model_metadata(widget_name)
+    return json_schema_to_pydantic(schema, model_name, schema_title)
+
+
+def build_widget_model(widget_def: WidgetDefinition) -> type[BaseModel]:
+    """Convert a widget definition's JSON schema into a Pydantic model."""
+    schema_dump = json.dumps(widget_def.json_schema, sort_keys=True)
+    return _build_pydantic_model(schema_dump, widget_def.name)
+
+
+@cache
+def _load_widget_template(template_path: str) -> WidgetTemplate:
+    """Load and cache a WidgetTemplate from disk."""
+    return WidgetTemplate.from_file(template_path)
+
+
+def render_widget_definition(widget_def: WidgetDefinition, **kwargs: Any) -> WidgetRoot:
+    """Validate inputs, render the widget's template, and return a WidgetRoot."""
+    model = build_widget_model(widget_def)
+    validated = model(**kwargs)
+    template = _load_widget_template(str(widget_def.file_path))
+    render_context = validated.model_dump()
+    render_context["undefined"] = None
+    return template.build(render_context)
+
+
+def _validate_widgets_dir(widgets_dir: Path | None) -> Path:
+    """Ensure the provided widgets directory exists and is a directory."""
+    if widgets_dir is None:
+        raise ValueError("The widgets_dir argument is required to load widgets.")
+    resolved_dir = widgets_dir.resolve()
+    if not resolved_dir.exists():
+        raise ValueError(f"Widgets directory does not exist: {resolved_dir}")
+    if not resolved_dir.is_dir():
+        raise ValueError(f"Widgets directory is not a directory: {resolved_dir}")
+    return resolved_dir
+
+
+def _collect_widget_files(base_dir: Path) -> list[Path]:
+    """Return .widget files that physically live inside the base directory."""
+    base_resolved = base_dir.resolve()
+    widget_files: list[Path] = []
+    seen_files: set[Path] = set()
+    for widget_file in sorted(base_dir.rglob("*.widget")):
+        if not widget_file.is_file():
+            continue
+        try:
+            resolved_path = widget_file.resolve()
+        except OSError as exc:
+            logger.warning(
+                "Skipping widget %s because it could not be resolved (%s)",
+                widget_file,
+                exc,
+            )
+            continue
+        try:
+            resolved_path.relative_to(base_resolved)
+        except ValueError:
+            logger.warning(
+                "Skipping widget %s because it is outside the widgets directory",
+                widget_file,
+            )
+            continue
+        if resolved_path in seen_files:
+            continue
+        seen_files.add(resolved_path)
+        widget_files.append(widget_file)
+    return widget_files
+
+
+def load_widget(widget_path: Path) -> WidgetDefinition:
+    """Load a widget definition from a .widget file."""
+    with widget_path.open(encoding="utf-8") as f:
+        data = json.load(f)
+
+    required_fields = ["name", "version", "jsonSchema", "outputJsonPreview", "template"]
+    missing_fields = [field for field in required_fields if field not in data]
+    if missing_fields:
+        raise ValueError(
+            f"Widget file {widget_path} missing required fields: "
+            f"{', '.join(missing_fields)}"
+        )
+
+    template_value = data["template"]
+    if not isinstance(template_value, str):
+        raise ValueError(f"Widget template must be a string: {widget_path}")
+
+    return WidgetDefinition(
+        name=str(data["name"]),
+        version=str(data["version"]),
+        json_schema=data["jsonSchema"],
+        output_json_preview=data["outputJsonPreview"],
+        template=template_value,
+        encoded_widget=data.get("encodedWidget"),
+        file_path=widget_path,
+    )
+
+
+def load_widgets(widgets_dir: Path | str | None) -> list[WidgetDefinition]:
+    """Load all .widget files from a curated directory."""
+    if isinstance(widgets_dir, str):
+        widgets_dir = Path(widgets_dir)
+    base_dir = _validate_widgets_dir(widgets_dir)
+    widget_files = _collect_widget_files(base_dir)
+
+    if not widget_files:
+        logger.warning("No widget definitions found in %s", base_dir)
+
+    return [load_widget(widget_file) for widget_file in widget_files]
+
+
+def _widget_tool_result(
+    widget_def: WidgetDefinition,
+    widget_root: WidgetRoot,
+) -> tuple[str, dict[str, Any]]:
+    """Return content and artifact payload for a rendered widget."""
+    copy_text = f"Rendered {widget_def.name} widget."
+    return copy_text, {
+        "structured_content": widget_root.model_dump(exclude_none=True),
+        "copy_text": copy_text,
+    }
+
+
+def _create_widget_tool_function(
+    widget_def: WidgetDefinition,
+) -> StructuredTool:
+    """Create a LangChain tool for a given widget definition."""
+    args_schema = build_widget_model(widget_def)
+
+    def widget_tool(**kwargs: Any) -> tuple[str, dict[str, Any]]:
+        widget_root = render_widget_definition(widget_def, **kwargs)
+        return _widget_tool_result(widget_def, widget_root)
+
+    async def widget_tool_async(**kwargs: Any) -> tuple[str, dict[str, Any]]:
+        widget_root = render_widget_definition(widget_def, **kwargs)
+        return _widget_tool_result(widget_def, widget_root)
+
+    return StructuredTool.from_function(
+        func=widget_tool,
+        coroutine=widget_tool_async,
+        name=_sanitize_tool_name(widget_def.name),
+        description=(
+            f"Generate a {widget_def.name} ChatKit widget from structured input."
+        ),
+        args_schema=args_schema,
+        return_direct=True,
+        response_format="content_and_artifact",
+    )
+
+
+def build_chatkit_widget_tools(
+    widgets_dir: Path | str | None,
+) -> list[BaseTool]:
+    """Load widget definitions from disk and project them into tools."""
+    if widgets_dir is None:
+        raise ValueError("The widgets_dir argument is required to build widget tools.")
+
+    resolved_dir = Path(widgets_dir).expanduser().resolve()
+    widget_defs = load_widgets(resolved_dir)
+    return [_create_widget_tool_function(widget_def) for widget_def in widget_defs]
+
+
+__all__ = [
+    "WidgetDefinition",
+    "build_chatkit_widget_tools",
+    "build_widget_model",
+    "json_schema_to_pydantic",
+    "load_widget",
+    "load_widgets",
+    "render_widget_definition",
+]

--- a/tests/widgets/test_chatkit.py
+++ b/tests/widgets/test_chatkit.py
@@ -3,15 +3,23 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from langchain_core.runnables import RunnableConfig
+from pydantic import BaseModel
 
 from orcheo.graph.state import State
 from orcheo.nodes.ai import AgentNode, build_chatkit_widget_tools
 from orcheo.widgets.chatkit import (
+    _collect_widget_files,
+    _create_widget_tool_function,
+    _sanitize_tool_name,
+    _to_title_case,
+    _validate_widgets_dir,
+    build_chatkit_widget_tools as _build_widget_tools_direct,
     json_schema_to_pydantic,
     load_widget,
     load_widgets,
@@ -175,3 +183,295 @@ async def test_agent_prepares_chatkit_widget_tools(
     call_kwargs = mock_create_agent.call_args[1]
     assert len(call_kwargs["tools"]) == 1
     assert call_kwargs["tools"][0].name == "greeting_card"
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_tool_name – digit-leading name (line 36)
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_tool_name_prefixes_digit_start() -> None:
+    """Widget names starting with a digit get a leading underscore."""
+    assert _sanitize_tool_name("1Widget") == "_1widget"
+
+
+# ---------------------------------------------------------------------------
+# _to_title_case – both branches (lines 48-51)
+# ---------------------------------------------------------------------------
+
+
+def test_to_title_case_with_underscore() -> None:
+    """Snake-case strings are converted to TitleCase (lines 48-50)."""
+    assert _to_title_case("foo_bar") == "FooBar"
+
+
+def test_to_title_case_without_underscore() -> None:
+    """Plain lowercase strings are capitalised (line 51)."""
+    assert _to_title_case("foo") == "Foo"
+
+
+# ---------------------------------------------------------------------------
+# json_schema_to_pydantic – nested object field (lines 94-95 + 48-50 via
+# _to_title_case on a snake_case field name)
+# ---------------------------------------------------------------------------
+
+
+def test_json_schema_to_pydantic_nested_object_field() -> None:
+    """Nested-object schema property triggers _resolve_field_type object branch."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "home_address": {  # underscore → _to_title_case hits lines 48-50
+                "type": "object",
+                "properties": {"street": {"type": "string"}},
+            }
+        },
+    }
+    model = json_schema_to_pydantic(schema)
+    assert issubclass(model, BaseModel)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_array_type – all branches (lines 70-84, line 97)
+# ---------------------------------------------------------------------------
+
+
+def test_json_schema_to_pydantic_array_field_no_items() -> None:
+    """Array property with no items schema resolves to list[Any] (lines 70-72)."""
+    schema = {
+        "type": "object",
+        "properties": {"tags": {"type": "array"}},
+    }
+    model = json_schema_to_pydantic(schema)
+    assert issubclass(model, BaseModel)
+
+
+def test_json_schema_to_pydantic_array_of_objects() -> None:
+    """Array of objects creates a nested Pydantic model (lines 75-78, line 51 via _to_title_case)."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "rows": {  # no underscore → _to_title_case hits line 51
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {"value": {"type": "string"}},
+                },
+            }
+        },
+    }
+    model = json_schema_to_pydantic(schema)
+    assert issubclass(model, BaseModel)
+
+
+def test_json_schema_to_pydantic_array_of_arrays() -> None:
+    """Array-of-arrays items type returns list[Any] (lines 79-80)."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "matrix": {
+                "type": "array",
+                "items": {"type": "array"},
+            }
+        },
+    }
+    model = json_schema_to_pydantic(schema)
+    assert issubclass(model, BaseModel)
+
+
+def test_json_schema_to_pydantic_array_of_primitives() -> None:
+    """Array of primitive items uses type_map fallback (lines 82-84, line 97)."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "names": {
+                "type": "array",
+                "items": {"type": "string"},
+            }
+        },
+    }
+    model = json_schema_to_pydantic(schema)
+    assert issubclass(model, BaseModel)
+
+
+# ---------------------------------------------------------------------------
+# _build_field_definitions – optional field path (lines 113-114)
+# ---------------------------------------------------------------------------
+
+
+def test_json_schema_to_pydantic_optional_field() -> None:
+    """Fields absent from required[] are typed as optional (lines 113-114)."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "nickname": {"type": "string"},
+        },
+        "required": ["name"],
+    }
+    model = json_schema_to_pydantic(schema)
+    instance = model(name="Alice")  # type: ignore[call-arg]
+    assert instance.nickname is None  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# _build_model_config branches + bare create_model path (126->128, 128->130, 154)
+# ---------------------------------------------------------------------------
+
+
+def test_json_schema_to_pydantic_without_config() -> None:
+    """Schema with no title and no additionalProperties uses bare create_model (line 154)."""
+    schema = {"type": "object", "properties": {"x": {"type": "string"}}}
+    model = json_schema_to_pydantic(
+        schema
+    )  # schema_title=None, no additionalProperties
+    assert issubclass(model, BaseModel)
+
+
+# ---------------------------------------------------------------------------
+# _validate_widgets_dir error paths (lines 196, 199, 201)
+# ---------------------------------------------------------------------------
+
+
+def test_validate_widgets_dir_raises_for_none() -> None:
+    """None argument raises ValueError (line 196)."""
+    with pytest.raises(ValueError, match="required to load widgets"):
+        _validate_widgets_dir(None)
+
+
+def test_validate_widgets_dir_raises_for_nonexistent(tmp_path: Path) -> None:
+    """Non-existent path raises ValueError (line 199)."""
+    with pytest.raises(ValueError, match="does not exist"):
+        _validate_widgets_dir(tmp_path / "missing")
+
+
+def test_validate_widgets_dir_raises_for_file(tmp_path: Path) -> None:
+    """A regular file path (not a directory) raises ValueError (line 201)."""
+    file_path = tmp_path / "notadir"
+    file_path.touch()
+    with pytest.raises(ValueError, match="not a directory"):
+        _validate_widgets_dir(file_path)
+
+
+# ---------------------------------------------------------------------------
+# _collect_widget_files edge cases (lines 212, 215-221, 224-229, 231)
+# ---------------------------------------------------------------------------
+
+
+def test_collect_widget_files_skips_non_file_entries(tmp_path: Path) -> None:
+    """A directory named *.widget is skipped (line 212)."""
+    (tmp_path / "fake.widget").mkdir()
+    assert _collect_widget_files(tmp_path) == []
+
+
+def test_collect_widget_files_skips_unresolvable(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """OSError during resolve is caught and logged (lines 215-221)."""
+    (tmp_path / "broken.widget").write_text("{}")
+
+    original_resolve = Path.resolve
+
+    def conditional_resolve(self: Path, strict: bool = False) -> Path:
+        if str(self).endswith(".widget"):
+            raise OSError("cannot resolve")
+        return original_resolve(self, strict)
+
+    with patch.object(Path, "resolve", conditional_resolve):
+        with caplog.at_level(logging.WARNING, logger="orcheo.widgets.chatkit"):
+            result = _collect_widget_files(tmp_path)
+
+    assert result == []
+    assert "could not be resolved" in caplog.text
+
+
+def test_collect_widget_files_skips_outside_dir(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Symlinks pointing outside the base directory are skipped (lines 224-229)."""
+    outer = tmp_path / "outer"
+    outer.mkdir()
+    outside_widget = outer / "outside.widget"
+    outside_widget.write_text(json.dumps({"name": "x"}))
+
+    base_dir = tmp_path / "widgets"
+    base_dir.mkdir()
+    (base_dir / "link.widget").symlink_to(outside_widget)
+
+    with caplog.at_level(logging.WARNING, logger="orcheo.widgets.chatkit"):
+        result = _collect_widget_files(base_dir)
+
+    assert result == []
+    assert "outside the widgets directory" in caplog.text
+
+
+def test_collect_widget_files_deduplicates_symlinks(tmp_path: Path) -> None:
+    """Two paths resolving to the same file are counted once (line 231)."""
+    real_widget = tmp_path / "real.widget"
+    real_widget.write_text(json.dumps({"name": "x"}))
+    (tmp_path / "link.widget").symlink_to(real_widget)
+
+    result = _collect_widget_files(tmp_path)
+    assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# load_widget – non-string template (line 252)
+# ---------------------------------------------------------------------------
+
+
+def test_load_widget_raises_for_non_string_template(tmp_path: Path) -> None:
+    """Widget file whose template is not a string raises ValueError (line 252)."""
+    widget_path = tmp_path / "bad.widget"
+    widget_path.write_text(
+        json.dumps(
+            {
+                "version": "1.0",
+                "name": "bad",
+                "template": {"not": "a string"},
+                "jsonSchema": {"type": "object", "properties": {}},
+                "outputJsonPreview": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="template must be a string"):
+        load_widget(widget_path)
+
+
+# ---------------------------------------------------------------------------
+# load_widgets – string path input (line 268)
+# ---------------------------------------------------------------------------
+
+
+def test_load_widgets_accepts_string_path(tmp_path: Path) -> None:
+    """load_widgets converts a str argument to Path before loading (line 268)."""
+    _write_widget_file(tmp_path)
+    widgets = load_widgets(str(tmp_path))
+    assert len(widgets) == 1
+
+
+# ---------------------------------------------------------------------------
+# Async widget tool coroutine (lines 301-302)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_widget_tool_async_invocation(tmp_path: Path) -> None:
+    """ainvoke() exercises the async coroutine path in the widget tool (lines 301-302)."""
+    widget_def = load_widget(_write_widget_file(tmp_path))
+    tool = _create_widget_tool_function(widget_def)
+
+    result = await tool.ainvoke({"title": "Async Hello"})
+    assert result == "Rendered Greeting Card widget."
+
+
+# ---------------------------------------------------------------------------
+# build_chatkit_widget_tools – None guard (line 322)
+# ---------------------------------------------------------------------------
+
+
+def test_build_chatkit_widget_tools_raises_for_none() -> None:
+    """None widgets_dir raises ValueError in build_chatkit_widget_tools (line 322)."""
+    with pytest.raises(ValueError, match="required to build widget tools"):
+        _build_widget_tools_direct(None)

--- a/tests/widgets/test_chatkit.py
+++ b/tests/widgets/test_chatkit.py
@@ -1,0 +1,177 @@
+"""Tests for native ChatKit widget helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from langchain_core.runnables import RunnableConfig
+
+from orcheo.graph.state import State
+from orcheo.nodes.ai import AgentNode, build_chatkit_widget_tools
+from orcheo.widgets.chatkit import (
+    json_schema_to_pydantic,
+    load_widget,
+    load_widgets,
+    render_widget_definition,
+)
+
+
+def _write_widget_file(base_dir: Path, name: str = "Greeting Card") -> Path:
+    widget_path = base_dir / f"{name}.widget"
+    widget_path.write_text(
+        json.dumps(
+            {
+                "version": "1.0",
+                "name": name,
+                "template": (
+                    '{"type":"Card","children":[{"type":"Text","value":'
+                    "{{ (title) | tojson }} }]}"
+                ),
+                "jsonSchema": {
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "type": "object",
+                    "properties": {
+                        "title": {
+                            "type": "string",
+                        }
+                    },
+                    "required": ["title"],
+                    "additionalProperties": False,
+                },
+                "outputJsonPreview": {
+                    "type": "Card",
+                    "children": [
+                        {
+                            "type": "Text",
+                            "value": "Hello",
+                        }
+                    ],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return widget_path
+
+
+def test_json_schema_to_pydantic_rejects_non_object_root() -> None:
+    """The schema converter should reject non-object roots."""
+
+    with pytest.raises(ValueError, match="Root schema must be of type 'object'"):
+        json_schema_to_pydantic({"type": "string"})
+
+
+def test_load_widget_and_render_widget_definition(tmp_path: Path) -> None:
+    """Widget definitions should load and render into ChatKit roots."""
+
+    widget_path = _write_widget_file(tmp_path)
+    widget_def = load_widget(widget_path)
+
+    assert widget_def.name == "Greeting Card"
+    assert widget_def.version == "1.0"
+
+    widget_root = render_widget_definition(widget_def, title="Hello Orcheo")
+    rendered = widget_root.model_dump(exclude_none=True)
+
+    assert rendered["type"] == "Card"
+    assert rendered["children"][0]["value"] == "Hello Orcheo"
+
+
+def test_load_widgets_returns_empty_list_for_empty_directory(
+    tmp_path: Path,
+) -> None:
+    """Empty curated directories should return an empty widget list."""
+
+    assert load_widgets(tmp_path) == []
+
+
+def test_load_widget_requires_required_fields(tmp_path: Path) -> None:
+    """Widget files missing required keys should raise a validation error."""
+
+    widget_path = tmp_path / "Broken.widget"
+    widget_path.write_text(
+        json.dumps(
+            {
+                "version": "1.0",
+                "name": "Broken",
+                "jsonSchema": {"type": "object", "properties": {}},
+                "outputJsonPreview": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="missing required fields"):
+        load_widget(widget_path)
+
+
+def test_agentnode_defaults_chatkit_widgets_dir() -> None:
+    """AgentNode should default to the bundled ChatKit widgets directory."""
+
+    agent = AgentNode(
+        name="test_agent",
+        ai_model="openai:gpt-4o-mini",
+        system_prompt="Test prompt",
+    )
+
+    assert agent.chatkit_widgets_dir == "/app/examples/chatkit_widgets/widgets"
+
+
+def test_build_chatkit_widget_tools_projects_widget_tools(
+    tmp_path: Path,
+) -> None:
+    """Widget definitions should be projected into direct-return tools."""
+
+    _write_widget_file(tmp_path)
+    tools = build_chatkit_widget_tools(tmp_path)
+
+    assert len(tools) == 1
+    tool = tools[0]
+    assert tool.name == "greeting_card"
+    assert tool.return_direct is True
+    assert tool.response_format == "content_and_artifact"
+    assert tool.invoke({"title": "Hello"}) == "Rendered Greeting Card widget."
+
+
+@pytest.mark.asyncio
+@patch("orcheo.nodes.ai.create_agent")
+@patch("orcheo.nodes.ai.MultiServerMCPClient")
+async def test_agent_prepares_chatkit_widget_tools(
+    mock_mcp_client_class,
+    mock_create_agent,
+    tmp_path: Path,
+) -> None:
+    """AgentNode should merge native widget tools into the tool list."""
+
+    _write_widget_file(tmp_path)
+    mock_mcp_client = AsyncMock()
+    mock_mcp_client.get_tools.return_value = []
+    mock_mcp_client_class.return_value = mock_mcp_client
+    mock_agent = AsyncMock()
+    mock_agent.ainvoke.return_value = {
+        "messages": [{"role": "assistant", "content": "ok"}]
+    }
+    mock_create_agent.return_value = mock_agent
+
+    agent = AgentNode(
+        name="test_agent",
+        ai_model="openai:gpt-4o-mini",
+        system_prompt="Test prompt",
+        predefined_tools=[],
+        workflow_tools=[],
+        use_chatkit_widget_tools=True,
+        chatkit_widgets_dir=str(tmp_path),
+    )
+
+    state: State = {"messages": [{"role": "user", "content": "build a widget"}]}
+    config = RunnableConfig()
+
+    await agent.run(state, config)
+
+    mock_create_agent.assert_called_once()
+    call_kwargs = mock_create_agent.call_args[1]
+    assert len(call_kwargs["tools"]) == 1
+    assert call_kwargs["tools"][0].name == "greeting_card"


### PR DESCRIPTION
## What changed
- Added `orcheo.widgets.chatkit` helpers to load `.widget` definitions, convert JSON Schema into Pydantic tool args, render widgets, and expose them as LangChain `StructuredTool`s.
- Added an opt-in `AgentNode` flag for native ChatKit widget tools, with a configurable widgets directory that defaults to `/app/examples/chatkit_widgets/widgets`.
- Mounted curated widget fixtures into the backend, worker, and celery-beat containers and added sample widgets under `deploy/stack/chatkit_widgets`.
- Trimmed the Studio workflow config sheet to keep only `configurable`, `recursion_limit`, and `max_concurrency`, while inferring schemas for configurable fields and merging declared schemas where present.
- Expanded tests for widget loading/rendering and workflow config schema behavior.

## Validation
- `uv run pytest tests/widgets/test_chatkit.py -q`
- `npm --prefix apps/studio test -- --run src/features/workflow/pages/workflow/components/workflow-config-sheet.utils.test.ts`