### PR TITLE
Add workspace teams and team-aware onboarding

### DIFF
--- a/apps/backend/src/orcheo_backend/app/factory.py
+++ b/apps/backend/src/orcheo_backend/app/factory.py
@@ -63,6 +63,7 @@ from orcheo_backend.app.routers import (
     nodes,
     runs,
     system,
+    teams,
     triggers,
     websocket,
     workflows,
@@ -149,6 +150,7 @@ def _build_api_router() -> APIRouter:
     )
     protected_router.include_router(service_token_router)
     protected_router.include_router(workflows.router)
+    protected_router.include_router(teams.router)
     protected_router.include_router(credentials.router)
     protected_router.include_router(credential_templates.router)
     protected_router.include_router(credential_alerts.router)

--- a/apps/backend/src/orcheo_backend/app/repository/__init__.py
+++ b/apps/backend/src/orcheo_backend/app/repository/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 from orcheo.models import (
+    Team,
     Workflow,
     WorkflowRun,
     WorkflowVersion,
@@ -9,6 +10,8 @@ from orcheo.models import (
 from orcheo_backend.app.repository.errors import (
     CronTriggerNotFoundError,
     RepositoryError,
+    TeamNotFoundError,
+    TeamSlugConflictError,
     WorkflowHandleConflictError,
     WorkflowNotFoundError,
     WorkflowPublishStateError,
@@ -24,6 +27,9 @@ __all__ = [
     "InMemoryWorkflowRepository",
     "CronTriggerNotFoundError",
     "RepositoryError",
+    "Team",
+    "TeamNotFoundError",
+    "TeamSlugConflictError",
     "VersionDiff",
     "WorkflowHandleConflictError",
     "Workflow",

--- a/apps/backend/src/orcheo_backend/app/repository/__init__.py
+++ b/apps/backend/src/orcheo_backend/app/repository/__init__.py
@@ -10,6 +10,7 @@ from orcheo.models import (
 from orcheo_backend.app.repository.errors import (
     CronTriggerNotFoundError,
     RepositoryError,
+    TeamNotEmptyError,
     TeamNotFoundError,
     TeamSlugConflictError,
     WorkflowHandleConflictError,
@@ -28,6 +29,7 @@ __all__ = [
     "CronTriggerNotFoundError",
     "RepositoryError",
     "Team",
+    "TeamNotEmptyError",
     "TeamNotFoundError",
     "TeamSlugConflictError",
     "VersionDiff",

--- a/apps/backend/src/orcheo_backend/app/repository/errors.py
+++ b/apps/backend/src/orcheo_backend/app/repository/errors.py
@@ -31,6 +31,14 @@ class CronTriggerNotFoundError(RepositoryError):
     """Raised when a cron trigger config cannot be located."""
 
 
+class TeamNotFoundError(RepositoryError):
+    """Raised when a team cannot be located within a workspace."""
+
+
+class TeamSlugConflictError(RepositoryError):
+    """Raised when a team slug conflicts with an existing team."""
+
+
 __all__ = [
     "RepositoryError",
     "WorkflowNotFoundError",
@@ -39,4 +47,6 @@ __all__ = [
     "WorkflowPublishStateError",
     "WorkflowHandleConflictError",
     "CronTriggerNotFoundError",
+    "TeamNotFoundError",
+    "TeamSlugConflictError",
 ]

--- a/apps/backend/src/orcheo_backend/app/repository/errors.py
+++ b/apps/backend/src/orcheo_backend/app/repository/errors.py
@@ -39,6 +39,10 @@ class TeamSlugConflictError(RepositoryError):
     """Raised when a team slug conflicts with an existing team."""
 
 
+class TeamNotEmptyError(RepositoryError):
+    """Raised when attempting to delete a team that still has colleagues."""
+
+
 __all__ = [
     "RepositoryError",
     "WorkflowNotFoundError",
@@ -49,4 +53,5 @@ __all__ = [
     "CronTriggerNotFoundError",
     "TeamNotFoundError",
     "TeamSlugConflictError",
+    "TeamNotEmptyError",
 ]

--- a/apps/backend/src/orcheo_backend/app/repository/in_memory/__init__.py
+++ b/apps/backend/src/orcheo_backend/app/repository/in_memory/__init__.py
@@ -6,6 +6,7 @@ from orcheo_backend.app.repository.in_memory.listeners import ListenerRepository
 from orcheo_backend.app.repository.in_memory.retry import RetryPolicyMixin
 from orcheo_backend.app.repository.in_memory.runs import WorkflowRunMixin
 from orcheo_backend.app.repository.in_memory.state import InMemoryRepositoryState
+from orcheo_backend.app.repository.in_memory.teams import TeamCrudMixin
 from orcheo_backend.app.repository.in_memory.triggers import TriggerDispatchMixin
 from orcheo_backend.app.repository.in_memory.versions import WorkflowVersionMixin
 from orcheo_backend.app.repository.in_memory.workflows import WorkflowCrudMixin
@@ -17,6 +18,7 @@ class InMemoryWorkflowRepository(
     TriggerDispatchMixin,
     WorkflowRunMixin,
     WorkflowVersionMixin,
+    TeamCrudMixin,
     WorkflowCrudMixin,
     InMemoryRepositoryState,
 ):

--- a/apps/backend/src/orcheo_backend/app/repository/in_memory/state.py
+++ b/apps/backend/src/orcheo_backend/app/repository/in_memory/state.py
@@ -7,6 +7,7 @@ from typing import Any
 from uuid import UUID
 from orcheo.listeners import ListenerCursor, ListenerDedupeRecord, ListenerSubscription
 from orcheo.models import (
+    Team,
     Workflow,
     WorkflowRun,
     WorkflowVersion,
@@ -33,8 +34,12 @@ class InMemoryRepositoryState:
         self._lock = asyncio.Lock()
         self._workflows: dict[UUID, Workflow] = {}
         self._workflow_workspaces: dict[UUID, str] = {}
-        self._active_workflow_handles: dict[str | None, dict[str, UUID]] = {}
+        # A handle can be active in multiple teams within one workspace, so the
+        # index maps handle -> ordered list of workflow ids (default team first).
+        self._active_workflow_handles: dict[str | None, dict[str, list[UUID]]] = {}
         self._archived_workflow_handles: dict[str | None, dict[str, list[UUID]]] = {}
+        self._teams: dict[UUID, Team] = {}
+        self._default_team_by_workspace: dict[str, str] = {}
         self._workflow_versions: dict[UUID, list[UUID]] = {}
         self._versions: dict[UUID, WorkflowVersion] = {}
         self._runs: dict[UUID, WorkflowRun] = {}
@@ -54,6 +59,8 @@ class InMemoryRepositoryState:
             self._workflow_workspaces.clear()
             self._active_workflow_handles.clear()
             self._archived_workflow_handles.clear()
+            self._teams.clear()
+            self._default_team_by_workspace.clear()
             self._workflow_versions.clear()
             self._versions.clear()
             self._runs.clear()
@@ -208,6 +215,21 @@ class InMemoryRepositoryState:
         if not report.is_healthy:
             raise CredentialHealthError(report)
 
+    def _is_default_team_workflow(self, workflow: Workflow) -> bool:
+        """Return True when the workflow belongs to its workspace's default team."""
+        if workflow.workspace_id is None or workflow.team_id is None:
+            return False
+        default_team = self._default_team_by_workspace.get(workflow.workspace_id)
+        return default_team is not None and workflow.team_id == default_team
+
+    def _active_handle_sort_key(self, workflow_id: UUID) -> tuple[int, float]:
+        """Order active handle matches default-team-first, then most recent."""
+        workflow = self._workflows.get(workflow_id)
+        if workflow is None:  # pragma: no cover - defensive
+            return (1, 0.0)
+        is_default = self._is_default_team_workflow(workflow)
+        return (0 if is_default else 1, -workflow.updated_at.timestamp())
+
     def _rebuild_handle_indexes_locked(self) -> None:
         """Rebuild handle indexes from workflow state. Caller must hold the lock."""
         self._active_workflow_handles.clear()
@@ -223,9 +245,16 @@ class InMemoryRepositoryState:
                     [],
                 ).append(workflow.id)
                 continue
-            self._active_workflow_handles.setdefault(workspace_id, {})[
-                workflow.handle
-            ] = workflow.id
+            self._active_workflow_handles.setdefault(workspace_id, {}).setdefault(
+                workflow.handle,
+                [],
+            ).append(workflow.id)
+
+        # Within a (workspace, handle) bucket, surface the default team first so
+        # bare-handle resolution honours the default-team-wins rule.
+        for handles in self._active_workflow_handles.values():
+            for matches in handles.values():
+                matches.sort(key=self._active_handle_sort_key)
 
     def _ensure_handle_available_locked(
         self,
@@ -234,8 +263,9 @@ class InMemoryRepositoryState:
         workflow_id: UUID | None,
         is_archived: bool,
         workspace_id: str | None = None,
+        team_id: str | None = None,
     ) -> None:
-        """Ensure the provided handle is valid for assignment."""
+        """Ensure the provided handle is valid for assignment within the team."""
         if handle is None:
             return
 
@@ -245,16 +275,59 @@ class InMemoryRepositoryState:
                 continue
             if existing.workspace_id != workspace_id:
                 continue
+            # Handle uniqueness is scoped per team: the same handle may live in
+            # different teams of one workspace.
+            if existing.team_id != team_id:
+                continue
             if not existing.is_archived:
                 msg = f"Workflow handle '{handle}' is already in use."
                 raise WorkflowHandleConflictError(msg)
 
-    async def resolve_workflow_ref(  # noqa: C901
+    def _matches_team(self, workflow_id: UUID, team_id: str | None) -> bool:
+        """Return True when *team_id* is unset or the workflow is in that team."""
+        if team_id is None:
+            return True
+        workflow = self._workflows.get(workflow_id)
+        return workflow is not None and workflow.team_id == team_id
+
+    def _find_in_handle_index(
+        self,
+        index: dict[str | None, dict[str, list[UUID]]],
+        scope_keys: list[str | None],
+        normalized_ref: str,
+        team_id: str | None,
+    ) -> UUID | None:
+        for scope_key in scope_keys:
+            for match in index.get(scope_key, {}).get(normalized_ref, []):
+                if self._matches_team(match, team_id):
+                    return match
+        return None
+
+    def _resolve_by_uuid(
+        self,
+        normalized_ref: str,
+        workspace_id: str | None,
+        team_id: str | None,
+    ) -> UUID | None:
+        if team_id is not None or not workflow_ref_is_uuid(normalized_ref):
+            return None
+        workflow_uuid = UUID(normalized_ref)
+        if workflow_uuid not in self._workflows:
+            return None
+        if workspace_id is None:
+            return workflow_uuid
+        stored = self._workflow_workspaces.get(workflow_uuid)
+        if stored is None or stored == workspace_id:
+            return workflow_uuid
+        return None
+
+    async def resolve_workflow_ref(
         self,
         workflow_ref: str,
         *,
         include_archived: bool = True,
         workspace_id: str | None = None,
+        team_id: str | None = None,
     ) -> UUID:
         """Resolve a user-facing workflow ref to a canonical UUID."""
         normalized_ref = workflow_ref.strip().lower()
@@ -268,29 +341,25 @@ class InMemoryRepositoryState:
             else:
                 scope_keys = [None, *self._active_workflow_handles.keys()]
 
-            for scope_key in scope_keys:
-                active_handles = self._active_workflow_handles.get(scope_key, {})
-                active_match = active_handles.get(normalized_ref)
-                if active_match is not None:
-                    return active_match
+            found = self._find_in_handle_index(
+                self._active_workflow_handles, scope_keys, normalized_ref, team_id
+            )
+            if found is not None:
+                return found
 
             if include_archived:
-                for scope_key in scope_keys:
-                    archived_handles = self._archived_workflow_handles.get(
-                        scope_key, {}
-                    )
-                    archived_matches = archived_handles.get(normalized_ref)
-                    if archived_matches:
-                        return archived_matches[0]
+                found = self._find_in_handle_index(
+                    self._archived_workflow_handles,
+                    scope_keys,
+                    normalized_ref,
+                    team_id,
+                )
+                if found is not None:
+                    return found
 
-            if workflow_ref_is_uuid(normalized_ref):
-                workflow_uuid = UUID(normalized_ref)
-                if workflow_uuid in self._workflows:
-                    if workspace_id is None:
-                        return workflow_uuid
-                    stored_workspace = self._workflow_workspaces.get(workflow_uuid)
-                    if stored_workspace is None or stored_workspace == workspace_id:
-                        return workflow_uuid
+            found = self._resolve_by_uuid(normalized_ref, workspace_id, team_id)
+            if found is not None:
+                return found
 
         raise WorkflowNotFoundError(normalized_ref)
 

--- a/apps/backend/src/orcheo_backend/app/repository/in_memory/teams.py
+++ b/apps/backend/src/orcheo_backend/app/repository/in_memory/teams.py
@@ -1,0 +1,112 @@
+"""Team grouping operations for the in-memory repository."""
+
+from __future__ import annotations
+from uuid import UUID
+from orcheo.models import Team, normalize_team_slug
+from orcheo_backend.app.repository.errors import (
+    TeamNotFoundError,
+    TeamSlugConflictError,
+)
+from orcheo_backend.app.repository.in_memory.state import InMemoryRepositoryState
+
+
+class TeamCrudMixin(InMemoryRepositoryState):
+    """Implements team management helpers."""
+
+    def _sorted_teams_locked(self, workspace_id: str) -> list[Team]:
+        teams = [
+            team for team in self._teams.values() if team.workspace_id == workspace_id
+        ]
+        teams.sort(key=lambda team: (not team.is_default, team.slug))
+        return [team.model_copy(deep=True) for team in teams]
+
+    async def list_teams(self, *, workspace_id: str) -> list[Team]:
+        """Return teams in the workspace, default team first."""
+        async with self._lock:
+            return self._sorted_teams_locked(workspace_id)
+
+    async def get_team(self, team_id: UUID, *, workspace_id: str) -> Team:
+        """Return a single team scoped to the workspace."""
+        async with self._lock:
+            team = self._teams.get(team_id)
+            if team is None or team.workspace_id != workspace_id:
+                raise TeamNotFoundError(str(team_id))
+            return team.model_copy(deep=True)
+
+    async def get_team_by_slug(self, slug: str, *, workspace_id: str) -> Team:
+        """Return a team by slug scoped to the workspace."""
+        normalized = normalize_team_slug(slug)
+        async with self._lock:
+            for team in self._teams.values():
+                if team.workspace_id == workspace_id and team.slug == normalized:
+                    return team.model_copy(deep=True)
+            raise TeamNotFoundError(normalized)
+
+    def _create_team_locked(
+        self,
+        *,
+        workspace_id: str,
+        name: str,
+        slug: str,
+        is_default: bool,
+    ) -> Team:
+        normalized = normalize_team_slug(slug)
+        for team in self._teams.values():
+            if team.workspace_id == workspace_id and team.slug == normalized:
+                msg = f"Team slug already exists: {normalized}"
+                raise TeamSlugConflictError(msg)
+        team = Team(
+            workspace_id=workspace_id,
+            name=name,
+            slug=normalized,
+            is_default=is_default,
+        )
+        self._teams[team.id] = team
+        if is_default:
+            self._default_team_by_workspace[workspace_id] = str(team.id)
+        return team
+
+    async def create_team(
+        self,
+        *,
+        workspace_id: str,
+        name: str,
+        slug: str,
+        is_default: bool = False,
+    ) -> Team:
+        """Persist and return a new team; raises on slug conflict."""
+        async with self._lock:
+            team = self._create_team_locked(
+                workspace_id=workspace_id,
+                name=name,
+                slug=slug,
+                is_default=is_default,
+            )
+            return team.model_copy(deep=True)
+
+    async def ensure_default_team(
+        self,
+        *,
+        workspace_id: str,
+        name: str,
+        slug: str,
+    ) -> Team:
+        """Return the workspace's default team, creating it if absent."""
+        async with self._lock:
+            existing_id = self._default_team_by_workspace.get(workspace_id)
+            if existing_id is not None:
+                team = self._teams.get(UUID(existing_id))
+                if team is not None:
+                    return team.model_copy(deep=True)
+            team = self._create_team_locked(
+                workspace_id=workspace_id,
+                name=name,
+                slug=slug,
+                is_default=True,
+            )
+            # The default team became the head of every active handle bucket.
+            self._rebuild_handle_indexes_locked()
+            return team.model_copy(deep=True)
+
+
+__all__ = ["TeamCrudMixin"]

--- a/apps/backend/src/orcheo_backend/app/repository/in_memory/teams.py
+++ b/apps/backend/src/orcheo_backend/app/repository/in_memory/teams.py
@@ -117,7 +117,11 @@ class TeamCrudMixin(InMemoryRepositoryState):
                 raise TeamNotFoundError(str(team_id))
             team_id_str = str(team_id)
             for workflow in self._workflows.values():
-                if workflow.team_id == team_id_str:
+                if (
+                    workflow.workspace_id == workspace_id
+                    and workflow.team_id == team_id_str
+                    and not workflow.is_archived
+                ):
                     msg = f"Team '{team.name}' still has colleagues."
                     raise TeamNotEmptyError(msg)
             del self._teams[team_id]

--- a/apps/backend/src/orcheo_backend/app/repository/in_memory/teams.py
+++ b/apps/backend/src/orcheo_backend/app/repository/in_memory/teams.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from uuid import UUID
 from orcheo.models import Team, normalize_team_slug
 from orcheo_backend.app.repository.errors import (
+    TeamNotEmptyError,
     TeamNotFoundError,
     TeamSlugConflictError,
 )
@@ -107,6 +108,21 @@ class TeamCrudMixin(InMemoryRepositoryState):
             # The default team became the head of every active handle bucket.
             self._rebuild_handle_indexes_locked()
             return team.model_copy(deep=True)
+
+    async def delete_team(self, team_id: UUID, *, workspace_id: str) -> None:
+        """Delete a team; raises TeamNotEmptyError if the team has colleagues."""
+        async with self._lock:
+            team = self._teams.get(team_id)
+            if team is None or team.workspace_id != workspace_id:
+                raise TeamNotFoundError(str(team_id))
+            team_id_str = str(team_id)
+            for workflow in self._workflows.values():
+                if workflow.team_id == team_id_str:
+                    msg = f"Team '{team.name}' still has colleagues."
+                    raise TeamNotEmptyError(msg)
+            del self._teams[team_id]
+            if self._default_team_by_workspace.get(workspace_id) == team_id_str:
+                del self._default_team_by_workspace[workspace_id]
 
 
 __all__ = ["TeamCrudMixin"]

--- a/apps/backend/src/orcheo_backend/app/repository/in_memory/workflows.py
+++ b/apps/backend/src/orcheo_backend/app/repository/in_memory/workflows.py
@@ -77,6 +77,7 @@ class WorkflowCrudMixin(InMemoryRepositoryState):
         draft_access: WorkflowDraftAccess,
         actor: str,
         workspace_id: str | None = None,
+        team_id: str | None = None,
     ) -> Workflow:
         """Persist a new workflow and return the created instance."""
         normalized_handle = normalize_workflow_handle(handle)
@@ -86,11 +87,13 @@ class WorkflowCrudMixin(InMemoryRepositoryState):
                 workflow_id=None,
                 is_archived=False,
                 workspace_id=workspace_id,
+                team_id=team_id,
             )
             workflow = Workflow(
                 name=name,
                 handle=normalized_handle,
                 workspace_id=workspace_id,
+                team_id=team_id,
                 slug=slug or "",
                 description=description,
                 tags=list(tags or []),
@@ -135,12 +138,14 @@ class WorkflowCrudMixin(InMemoryRepositoryState):
         *,
         include_archived: bool = True,
         workspace_id: str | None = None,
+        team_id: str | None = None,
     ) -> UUID:
         """Resolve a workflow ref using handle-first semantics."""
         return await super().resolve_workflow_ref(
             workflow_ref,
             include_archived=include_archived,
             workspace_id=workspace_id,
+            team_id=team_id,
         )
 
     async def update_workflow(
@@ -178,6 +183,7 @@ class WorkflowCrudMixin(InMemoryRepositoryState):
                     workflow_id=workflow_id,
                     is_archived=next_is_archived,
                     workspace_id=workflow.workspace_id,
+                    team_id=workflow.team_id,
                 )
                 metadata["handle"] = {
                     "from": workflow.handle,

--- a/apps/backend/src/orcheo_backend/app/repository/protocol.py
+++ b/apps/backend/src/orcheo_backend/app/repository/protocol.py
@@ -15,6 +15,7 @@ from orcheo.listeners import (
 from orcheo.models import (
     ChatKitStartScreenPrompt,
     ChatKitSupportedModel,
+    Team,
     Workflow,
     WorkflowDraftAccess,
     WorkflowRun,
@@ -62,8 +63,43 @@ class WorkflowRepository(Protocol):
         draft_access: WorkflowDraftAccess,
         actor: str,
         workspace_id: str | None = None,
+        team_id: str | None = None,
     ) -> Workflow:
-        """Persist and return a new workflow definition."""
+        """Persist and return a new workflow definition.
+
+        When *team_id* is provided the workflow is grouped under that team and
+        handle-uniqueness is scoped to ``(workspace_id, team_id, handle)``.
+        """
+
+    # -- Teams --------------------------------------------------------------
+
+    async def list_teams(self, *, workspace_id: str) -> list[Team]:
+        """Return teams in the workspace ordered with the default team first."""
+
+    async def get_team(self, team_id: UUID, *, workspace_id: str) -> Team:
+        """Return a single team scoped to the workspace."""
+
+    async def get_team_by_slug(self, slug: str, *, workspace_id: str) -> Team:
+        """Return a team by slug scoped to the workspace."""
+
+    async def create_team(
+        self,
+        *,
+        workspace_id: str,
+        name: str,
+        slug: str,
+        is_default: bool = False,
+    ) -> Team:
+        """Persist and return a new team; raises on slug conflict."""
+
+    async def ensure_default_team(
+        self,
+        *,
+        workspace_id: str,
+        name: str,
+        slug: str,
+    ) -> Team:
+        """Return the workspace's default team, creating it if absent."""
 
     async def get_workflow(
         self,
@@ -86,11 +122,15 @@ class WorkflowRepository(Protocol):
         *,
         include_archived: bool = True,
         workspace_id: str | None = None,
+        team_id: str | None = None,
     ) -> UUID:
         """Resolve a user-facing workflow ref to the canonical UUID.
 
         When *workspace_id* is provided resolution is limited to that workspace's
-        workflows.
+        workflows. When *team_id* is provided resolution is further limited to
+        that team (used by onboarding to decide create-vs-version). When
+        *team_id* is omitted and a bare handle exists in multiple teams, the
+        default team's workflow wins.
         """
 
     async def update_workflow(

--- a/apps/backend/src/orcheo_backend/app/repository/protocol.py
+++ b/apps/backend/src/orcheo_backend/app/repository/protocol.py
@@ -101,6 +101,9 @@ class WorkflowRepository(Protocol):
     ) -> Team:
         """Return the workspace's default team, creating it if absent."""
 
+    async def delete_team(self, team_id: UUID, *, workspace_id: str) -> None:
+        """Delete a team; raises TeamNotEmptyError if the team has colleagues."""
+
     async def get_workflow(
         self,
         workflow_id: UUID,

--- a/apps/backend/src/orcheo_backend/app/repository_postgres/__init__.py
+++ b/apps/backend/src/orcheo_backend/app/repository_postgres/__init__.py
@@ -5,6 +5,7 @@ from orcheo.vault.oauth import OAuthCredentialService
 from orcheo_backend.app.repository_postgres._listeners import ListenerRepositoryMixin
 from orcheo_backend.app.repository_postgres._retry import RetryPolicyMixin
 from orcheo_backend.app.repository_postgres._runs import WorkflowRunMixin
+from orcheo_backend.app.repository_postgres._teams import TeamRepositoryMixin
 from orcheo_backend.app.repository_postgres._triggers import TriggerRepositoryMixin
 from orcheo_backend.app.repository_postgres._versions import WorkflowVersionMixin
 from orcheo_backend.app.repository_postgres._workflows import WorkflowRepositoryMixin
@@ -16,6 +17,7 @@ class PostgresWorkflowRepository(
     RetryPolicyMixin,
     WorkflowRunMixin,
     WorkflowVersionMixin,
+    TeamRepositoryMixin,
     WorkflowRepositoryMixin,
 ):
     """PostgreSQL-backed workflow repository for production deployments."""

--- a/apps/backend/src/orcheo_backend/app/repository_postgres/_base.py
+++ b/apps/backend/src/orcheo_backend/app/repository_postgres/_base.py
@@ -50,8 +50,21 @@ CREATE TABLE IF NOT EXISTS workflows (
     payload JSONB NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL,
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
-    workspace_id TEXT
+    workspace_id TEXT,
+    team_id TEXT
 );
+
+CREATE TABLE IF NOT EXISTS teams (
+    id TEXT PRIMARY KEY,
+    workspace_id TEXT NOT NULL,
+    slug TEXT NOT NULL,
+    name TEXT NOT NULL,
+    is_default BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    UNIQUE (workspace_id, slug)
+);
+CREATE INDEX IF NOT EXISTS idx_teams_workspace ON teams(workspace_id);
 
 CREATE TABLE IF NOT EXISTS workflow_versions (
     id TEXT PRIMARY KEY,
@@ -276,6 +289,10 @@ class PostgresRepositoryBase:
                     stmt = raw_stmt.strip()
                     if stmt:
                         await conn.execute(stmt)
+                # Backfill the team_id column on pre-existing deployments.
+                await conn.execute(
+                    "ALTER TABLE workflows ADD COLUMN IF NOT EXISTS team_id TEXT"
+                )
                 await conn.execute(
                     "CREATE INDEX IF NOT EXISTS idx_workflows_handle "
                     "ON workflows(handle)"
@@ -288,10 +305,15 @@ class PostgresRepositoryBase:
                     "   AND is_archived = FALSE"
                     "   AND handle IS NOT NULL"
                 )
+                # Handle uniqueness is scoped per team so the same colleague can
+                # be onboarded into more than one team within a workspace.
+                await conn.execute(
+                    "DROP INDEX IF EXISTS idx_workflows_active_handle_workspace"
+                )
                 await conn.execute(
                     "CREATE UNIQUE INDEX IF NOT EXISTS "
-                    "idx_workflows_active_handle_workspace"
-                    " ON workflows(workspace_id, handle)"
+                    "idx_workflows_active_handle_team"
+                    " ON workflows(workspace_id, COALESCE(team_id, ''), handle)"
                     " WHERE workspace_id IS NOT NULL"
                     "   AND is_archived = FALSE"
                     "   AND handle IS NOT NULL"
@@ -299,6 +321,10 @@ class PostgresRepositoryBase:
                 await conn.execute(
                     "CREATE INDEX IF NOT EXISTS idx_workflows_workspace_id "
                     "ON workflows(workspace_id)"
+                )
+                await conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_workflows_team_id "
+                    "ON workflows(team_id)"
                 )
                 await conn.execute(
                     "CREATE INDEX IF NOT EXISTS idx_runs_workspace_id "

--- a/apps/backend/src/orcheo_backend/app/repository_postgres/_base.py
+++ b/apps/backend/src/orcheo_backend/app/repository_postgres/_base.py
@@ -289,10 +289,6 @@ class PostgresRepositoryBase:
                     stmt = raw_stmt.strip()
                     if stmt:
                         await conn.execute(stmt)
-                # Backfill the team_id column on pre-existing deployments.
-                await conn.execute(
-                    "ALTER TABLE workflows ADD COLUMN IF NOT EXISTS team_id TEXT"
-                )
                 await conn.execute(
                     "CREATE INDEX IF NOT EXISTS idx_workflows_handle "
                     "ON workflows(handle)"
@@ -304,11 +300,6 @@ class PostgresRepositoryBase:
                     " WHERE workspace_id IS NULL"
                     "   AND is_archived = FALSE"
                     "   AND handle IS NOT NULL"
-                )
-                # Handle uniqueness is scoped per team so the same colleague can
-                # be onboarded into more than one team within a workspace.
-                await conn.execute(
-                    "DROP INDEX IF EXISTS idx_workflows_active_handle_workspace"
                 )
                 await conn.execute(
                     "CREATE UNIQUE INDEX IF NOT EXISTS "

--- a/apps/backend/src/orcheo_backend/app/repository_postgres/_persistence.py
+++ b/apps/backend/src/orcheo_backend/app/repository_postgres/_persistence.py
@@ -24,9 +24,16 @@ class PostgresPersistenceMixin(PostgresRepositoryBase):
 
     @staticmethod
     def _deserialize_workflow(
-        payload: dict[str, Any] | str, *, workspace_id: str | None = None
+        payload: dict[str, Any] | str,
+        *,
+        workspace_id: str | None = None,
+        team_id: str | None = None,
     ) -> Workflow:
-        """Return a Workflow instance from serialized JSON."""
+        """Return a Workflow instance from serialized JSON.
+
+        The ``team_id`` column is authoritative (it is what the backfill writes),
+        so it overrides whatever is embedded in the payload when provided.
+        """
         data: dict[str, Any]
         if isinstance(payload, str):
             data = json.loads(payload)
@@ -34,6 +41,8 @@ class PostgresPersistenceMixin(PostgresRepositoryBase):
             data = payload
         if workspace_id is not None:
             data["workspace_id"] = workspace_id
+        if team_id is not None:
+            data["team_id"] = team_id
         return Workflow.model_validate(data)
 
     @staticmethod
@@ -53,7 +62,7 @@ class PostgresPersistenceMixin(PostgresRepositoryBase):
     async def _get_workflow_locked(self, workflow_id: UUID) -> Workflow:
         async with self._connection() as conn:
             cursor = await conn.execute(
-                "SELECT payload, workspace_id FROM workflows WHERE id = %s",
+                "SELECT payload, workspace_id, team_id FROM workflows WHERE id = %s",
                 (str(workflow_id),),
             )
             row = await cursor.fetchone()
@@ -63,7 +72,13 @@ class PostgresPersistenceMixin(PostgresRepositoryBase):
             workspace_id = row["workspace_id"]
         except (KeyError, IndexError, TypeError):
             workspace_id = None
-        return self._deserialize_workflow(row["payload"], workspace_id=workspace_id)
+        try:
+            team_id = row["team_id"]
+        except (KeyError, IndexError, TypeError):
+            team_id = None
+        return self._deserialize_workflow(
+            row["payload"], workspace_id=workspace_id, team_id=team_id
+        )
 
     async def _ensure_handle_available_locked(
         self,
@@ -72,8 +87,9 @@ class PostgresPersistenceMixin(PostgresRepositoryBase):
         workflow_id: UUID | None,
         is_archived: bool,
         workspace_id: str | None = None,
+        team_id: str | None = None,
     ) -> None:
-        """Ensure the provided handle can be assigned."""
+        """Ensure the provided handle can be assigned within the team scope."""
         if handle is None:
             return
 
@@ -107,8 +123,9 @@ class PostgresPersistenceMixin(PostgresRepositoryBase):
                           FROM workflows
                          WHERE handle = %s
                            AND workspace_id = %s
+                           AND COALESCE(team_id, '') = COALESCE(%s, '')
                         """,
-                    (handle, workspace_id),
+                    (handle, workspace_id, team_id),
                 )
             else:
                 cursor = await conn.execute(
@@ -117,9 +134,10 @@ class PostgresPersistenceMixin(PostgresRepositoryBase):
                           FROM workflows
                          WHERE handle = %s
                            AND workspace_id = %s
+                           AND COALESCE(team_id, '') = COALESCE(%s, '')
                            AND id != %s::uuid
                         """,
-                    (handle, workspace_id, str(workflow_id)),
+                    (handle, workspace_id, team_id, str(workflow_id)),
                 )
             rows = await cursor.fetchall()
 
@@ -128,17 +146,55 @@ class PostgresPersistenceMixin(PostgresRepositoryBase):
                 msg = f"Workflow handle '{handle}' is already in use."
                 raise WorkflowHandleConflictError(msg)
 
+    async def _resolve_workflow_ref_in_team_locked(
+        self,
+        normalized_ref: str,
+        *,
+        include_archived: bool,
+        workspace_id: str,
+        team_id: str,
+    ) -> UUID:
+        """Resolve a handle strictly within a single team (onboarding path)."""
+        async with self._connection() as conn:
+            cursor = await conn.execute(
+                """
+                SELECT id
+                  FROM workflows
+                 WHERE handle = %s
+                   AND workspace_id = %s
+                   AND COALESCE(team_id, '') = COALESCE(%s, '')
+                   AND (%s OR is_archived = FALSE)
+              ORDER BY is_archived ASC, updated_at DESC
+                 LIMIT 1
+                """,
+                (normalized_ref, workspace_id, team_id, include_archived),
+            )
+            row = await cursor.fetchone()
+        if row is not None:
+            return UUID(row["id"])
+        raise WorkflowNotFoundError(normalized_ref)
+
     async def _resolve_workflow_ref_locked(
         self,
         workflow_ref: str,
         *,
         include_archived: bool = True,
         workspace_id: str | None = None,
+        team_id: str | None = None,
     ) -> UUID:
         """Resolve a workflow ref using handle-first semantics."""
         normalized_ref = workflow_ref.strip().lower()
         if not normalized_ref:
             raise WorkflowNotFoundError("workflow ref is empty")
+
+        # Onboarding scopes resolution to one team; no global / UUID fallback.
+        if team_id is not None and workspace_id is not None:
+            return await self._resolve_workflow_ref_in_team_locked(
+                normalized_ref,
+                include_archived=include_archived,
+                workspace_id=workspace_id,
+                team_id=team_id,
+            )
 
         should_match_uuid = workflow_ref_is_uuid(normalized_ref)
         async with self._connection() as conn:
@@ -179,24 +235,28 @@ class PostgresPersistenceMixin(PostgresRepositoryBase):
                     else:
                         cursor = await conn.execute(
                             """
-                            SELECT id
-                              FROM workflows
+                            SELECT w.id
+                              FROM workflows w
+                         LEFT JOIN teams t ON t.id = w.team_id
                              WHERE (
-                                       handle = %s
-                                   AND workspace_id = %s
-                                   AND (%s OR is_archived = FALSE)
+                                       w.handle = %s
+                                   AND w.workspace_id = %s
+                                   AND (%s OR w.is_archived = FALSE)
                                    )
                                 OR (
-                                       %s AND id = %s
-                                   AND workspace_id = %s
+                                       %s AND w.id = %s
+                                   AND w.workspace_id = %s
                                    )
                           ORDER BY
                                 CASE
-                                    WHEN handle = %s AND is_archived = FALSE THEN 0
-                                    WHEN handle = %s AND is_archived = TRUE THEN 1
+                                    WHEN w.handle = %s
+                                     AND w.is_archived = FALSE THEN 0
+                                    WHEN w.handle = %s
+                                     AND w.is_archived = TRUE THEN 1
                                     ELSE 2
                                 END,
-                                updated_at DESC
+                                COALESCE(t.is_default, FALSE) DESC,
+                                w.updated_at DESC
                              LIMIT 1
                             """,
                             (

--- a/apps/backend/src/orcheo_backend/app/repository_postgres/_persistence.py
+++ b/apps/backend/src/orcheo_backend/app/repository_postgres/_persistence.py
@@ -29,11 +29,7 @@ class PostgresPersistenceMixin(PostgresRepositoryBase):
         workspace_id: str | None = None,
         team_id: str | None = None,
     ) -> Workflow:
-        """Return a Workflow instance from serialized JSON.
-
-        The ``team_id`` column is authoritative (it is what the backfill writes),
-        so it overrides whatever is embedded in the payload when provided.
-        """
+        """Return a Workflow instance from serialized JSON."""
         data: dict[str, Any]
         if isinstance(payload, str):
             data = json.loads(payload)

--- a/apps/backend/src/orcheo_backend/app/repository_postgres/_teams.py
+++ b/apps/backend/src/orcheo_backend/app/repository_postgres/_teams.py
@@ -203,8 +203,14 @@ class TeamRepositoryMixin(PostgresPersistenceMixin):
                 team_name = row["name"]
 
                 cursor = await conn.execute(
-                    "SELECT COUNT(*) AS cnt FROM workflows WHERE team_id = %s",
-                    (str(team_id),),
+                    """
+                    SELECT COUNT(*) AS cnt
+                      FROM workflows
+                     WHERE team_id = %s
+                       AND workspace_id = %s
+                       AND is_archived = FALSE
+                    """,
+                    (str(team_id), workspace_id),
                 )
                 count_row = await cursor.fetchone()
                 if count_row and int(count_row["cnt"]) > 0:

--- a/apps/backend/src/orcheo_backend/app/repository_postgres/_teams.py
+++ b/apps/backend/src/orcheo_backend/app/repository_postgres/_teams.py
@@ -1,0 +1,191 @@
+"""Team grouping operations for the PostgreSQL repository."""
+
+from __future__ import annotations
+from typing import Any
+from uuid import UUID
+from orcheo.models import Team, normalize_team_slug
+from orcheo_backend.app.repository.errors import (
+    TeamNotFoundError,
+    TeamSlugConflictError,
+)
+from orcheo_backend.app.repository_postgres._persistence import PostgresPersistenceMixin
+
+
+class TeamRepositoryMixin(PostgresPersistenceMixin):
+    """Helpers for managing teams within a workspace."""
+
+    @staticmethod
+    def _row_to_team(row: dict[str, Any]) -> Team:
+        return Team(
+            id=UUID(row["id"]),
+            workspace_id=row["workspace_id"],
+            slug=row["slug"],
+            name=row["name"],
+            is_default=bool(row["is_default"]),
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+        )
+
+    async def list_teams(self, *, workspace_id: str) -> list[Team]:
+        await self._ensure_initialized()
+        async with self._lock:
+            async with self._connection() as conn:
+                cursor = await conn.execute(
+                    """
+                    SELECT id, workspace_id, slug, name, is_default,
+                           created_at, updated_at
+                      FROM teams
+                     WHERE workspace_id = %s
+                  ORDER BY is_default DESC, slug ASC
+                    """,
+                    (workspace_id,),
+                )
+                rows = await cursor.fetchall()
+            return [self._row_to_team(row) for row in rows]
+
+    async def get_team(self, team_id: UUID, *, workspace_id: str) -> Team:
+        await self._ensure_initialized()
+        async with self._lock:
+            async with self._connection() as conn:
+                cursor = await conn.execute(
+                    """
+                    SELECT id, workspace_id, slug, name, is_default,
+                           created_at, updated_at
+                      FROM teams
+                     WHERE id = %s AND workspace_id = %s
+                    """,
+                    (str(team_id), workspace_id),
+                )
+                row = await cursor.fetchone()
+        if row is None:
+            raise TeamNotFoundError(str(team_id))
+        return self._row_to_team(row)
+
+    async def get_team_by_slug(self, slug: str, *, workspace_id: str) -> Team:
+        await self._ensure_initialized()
+        normalized = normalize_team_slug(slug)
+        async with self._lock:
+            async with self._connection() as conn:
+                cursor = await conn.execute(
+                    """
+                    SELECT id, workspace_id, slug, name, is_default,
+                           created_at, updated_at
+                      FROM teams
+                     WHERE slug = %s AND workspace_id = %s
+                    """,
+                    (normalized, workspace_id),
+                )
+                row = await cursor.fetchone()
+        if row is None:
+            raise TeamNotFoundError(normalized)
+        return self._row_to_team(row)
+
+    async def _insert_team_locked(
+        self,
+        conn: Any,
+        *,
+        workspace_id: str,
+        name: str,
+        slug: str,
+        is_default: bool,
+    ) -> Team:
+        team = Team(
+            workspace_id=workspace_id,
+            name=name,
+            slug=slug,
+            is_default=is_default,
+        )
+        try:
+            await conn.execute(
+                """
+                INSERT INTO teams (
+                    id, workspace_id, slug, name, is_default,
+                    created_at, updated_at
+                )
+                VALUES (%s, %s, %s, %s, %s, %s, %s)
+                """,
+                (
+                    str(team.id),
+                    team.workspace_id,
+                    team.slug,
+                    team.name,
+                    team.is_default,
+                    team.created_at,
+                    team.updated_at,
+                ),
+            )
+        except Exception as exc:  # noqa: BLE001 - normalize unique-violation
+            message = str(exc).lower()
+            if "teams_workspace_id_slug_key" in message or "unique" in message:
+                raise TeamSlugConflictError(
+                    f"Team slug already exists: {team.slug}"
+                ) from exc
+            raise
+        return team
+
+    async def create_team(
+        self,
+        *,
+        workspace_id: str,
+        name: str,
+        slug: str,
+        is_default: bool = False,
+    ) -> Team:
+        await self._ensure_initialized()
+        normalized = normalize_team_slug(slug)
+        async with self._lock:
+            async with self._connection() as conn:
+                return await self._insert_team_locked(
+                    conn,
+                    workspace_id=workspace_id,
+                    name=name,
+                    slug=normalized,
+                    is_default=is_default,
+                )
+
+    async def ensure_default_team(
+        self,
+        *,
+        workspace_id: str,
+        name: str,
+        slug: str,
+    ) -> Team:
+        await self._ensure_initialized()
+        normalized = normalize_team_slug(slug)
+        async with self._lock:
+            async with self._connection() as conn:
+                cursor = await conn.execute(
+                    """
+                    SELECT id, workspace_id, slug, name, is_default,
+                           created_at, updated_at
+                      FROM teams
+                     WHERE workspace_id = %s AND is_default = TRUE
+                     LIMIT 1
+                    """,
+                    (workspace_id,),
+                )
+                row = await cursor.fetchone()
+                if row is not None:
+                    return self._row_to_team(row)
+
+                team = await self._insert_team_locked(
+                    conn,
+                    workspace_id=workspace_id,
+                    name=name,
+                    slug=normalized,
+                    is_default=True,
+                )
+                # Backfill pre-existing colleagues into the default team so they
+                # surface under it in the gallery.
+                await conn.execute(
+                    """
+                    UPDATE workflows
+                       SET team_id = %s
+                     WHERE workspace_id = %s AND team_id IS NULL
+                    """,
+                    (str(team.id), workspace_id),
+                )
+            return team
+
+
+__all__ = ["TeamRepositoryMixin"]

--- a/apps/backend/src/orcheo_backend/app/repository_postgres/_teams.py
+++ b/apps/backend/src/orcheo_backend/app/repository_postgres/_teams.py
@@ -5,6 +5,7 @@ from typing import Any
 from uuid import UUID
 from orcheo.models import Team, normalize_team_slug
 from orcheo_backend.app.repository.errors import (
+    TeamNotEmptyError,
     TeamNotFoundError,
     TeamSlugConflictError,
 )
@@ -186,6 +187,34 @@ class TeamRepositoryMixin(PostgresPersistenceMixin):
                     (str(team.id), workspace_id),
                 )
             return team
+
+    async def delete_team(self, team_id: UUID, *, workspace_id: str) -> None:
+        """Delete a team; raises TeamNotEmptyError if the team has colleagues."""
+        await self._ensure_initialized()
+        async with self._lock:
+            async with self._connection() as conn:
+                cursor = await conn.execute(
+                    "SELECT name FROM teams WHERE id = %s AND workspace_id = %s",
+                    (str(team_id), workspace_id),
+                )
+                row = await cursor.fetchone()
+                if row is None:
+                    raise TeamNotFoundError(str(team_id))
+                team_name = row["name"]
+
+                cursor = await conn.execute(
+                    "SELECT COUNT(*) AS cnt FROM workflows WHERE team_id = %s",
+                    (str(team_id),),
+                )
+                count_row = await cursor.fetchone()
+                if count_row and int(count_row["cnt"]) > 0:
+                    msg = f"Team '{team_name}' still has colleagues."
+                    raise TeamNotEmptyError(msg)
+
+                await conn.execute(
+                    "DELETE FROM teams WHERE id = %s AND workspace_id = %s",
+                    (str(team_id), workspace_id),
+                )
 
 
 __all__ = ["TeamRepositoryMixin"]

--- a/apps/backend/src/orcheo_backend/app/repository_postgres/_teams.py
+++ b/apps/backend/src/orcheo_backend/app/repository_postgres/_teams.py
@@ -176,16 +176,6 @@ class TeamRepositoryMixin(PostgresPersistenceMixin):
                     slug=normalized,
                     is_default=True,
                 )
-                # Backfill pre-existing colleagues into the default team so they
-                # surface under it in the gallery.
-                await conn.execute(
-                    """
-                    UPDATE workflows
-                       SET team_id = %s
-                     WHERE workspace_id = %s AND team_id IS NULL
-                    """,
-                    (str(team.id), workspace_id),
-                )
             return team
 
     async def delete_team(self, team_id: UUID, *, workspace_id: str) -> None:

--- a/apps/backend/src/orcheo_backend/app/repository_postgres/_workflows.py
+++ b/apps/backend/src/orcheo_backend/app/repository_postgres/_workflows.py
@@ -63,18 +63,23 @@ class WorkflowRepositoryMixin(PostgresPersistenceMixin):
             async with self._connection() as conn:
                 if workspace_id is not None:
                     cursor = await conn.execute(
-                        "SELECT payload FROM workflows"
+                        "SELECT payload, workspace_id, team_id FROM workflows"
                         " WHERE workspace_id = %s"
                         " ORDER BY created_at ASC",
                         (workspace_id,),
                     )
                 else:
                     cursor = await conn.execute(
-                        "SELECT payload FROM workflows ORDER BY created_at ASC"
+                        "SELECT payload, workspace_id, team_id FROM workflows"
+                        " ORDER BY created_at ASC"
                     )
                 rows = await cursor.fetchall()
             workflows = [
-                self._deserialize_workflow(row["payload"]).model_copy(deep=True)
+                self._deserialize_workflow(
+                    row["payload"],
+                    workspace_id=row.get("workspace_id"),
+                    team_id=row.get("team_id"),
+                ).model_copy(deep=True)
                 for row in rows
             ]
             if include_archived:
@@ -92,6 +97,7 @@ class WorkflowRepositoryMixin(PostgresPersistenceMixin):
         draft_access: WorkflowDraftAccess,
         actor: str,
         workspace_id: str | None = None,
+        team_id: str | None = None,
     ) -> Workflow:
         await self._ensure_initialized()
         normalized_handle = normalize_workflow_handle(handle)
@@ -101,11 +107,13 @@ class WorkflowRepositoryMixin(PostgresPersistenceMixin):
                 workflow_id=None,
                 is_archived=False,
                 workspace_id=workspace_id,
+                team_id=team_id,
             )
             workflow = Workflow(
                 name=name,
                 handle=normalized_handle,
                 workspace_id=workspace_id,
+                team_id=team_id,
                 slug=slug or "",
                 description=description,
                 tags=list(tags or []),
@@ -122,9 +130,10 @@ class WorkflowRepositoryMixin(PostgresPersistenceMixin):
                         payload,
                         created_at,
                         updated_at,
-                        workspace_id
+                        workspace_id,
+                        team_id
                     )
-                    VALUES (%s, %s, %s, %s, %s, %s, %s)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
                     """,
                     (
                         str(workflow.id),
@@ -134,6 +143,7 @@ class WorkflowRepositoryMixin(PostgresPersistenceMixin):
                         workflow.created_at,
                         workflow.updated_at,
                         workspace_id,
+                        team_id,
                     ),
                 )
             return workflow.model_copy(deep=True)
@@ -182,6 +192,7 @@ class WorkflowRepositoryMixin(PostgresPersistenceMixin):
         *,
         include_archived: bool = True,
         workspace_id: str | None = None,
+        team_id: str | None = None,
     ) -> UUID:
         await self._ensure_initialized()
         async with self._lock:
@@ -189,6 +200,7 @@ class WorkflowRepositoryMixin(PostgresPersistenceMixin):
                 workflow_ref,
                 include_archived=include_archived,
                 workspace_id=workspace_id,
+                team_id=team_id,
             )
             if workspace_id is not None:
                 row_tid = await self._get_workflow_workspace_id_locked(workflow_id)
@@ -233,6 +245,7 @@ class WorkflowRepositoryMixin(PostgresPersistenceMixin):
                     workflow_id=workflow_id,
                     is_archived=next_is_archived,
                     workspace_id=workflow.workspace_id,
+                    team_id=workflow.team_id,
                 )
                 metadata["handle"] = {
                     "from": workflow.handle,

--- a/apps/backend/src/orcheo_backend/app/routers/__init__.py
+++ b/apps/backend/src/orcheo_backend/app/routers/__init__.py
@@ -14,6 +14,7 @@ __all__ = [
     "listeners",
     "nodes",
     "runs",
+    "teams",
     "triggers",
     "websocket",
 ]

--- a/apps/backend/src/orcheo_backend/app/routers/candidates.py
+++ b/apps/backend/src/orcheo_backend/app/routers/candidates.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 import logging
 from typing import Any
+from uuid import UUID
 from fastapi import APIRouter, HTTPException, status
 from pydantic import BaseModel, ValidationError
 from orcheo.graph.ingestion import ScriptIngestionError, ingest_langgraph_script
@@ -24,7 +25,9 @@ from orcheo_backend.app.repository import (
     WorkflowHandleConflictError,
     WorkflowNotFoundError,
 )
+from orcheo_backend.app.repository.errors import TeamNotFoundError
 from orcheo_backend.app.schemas.candidates import CandidateItem, CandidatePublicItem
+from orcheo_backend.app.teams_service import ensure_default_team
 from orcheo_backend.app.workspace import WorkspaceContextDep
 from orcheo_backend.app.workspace_governance import ensure_workspace_workflow_quota
 
@@ -37,6 +40,7 @@ class CandidateOnboardRequest(BaseModel):
     """Request body for server-side candidate onboarding."""
 
     id: str
+    team_id: str | None = None
 
 
 def _candidates_502(exc: Exception) -> HTTPException:
@@ -254,13 +258,30 @@ async def onboard_candidate(
 
     workspace_id = str(workspace.workspace_id)
 
-    # Resolve existing workflow by candidate handle, or create a new one.
+    # Resolve the target team. When unspecified, onboard into the default team.
+    default_team = await ensure_default_team(repository, workspace)
+    target_team_id = request.team_id or str(default_team.id)
+    if request.team_id is not None:
+        try:
+            await repository.get_team(UUID(request.team_id), workspace_id=workspace_id)
+        except (TeamNotFoundError, ValueError) as exc:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail={
+                    "message": f"Team '{request.team_id}' not found.",
+                    "code": "team.not_found",
+                },
+            ) from exc
+
+    # If the candidate already lives in the target team, append a version;
+    # otherwise onboard it as a new colleague within that team.
     workflow: Workflow
     try:
         workflow_id = await repository.resolve_workflow_ref(
             candidate.handle,
             include_archived=False,
             workspace_id=workspace_id,
+            team_id=target_team_id,
         )
         workflow = await repository.get_workflow(workflow_id, workspace_id=workspace_id)
     except WorkflowNotFoundError:
@@ -278,6 +299,7 @@ async def onboard_candidate(
                 draft_access=WorkflowDraftAccess.WORKSPACE,
                 actor="onboard",
                 workspace_id=workspace_id,
+                team_id=target_team_id,
             )
         except WorkflowHandleConflictError as exc:
             raise HTTPException(

--- a/apps/backend/src/orcheo_backend/app/routers/teams.py
+++ b/apps/backend/src/orcheo_backend/app/routers/teams.py
@@ -1,0 +1,61 @@
+"""Endpoints for managing teams (colleague groupings) within a workspace."""
+
+from __future__ import annotations
+import logging
+from fastapi import APIRouter, HTTPException, status
+from orcheo_backend.app.dependencies import RepositoryDep
+from orcheo_backend.app.repository.errors import TeamSlugConflictError
+from orcheo_backend.app.schemas.teams import TeamCreateRequest, TeamItem
+from orcheo_backend.app.teams_service import ensure_default_team
+from orcheo_backend.app.workspace import WorkspaceContextDep
+
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+@router.get("/teams", response_model=list[TeamItem])
+async def list_teams(
+    repository: RepositoryDep,
+    workspace: WorkspaceContextDep,
+) -> list[TeamItem]:
+    """Return the teams in the active workspace, default team first.
+
+    The default team is provisioned lazily so a fresh workspace always has at
+    least one team to group colleagues under.
+    """
+    await ensure_default_team(repository, workspace)
+    teams = await repository.list_teams(workspace_id=str(workspace.workspace_id))
+    return [TeamItem.from_team(team) for team in teams]
+
+
+@router.post(
+    "/teams",
+    response_model=TeamItem,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_team(
+    request: TeamCreateRequest,
+    repository: RepositoryDep,
+    workspace: WorkspaceContextDep,
+) -> TeamItem:
+    """Create a new team within the active workspace."""
+    # Guarantee the default team exists before adding sibling teams.
+    await ensure_default_team(repository, workspace)
+    try:
+        team = await repository.create_team(
+            workspace_id=str(workspace.workspace_id),
+            name=request.name,
+            slug=request.slug,
+        )
+    except TeamSlugConflictError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={"message": str(exc), "code": "team.slug.conflict"},
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"message": str(exc), "code": "team.invalid"},
+        ) from exc
+    return TeamItem.from_team(team)

--- a/apps/backend/src/orcheo_backend/app/routers/teams.py
+++ b/apps/backend/src/orcheo_backend/app/routers/teams.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 import logging
+from uuid import UUID
 from fastapi import APIRouter, HTTPException, status
 from orcheo_backend.app.dependencies import RepositoryDep
-from orcheo_backend.app.repository.errors import TeamSlugConflictError
+from orcheo_backend.app.repository.errors import (
+    TeamNotEmptyError,
+    TeamNotFoundError,
+    TeamSlugConflictError,
+)
 from orcheo_backend.app.schemas.teams import TeamCreateRequest, TeamItem
 from orcheo_backend.app.teams_service import ensure_default_team
 from orcheo_backend.app.workspace import WorkspaceContextDep
@@ -59,3 +64,28 @@ async def create_team(
             detail={"message": str(exc), "code": "team.invalid"},
         ) from exc
     return TeamItem.from_team(team)
+
+
+@router.delete("/teams/{team_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_team(
+    team_id: UUID,
+    repository: RepositoryDep,
+    workspace: WorkspaceContextDep,
+) -> None:
+    """Delete a team.
+
+    Returns 409 when the team still contains colleagues so that no data is
+    silently orphaned.
+    """
+    try:
+        await repository.delete_team(team_id, workspace_id=str(workspace.workspace_id))
+    except TeamNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"message": str(exc), "code": "team.not_found"},
+        ) from exc
+    except TeamNotEmptyError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={"message": str(exc), "code": "team.not_empty"},
+        ) from exc

--- a/apps/backend/src/orcheo_backend/app/routers/workflows.py
+++ b/apps/backend/src/orcheo_backend/app/routers/workflows.py
@@ -106,19 +106,59 @@ def _resolve_studio_url() -> str | None:
     return str(value).rstrip("/")
 
 
-def _apply_share_url(workflow: Workflow, public_base_url: str | None) -> Workflow:
+def _apply_share_url(
+    workflow: Workflow,
+    public_base_url: str | None,
+    *,
+    team_slug: str | None = None,
+) -> Workflow:
     if public_base_url and workflow.is_public:
-        workflow.share_url = f"{public_base_url}/chat/{workflow.id}"
+        ref = workflow.handle or str(workflow.id)
+        if team_slug:
+            workflow.share_url = f"{public_base_url}/chat/team/{team_slug}/{ref}"
+        else:
+            workflow.share_url = f"{public_base_url}/chat/{ref}"
     else:
         workflow.share_url = None
     return workflow
 
 
+async def _resolve_team_slug(repository: Any, workflow: Workflow) -> str | None:
+    """Look up the slug for the team a workflow belongs to, or None."""
+    if not workflow.team_id:
+        return None
+    try:
+        team = await repository.get_team(
+            UUID(workflow.team_id), workspace_id=workflow.workspace_id
+        )
+        return team.slug
+    except Exception:  # noqa: BLE001
+        return None
+
+
+async def _apply_share_url_async(
+    workflow: Workflow,
+    repository: Any,
+    public_base_url: str | None,
+) -> Workflow:
+    """Resolve team slug then apply share URL — use for single-workflow responses."""
+    team_slug = await _resolve_team_slug(repository, workflow)
+    return _apply_share_url(workflow, public_base_url, team_slug=team_slug)
+
+
 def _apply_share_urls(
-    workflows: list[Workflow], public_base_url: str | None
+    workflows: list[Workflow],
+    public_base_url: str | None,
+    *,
+    teams_by_id: dict[str, str] | None = None,
 ) -> list[Workflow]:
     for workflow in workflows:
-        _apply_share_url(workflow, public_base_url)
+        team_slug = (
+            teams_by_id.get(workflow.team_id)
+            if teams_by_id and workflow.team_id
+            else None
+        )
+        _apply_share_url(workflow, public_base_url, team_slug=team_slug)
     return workflows
 
 
@@ -181,9 +221,12 @@ def _resolve_ingest_configurable_schema(
 
 
 def _serialize_public_workflow(
-    workflow: Workflow, public_base_url: str | None
+    workflow: Workflow,
+    public_base_url: str | None,
+    *,
+    team_slug: str | None = None,
 ) -> PublicWorkflow:
-    workflow = _apply_share_url(workflow, public_base_url)
+    workflow = _apply_share_url(workflow, public_base_url, team_slug=team_slug)
     return PublicWorkflow(
         id=workflow.id,
         handle=workflow.handle,
@@ -429,7 +472,10 @@ async def get_public_workflow(
                 "code": "workflow.not_public",
             },
         )
-    return _serialize_public_workflow(workflow, _resolve_studio_url())
+    team_slug = await _resolve_team_slug(repository, workflow)
+    return _serialize_public_workflow(
+        workflow, _resolve_studio_url(), team_slug=team_slug
+    )
 
 
 @router.get("/workflows", response_model=list[WorkflowListItem])
@@ -459,10 +505,14 @@ async def list_workflows(
     ):
         workflows.append(managed_workflow)
     public_base_url = _resolve_studio_url()
+    teams = await repository.list_teams(workspace_id=str(workspace.workspace_id))
+    teams_by_id = {str(team.id): team.slug for team in teams}
     return await asyncio.gather(
         *[
             _build_workflow_list_item(repository, workflow)
-            for workflow in _apply_share_urls(workflows, public_base_url)
+            for workflow in _apply_share_urls(
+                workflows, public_base_url, teams_by_id=teams_by_id
+            )
         ]
     )
 
@@ -500,7 +550,7 @@ async def create_workflow(
         workflow = await repository.create_workflow(
             **create_kwargs,
         )
-        return _apply_share_url(workflow, _resolve_studio_url())
+        return await _apply_share_url_async(workflow, repository, _resolve_studio_url())
     except WorkflowHandleConflictError as exc:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -523,7 +573,7 @@ async def get_workflow(
         workflow_ref,
         workspace_id=tid,
     )
-    return _apply_share_url(workflow, _resolve_studio_url())
+    return await _apply_share_url_async(workflow, repository, _resolve_studio_url())
 
 
 @router.get("/workflows/{workflow_ref}/workflow", response_model=WorkflowPagePayload)
@@ -541,7 +591,9 @@ async def get_workflow_page(
     )
     versions = await repository.list_versions(workflow.id)
     return WorkflowPagePayload(
-        workflow=_apply_share_url(workflow, _resolve_studio_url()),
+        workflow=await _apply_share_url_async(
+            workflow, repository, _resolve_studio_url()
+        ),
         versions=[_to_workflow_page_version_summary(version) for version in versions],
     )
 
@@ -589,7 +641,7 @@ async def update_workflow(
             workflow.id,
             **update_kwargs,
         )
-        return _apply_share_url(workflow, _resolve_studio_url())
+        return await _apply_share_url_async(workflow, repository, _resolve_studio_url())
     except WorkflowNotFoundError as exc:
         raise_not_found("Workflow not found", exc)
     except WorkflowHandleConflictError as exc:
@@ -617,7 +669,7 @@ async def archive_workflow(
         workspace_id=tid,
     )
     workflow = await repository.archive_workflow(workflow.id, actor=resolved_actor)
-    return _apply_share_url(workflow, _resolve_studio_url())
+    return await _apply_share_url_async(workflow, repository, _resolve_studio_url())
 
 
 @router.post(
@@ -881,7 +933,9 @@ async def publish_workflow(
             require_login=request.require_login,
             actor=actor,
         )
-        workflow = _apply_share_url(workflow, _resolve_studio_url())
+        workflow = await _apply_share_url_async(
+            workflow, repository, _resolve_studio_url()
+        )
     except WorkflowNotFoundError as exc:
         raise_not_found("Workflow not found", exc)
     except WorkflowPublishStateError as exc:
@@ -927,7 +981,9 @@ async def revoke_workflow_publish(
 
     try:
         workflow = await repository.revoke_publish(workflow.id, actor=actor)
-        workflow = _apply_share_url(workflow, _resolve_studio_url())
+        workflow = await _apply_share_url_async(
+            workflow, repository, _resolve_studio_url()
+        )
     except WorkflowNotFoundError as exc:
         raise_not_found("Workflow not found", exc)
     except WorkflowPublishStateError as exc:

--- a/apps/backend/src/orcheo_backend/app/routers/workflows.py
+++ b/apps/backend/src/orcheo_backend/app/routers/workflows.py
@@ -19,11 +19,11 @@ from orcheo.runtime.configurable_schema import (
     split_configurable,
 )
 from orcheo.runtime.runnable_config import RunnableConfigModel
-from orcheo.workspace import WorkspaceNotFoundError
 from orcheo.workflow.mermaid import (
     render_mermaid_from_graph_payload,
     render_mermaid_from_graph_payload_full_env,
 )
+from orcheo.workspace import WorkspaceNotFoundError
 from orcheo_backend.app.authentication import (
     AuthorizationError,
     AuthorizationPolicy,
@@ -65,7 +65,11 @@ from orcheo_backend.app.schemas.workflows import (
     WorkflowVersionIngestRequest,
     WorkflowVersionRunnableConfigUpdateRequest,
 )
-from orcheo_backend.app.workspace import WorkspaceContextDep, WorkspaceServiceDep, get_workspace_repository
+from orcheo_backend.app.workspace import (
+    WorkspaceContextDep,
+    WorkspaceServiceDep,
+    get_workspace_repository,
+)
 from orcheo_backend.app.workspace_governance import ensure_workspace_workflow_quota
 from orcheo_sdk.cli.workflow.frontmatter import parse_workflow_frontmatter
 
@@ -508,32 +512,34 @@ async def get_public_workflow(
     team_slug: str | None = Query(None),
 ) -> PublicWorkflow:
     """Fetch public workflow metadata without authentication.
-    
+
     When workspace_slug and/or team_slug are provided, workflow resolution
     will be scoped to the specified workspace and team context.
     """
     # Resolve workspace and team IDs from slugs if provided
     resolved_workspace_id: str | None = None
     resolved_team_id: str | None = None
-    
+
     if workspace_slug:
         resolved_workspace_id = _resolve_workspace_id_from_slug(
             workspace_service, workspace_slug
         )
         if not resolved_workspace_id:
-            raise_not_found("Workspace not found", WorkspaceNotFoundError(workspace_slug))
-            
+            raise_not_found(
+                "Workspace not found", WorkspaceNotFoundError(workspace_slug)
+            )
+
         if team_slug:
             resolved_team_id = await _resolve_team_id_from_slug(
                 repository, team_slug, resolved_workspace_id
             )
             if not resolved_team_id:
                 raise_not_found("Team not found", TeamNotFoundError(team_slug))
-    
+
     # Resolve workflow with team and workspace context
     workflow_id = await _resolve_workflow_uuid(
-        repository, 
-        workflow_ref, 
+        repository,
+        workflow_ref,
         workspace_id=resolved_workspace_id,
         team_id=resolved_team_id,
     )

--- a/apps/backend/src/orcheo_backend/app/routers/workflows.py
+++ b/apps/backend/src/orcheo_backend/app/routers/workflows.py
@@ -111,10 +111,17 @@ def _apply_share_url(
     public_base_url: str | None,
     *,
     team_slug: str | None = None,
+    workspace_slug: str | None = None,
 ) -> Workflow:
     if public_base_url and workflow.is_public:
         ref = workflow.handle or str(workflow.id)
-        if team_slug:
+        if workspace_slug and team_slug:
+            workflow.share_url = (
+                f"{public_base_url}/chat/{workspace_slug}/team/{team_slug}/{ref}"
+            )
+        elif workspace_slug:
+            workflow.share_url = f"{public_base_url}/chat/{workspace_slug}/{ref}"
+        elif team_slug:
             workflow.share_url = f"{public_base_url}/chat/team/{team_slug}/{ref}"
         else:
             workflow.share_url = f"{public_base_url}/chat/{ref}"
@@ -140,10 +147,14 @@ async def _apply_share_url_async(
     workflow: Workflow,
     repository: Any,
     public_base_url: str | None,
+    *,
+    workspace_slug: str | None = None,
 ) -> Workflow:
     """Resolve team slug then apply share URL — use for single-workflow responses."""
     team_slug = await _resolve_team_slug(repository, workflow)
-    return _apply_share_url(workflow, public_base_url, team_slug=team_slug)
+    return _apply_share_url(
+        workflow, public_base_url, team_slug=team_slug, workspace_slug=workspace_slug
+    )
 
 
 def _apply_share_urls(
@@ -151,6 +162,7 @@ def _apply_share_urls(
     public_base_url: str | None,
     *,
     teams_by_id: dict[str, str] | None = None,
+    workspace_slug: str | None = None,
 ) -> list[Workflow]:
     for workflow in workflows:
         team_slug = (
@@ -158,7 +170,12 @@ def _apply_share_urls(
             if teams_by_id and workflow.team_id
             else None
         )
-        _apply_share_url(workflow, public_base_url, team_slug=team_slug)
+        _apply_share_url(
+            workflow,
+            public_base_url,
+            team_slug=team_slug,
+            workspace_slug=workspace_slug,
+        )
     return workflows
 
 
@@ -225,8 +242,11 @@ def _serialize_public_workflow(
     public_base_url: str | None,
     *,
     team_slug: str | None = None,
+    workspace_slug: str | None = None,
 ) -> PublicWorkflow:
-    workflow = _apply_share_url(workflow, public_base_url, team_slug=team_slug)
+    workflow = _apply_share_url(
+        workflow, public_base_url, team_slug=team_slug, workspace_slug=workspace_slug
+    )
     return PublicWorkflow(
         id=workflow.id,
         handle=workflow.handle,
@@ -473,8 +493,18 @@ async def get_public_workflow(
             },
         )
     team_slug = await _resolve_team_slug(repository, workflow)
+    workspace_slug: str | None = None
+    if workflow.workspace_id:
+        try:
+            ws = get_workspace_repository().get_workspace(UUID(workflow.workspace_id))
+            workspace_slug = ws.slug
+        except Exception:  # noqa: BLE001
+            pass
     return _serialize_public_workflow(
-        workflow, _resolve_studio_url(), team_slug=team_slug
+        workflow,
+        _resolve_studio_url(),
+        team_slug=team_slug,
+        workspace_slug=workspace_slug,
     )
 
 
@@ -511,7 +541,10 @@ async def list_workflows(
         *[
             _build_workflow_list_item(repository, workflow)
             for workflow in _apply_share_urls(
-                workflows, public_base_url, teams_by_id=teams_by_id
+                workflows,
+                public_base_url,
+                teams_by_id=teams_by_id,
+                workspace_slug=workspace.workspace_slug,
             )
         ]
     )
@@ -550,7 +583,12 @@ async def create_workflow(
         workflow = await repository.create_workflow(
             **create_kwargs,
         )
-        return await _apply_share_url_async(workflow, repository, _resolve_studio_url())
+        return await _apply_share_url_async(
+            workflow,
+            repository,
+            _resolve_studio_url(),
+            workspace_slug=workspace.workspace_slug,
+        )
     except WorkflowHandleConflictError as exc:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -573,7 +611,12 @@ async def get_workflow(
         workflow_ref,
         workspace_id=tid,
     )
-    return await _apply_share_url_async(workflow, repository, _resolve_studio_url())
+    return await _apply_share_url_async(
+        workflow,
+        repository,
+        _resolve_studio_url(),
+        workspace_slug=workspace.workspace_slug,
+    )
 
 
 @router.get("/workflows/{workflow_ref}/workflow", response_model=WorkflowPagePayload)
@@ -592,7 +635,10 @@ async def get_workflow_page(
     versions = await repository.list_versions(workflow.id)
     return WorkflowPagePayload(
         workflow=await _apply_share_url_async(
-            workflow, repository, _resolve_studio_url()
+            workflow,
+            repository,
+            _resolve_studio_url(),
+            workspace_slug=workspace.workspace_slug,
         ),
         versions=[_to_workflow_page_version_summary(version) for version in versions],
     )
@@ -641,7 +687,12 @@ async def update_workflow(
             workflow.id,
             **update_kwargs,
         )
-        return await _apply_share_url_async(workflow, repository, _resolve_studio_url())
+        return await _apply_share_url_async(
+            workflow,
+            repository,
+            _resolve_studio_url(),
+            workspace_slug=workspace.workspace_slug,
+        )
     except WorkflowNotFoundError as exc:
         raise_not_found("Workflow not found", exc)
     except WorkflowHandleConflictError as exc:
@@ -669,7 +720,12 @@ async def archive_workflow(
         workspace_id=tid,
     )
     workflow = await repository.archive_workflow(workflow.id, actor=resolved_actor)
-    return await _apply_share_url_async(workflow, repository, _resolve_studio_url())
+    return await _apply_share_url_async(
+        workflow,
+        repository,
+        _resolve_studio_url(),
+        workspace_slug=workspace.workspace_slug,
+    )
 
 
 @router.post(
@@ -934,7 +990,10 @@ async def publish_workflow(
             actor=actor,
         )
         workflow = await _apply_share_url_async(
-            workflow, repository, _resolve_studio_url()
+            workflow,
+            repository,
+            _resolve_studio_url(),
+            workspace_slug=workspace.workspace_slug,
         )
     except WorkflowNotFoundError as exc:
         raise_not_found("Workflow not found", exc)
@@ -982,7 +1041,10 @@ async def revoke_workflow_publish(
     try:
         workflow = await repository.revoke_publish(workflow.id, actor=actor)
         workflow = await _apply_share_url_async(
-            workflow, repository, _resolve_studio_url()
+            workflow,
+            repository,
+            _resolve_studio_url(),
+            workspace_slug=workspace.workspace_slug,
         )
     except WorkflowNotFoundError as exc:
         raise_not_found("Workflow not found", exc)

--- a/apps/backend/src/orcheo_backend/app/routers/workflows.py
+++ b/apps/backend/src/orcheo_backend/app/routers/workflows.py
@@ -19,6 +19,7 @@ from orcheo.runtime.configurable_schema import (
     split_configurable,
 )
 from orcheo.runtime.runnable_config import RunnableConfigModel
+from orcheo.workspace import WorkspaceNotFoundError
 from orcheo.workflow.mermaid import (
     render_mermaid_from_graph_payload,
     render_mermaid_from_graph_payload_full_env,
@@ -43,6 +44,7 @@ from orcheo_backend.app.plugin_inventory import (
 )
 from orcheo_backend.app.repository import (
     CronTriggerNotFoundError,
+    TeamNotFoundError,
     WorkflowHandleConflictError,
     WorkflowNotFoundError,
     WorkflowPublishStateError,
@@ -63,7 +65,7 @@ from orcheo_backend.app.schemas.workflows import (
     WorkflowVersionIngestRequest,
     WorkflowVersionRunnableConfigUpdateRequest,
 )
-from orcheo_backend.app.workspace import WorkspaceContextDep, get_workspace_repository
+from orcheo_backend.app.workspace import WorkspaceContextDep, WorkspaceServiceDep, get_workspace_repository
 from orcheo_backend.app.workspace_governance import ensure_workspace_workflow_quota
 from orcheo_sdk.cli.workflow.frontmatter import parse_workflow_frontmatter
 
@@ -379,12 +381,14 @@ async def _resolve_workflow_id(
     *,
     include_archived: bool = True,
     workspace_id: str | None = None,
+    team_id: str | None = None,
 ) -> str:
     try:
         workflow_id = await repository.resolve_workflow_ref(
             workflow_ref,
             include_archived=include_archived,
             workspace_id=workspace_id,
+            team_id=team_id,
         )
     except WorkflowNotFoundError as exc:
         raise_not_found("Workflow not found", exc)
@@ -397,12 +401,14 @@ async def _resolve_workflow_uuid(
     *,
     include_archived: bool = True,
     workspace_id: str | None = None,
+    team_id: str | None = None,
 ) -> UUID:
     workflow_id = await _resolve_workflow_id(
         repository,
         workflow_ref,
         include_archived=include_archived,
         workspace_id=workspace_id,
+        team_id=team_id,
     )
     return UUID(workflow_id)
 
@@ -471,13 +477,66 @@ async def _build_workflow_list_item(
     )
 
 
+def _resolve_workspace_id_from_slug(
+    workspace_service: Any, workspace_slug: str
+) -> str | None:
+    """Resolve workspace ID from slug, returning None if not found."""
+    try:
+        workspace = workspace_service.repository.get_workspace_by_slug(workspace_slug)
+        return str(workspace.id)
+    except (WorkspaceNotFoundError, Exception):
+        return None
+
+
+async def _resolve_team_id_from_slug(
+    repository: Any, team_slug: str, workspace_id: str
+) -> str | None:
+    """Resolve team ID from slug within workspace, returning None if not found."""
+    try:
+        team = await repository.get_team_by_slug(team_slug, workspace_id=workspace_id)
+        return str(team.id)
+    except (TeamNotFoundError, Exception):
+        return None
+
+
 @public_router.get("/workflows/{workflow_ref}/public", response_model=PublicWorkflow)
 async def get_public_workflow(
     workflow_ref: str,
     repository: RepositoryDep,
+    workspace_service: WorkspaceServiceDep,
+    workspace_slug: str | None = Query(None),
+    team_slug: str | None = Query(None),
 ) -> PublicWorkflow:
-    """Fetch public workflow metadata without authentication."""
-    workflow_id = await _resolve_workflow_uuid(repository, workflow_ref)
+    """Fetch public workflow metadata without authentication.
+    
+    When workspace_slug and/or team_slug are provided, workflow resolution
+    will be scoped to the specified workspace and team context.
+    """
+    # Resolve workspace and team IDs from slugs if provided
+    resolved_workspace_id: str | None = None
+    resolved_team_id: str | None = None
+    
+    if workspace_slug:
+        resolved_workspace_id = _resolve_workspace_id_from_slug(
+            workspace_service, workspace_slug
+        )
+        if not resolved_workspace_id:
+            raise_not_found("Workspace not found", WorkspaceNotFoundError(workspace_slug))
+            
+        if team_slug:
+            resolved_team_id = await _resolve_team_id_from_slug(
+                repository, team_slug, resolved_workspace_id
+            )
+            if not resolved_team_id:
+                raise_not_found("Team not found", TeamNotFoundError(team_slug))
+    
+    # Resolve workflow with team and workspace context
+    workflow_id = await _resolve_workflow_uuid(
+        repository, 
+        workflow_ref, 
+        workspace_id=resolved_workspace_id,
+        team_id=resolved_team_id,
+    )
     try:
         workflow = await repository.get_workflow(workflow_id)
     except WorkflowNotFoundError as exc:
@@ -492,19 +551,19 @@ async def get_public_workflow(
                 "code": "workflow.not_public",
             },
         )
-    team_slug = await _resolve_team_slug(repository, workflow)
-    workspace_slug: str | None = None
+    team_slug_resolved = await _resolve_team_slug(repository, workflow)
+    workspace_slug_resolved: str | None = None
     if workflow.workspace_id:
         try:
             ws = get_workspace_repository().get_workspace(UUID(workflow.workspace_id))
-            workspace_slug = ws.slug
+            workspace_slug_resolved = ws.slug
         except Exception:  # noqa: BLE001
             pass
     return _serialize_public_workflow(
         workflow,
         _resolve_studio_url(),
-        team_slug=team_slug,
-        workspace_slug=workspace_slug,
+        team_slug=team_slug_resolved,
+        workspace_slug=workspace_slug_resolved,
     )
 
 

--- a/apps/backend/src/orcheo_backend/app/schemas/teams.py
+++ b/apps/backend/src/orcheo_backend/app/schemas/teams.py
@@ -1,0 +1,31 @@
+"""Schemas for the team grouping endpoints."""
+
+from __future__ import annotations
+from pydantic import BaseModel, Field
+from orcheo.models import Team
+
+
+class TeamItem(BaseModel):
+    """Public representation of a team within a workspace."""
+
+    id: str
+    slug: str
+    name: str
+    is_default: bool
+
+    @classmethod
+    def from_team(cls, team: Team) -> TeamItem:
+        """Build the public shape from a domain ``Team``."""
+        return cls(
+            id=str(team.id),
+            slug=team.slug,
+            name=team.name,
+            is_default=team.is_default,
+        )
+
+
+class TeamCreateRequest(BaseModel):
+    """Request body for creating a team."""
+
+    name: str = Field(min_length=1, max_length=128)
+    slug: str = Field(min_length=1, max_length=64)

--- a/apps/backend/src/orcheo_backend/app/teams_service.py
+++ b/apps/backend/src/orcheo_backend/app/teams_service.py
@@ -1,0 +1,34 @@
+"""Helpers for resolving and provisioning workspace teams."""
+
+from __future__ import annotations
+from orcheo.models import Team
+from orcheo.workspace.models import WorkspaceContext
+from orcheo_backend.app.repository import WorkflowRepository
+from orcheo_backend.app.workspace import get_workspace_repository
+
+
+async def ensure_default_team(
+    repository: WorkflowRepository,
+    workspace: WorkspaceContext,
+) -> Team:
+    """Return the workspace's default team, creating it on first access.
+
+    Requirement: a fresh workspace gets a default team named after the workspace
+    (name + slug) so users do not have to create one before onboarding.
+    """
+    workspace_id = str(workspace.workspace_id)
+    slug = getattr(workspace, "workspace_slug", None) or workspace_id
+    name = slug
+    try:
+        record = get_workspace_repository().get_workspace(workspace.workspace_id)
+        name = record.name
+    except Exception:  # noqa: BLE001 - fall back to the slug as the team name
+        name = slug
+    return await repository.ensure_default_team(
+        workspace_id=workspace_id,
+        name=name,
+        slug=slug,
+    )
+
+
+__all__ = ["ensure_default_team"]

--- a/apps/studio/index.html
+++ b/apps/studio/index.html
@@ -8,11 +8,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script
-      async
-      src="%VITE_ORCHEO_BACKEND_URL%/api/chatkit/assets/chatkit.js"
-      crossorigin="anonymous"
-    ></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -2,6 +2,7 @@ import { useLayoutEffect } from "react";
 import {
   BrowserRouter as Router,
   Navigate,
+  Outlet,
   Route,
   Routes,
   useParams,
@@ -22,6 +23,7 @@ import {
   setSelectedWorkspaceSlug,
 } from "@/lib/workspace-session";
 import { getWorkspaceGalleryPath } from "@/lib/workspace-routing";
+import { WorkspaceBootstrapGate } from "@features/shared/components/workspace-bootstrap-gate";
 
 const syncWorkspaceSlug = (workspaceSlug?: string) => {
   if (!workspaceSlug) {
@@ -56,6 +58,14 @@ function WorkspaceManagementRoute() {
   return <WorkspaceManagement />;
 }
 
+function RequireWorkspace() {
+  return (
+    <WorkspaceBootstrapGate>
+      <Outlet />
+    </WorkspaceBootstrapGate>
+  );
+}
+
 function WorkspaceWorkflowRoute() {
   const { workspaceSlug, workflowId } = useParams<{
     workspaceSlug?: string;
@@ -87,6 +97,7 @@ export default function OrcheoStudioApp() {
             <Route path="/chat/:workspaceSlug/team/:teamSlug/:workflowId" element={<PublicChatPage />} />
 
             <Route element={<RequireAuth />}>
+              <Route element={<RequireWorkspace />}>
                 <Route path="/" element={<WorkspaceHomeRedirect />} />
                 <Route
                   path="/:workspaceSlug"
@@ -114,6 +125,7 @@ export default function OrcheoStudioApp() {
                 <Route path="/profile" element={<Profile />} />
 
                 <Route path="/settings" element={<Settings />} />
+              </Route>
             </Route>
           </Routes>
           <Toaster />

--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -83,6 +83,8 @@ export default function OrcheoStudioApp() {
             <Route path="/auth/callback" element={<OAuthCallback />} />
             <Route path="/chat/:workflowId" element={<PublicChatPage />} />
             <Route path="/chat/team/:teamSlug/:workflowId" element={<PublicChatPage />} />
+            <Route path="/chat/:workspaceSlug/:workflowId" element={<PublicChatPage />} />
+            <Route path="/chat/:workspaceSlug/team/:teamSlug/:workflowId" element={<PublicChatPage />} />
 
             <Route element={<RequireAuth />}>
                 <Route path="/" element={<WorkspaceHomeRedirect />} />

--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -59,6 +59,7 @@ function WorkspaceManagementRoute() {
 function WorkspaceWorkflowRoute() {
   const { workspaceSlug, workflowId } = useParams<{
     workspaceSlug?: string;
+    teamSlug?: string;
     workflowId?: string;
   }>();
   useLayoutEffect(() => {
@@ -96,6 +97,10 @@ export default function OrcheoStudioApp() {
 
                 <Route
                   path="/:workspaceSlug/new"
+                  element={<WorkspaceWorkflowRoute />}
+                />
+                <Route
+                  path="/:workspaceSlug/team/:teamSlug/:workflowId"
                   element={<WorkspaceWorkflowRoute />}
                 />
                 <Route

--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -82,6 +82,7 @@ export default function OrcheoStudioApp() {
 
             <Route path="/auth/callback" element={<OAuthCallback />} />
             <Route path="/chat/:workflowId" element={<PublicChatPage />} />
+            <Route path="/chat/team/:teamSlug/:workflowId" element={<PublicChatPage />} />
 
             <Route element={<RequireAuth />}>
                 <Route path="/" element={<WorkspaceHomeRedirect />} />

--- a/apps/studio/src/features/chatkit/pages/public-chat.tsx
+++ b/apps/studio/src/features/chatkit/pages/public-chat.tsx
@@ -34,7 +34,7 @@ const sanitizeWorkflowNameForEmail = (value: string): string =>
     .trim();
 
 export default function PublicChatPage() {
-  const { workflowId, workspaceSlug, teamSlug } = useParams<{ 
+  const { workflowId, workspaceSlug, teamSlug } = useParams<{
     workflowId: string;
     workspaceSlug?: string;
     teamSlug?: string;
@@ -122,7 +122,7 @@ export default function PublicChatPage() {
     return () => {
       cancelled = true;
     };
-  }, [workflowId]);
+  }, [workflowId, workspaceSlug, teamSlug]);
 
   const contactHref = useMemo(() => {
     if (workflowState.status !== "ready") {

--- a/apps/studio/src/features/chatkit/pages/public-chat.tsx
+++ b/apps/studio/src/features/chatkit/pages/public-chat.tsx
@@ -34,7 +34,11 @@ const sanitizeWorkflowNameForEmail = (value: string): string =>
     .trim();
 
 export default function PublicChatPage() {
-  const { workflowId } = useParams<{ workflowId: string }>();
+  const { workflowId, workspaceSlug, teamSlug } = useParams<{ 
+    workflowId: string;
+    workspaceSlug?: string;
+    teamSlug?: string;
+  }>();
   const location = useLocation();
   const [workflowState, setWorkflowState] = useState<WorkflowState>({
     status: workflowId ? "loading" : "error",
@@ -67,7 +71,7 @@ export default function PublicChatPage() {
     let cancelled = false;
     setWorkflowState({ status: "loading" });
 
-    fetchPublicWorkflow(workflowId)
+    fetchPublicWorkflow(workflowId, { workspaceSlug, teamSlug })
       .then((workflow) => {
         if (cancelled) {
           return;

--- a/apps/studio/src/features/workflow/data/templates/candidate-badges.ts
+++ b/apps/studio/src/features/workflow/data/templates/candidate-badges.ts
@@ -132,6 +132,11 @@ export const getCandidateBadgeDefinition = (
 ): CandidateBadgeDefinition | undefined =>
   candidateBadges.find((badge) => badge.workflow.id === workflowId);
 
+export const getCandidateBadgeByHandle = (
+  handle: string,
+): CandidateBadgeDefinition | undefined =>
+  candidateBadges.find((badge) => badge.handle === handle);
+
 export const getCandidateTemplateDefinition = (
   templateId: string,
 ): WorkflowTemplateDefinition | undefined =>

--- a/apps/studio/src/features/workflow/data/workflow-types.ts
+++ b/apps/studio/src/features/workflow/data/workflow-types.ts
@@ -33,6 +33,7 @@ export interface WorkflowMermaidPreviewVersion {
 export interface Workflow {
   id: string;
   handle?: string;
+  teamId?: string | null;
   name: string;
   description?: string;
   avatarEmoji?: string | null;

--- a/apps/studio/src/features/workflow/lib/workflow-storage-api.ts
+++ b/apps/studio/src/features/workflow/lib/workflow-storage-api.ts
@@ -1,6 +1,7 @@
 import { authFetch } from "@/lib/auth-fetch";
 import { buildBackendHttpUrl, getBackendBaseUrl } from "@/lib/config";
 import type {
+  ApiTeam,
   ApiWorkflow,
   ApiWorkflowPagePayload,
   ApiWorkflowRun,
@@ -175,12 +176,28 @@ export interface ApiCandidate {
 export const fetchCandidates = async (): Promise<ApiCandidate[]> =>
   request<ApiCandidate[]>("/api/candidates");
 
+export const fetchTeams = async (): Promise<ApiTeam[]> =>
+  request<ApiTeam[]>("/api/teams");
+
+export const createTeam = async (input: {
+  name: string;
+  slug: string;
+}): Promise<ApiTeam> =>
+  request<ApiTeam>("/api/teams", {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+
 export const onboardCandidate = async (
   candidateId: string,
+  teamId?: string,
 ): Promise<ApiWorkflow> =>
   request<ApiWorkflow>("/api/candidates/onboard", {
     method: "POST",
-    body: JSON.stringify({ id: candidateId }),
+    body: JSON.stringify({
+      id: candidateId,
+      ...(teamId ? { team_id: teamId } : {}),
+    }),
   });
 
 export const fetchWorkflowListeners = async (

--- a/apps/studio/src/features/workflow/lib/workflow-storage-api.ts
+++ b/apps/studio/src/features/workflow/lib/workflow-storage-api.ts
@@ -106,11 +106,19 @@ export const fetchWorkflowPageData = async (
 
 export const fetchPublicWorkflow = async (
   workflowId: string,
+  context?: { workspaceSlug?: string; teamSlug?: string },
 ): Promise<PublicWorkflowMetadata | undefined> => {
   try {
-    return await request<PublicWorkflowMetadata>(
-      `${PUBLIC_WORKFLOW_PATH}/${workflowId}/public`,
-    );
+    const params = new URLSearchParams();
+    if (context?.workspaceSlug) {
+      params.set("workspace_slug", context.workspaceSlug);
+    }
+    if (context?.teamSlug) {
+      params.set("team_slug", context.teamSlug);
+    }
+    const queryString = params.toString();
+    const url = `${PUBLIC_WORKFLOW_PATH}/${workflowId}/public${queryString ? `?${queryString}` : ""}`;
+    return await request<PublicWorkflowMetadata>(url);
   } catch (error) {
     if (
       error instanceof ApiRequestError &&

--- a/apps/studio/src/features/workflow/lib/workflow-storage-api.ts
+++ b/apps/studio/src/features/workflow/lib/workflow-storage-api.ts
@@ -188,6 +188,12 @@ export const createTeam = async (input: {
     body: JSON.stringify(input),
   });
 
+export const deleteTeam = async (teamId: string): Promise<void> =>
+  request<void>(`/api/teams/${teamId}`, {
+    method: "DELETE",
+    expectJson: false,
+  });
+
 export const onboardCandidate = async (
   candidateId: string,
   teamId?: string,

--- a/apps/studio/src/features/workflow/lib/workflow-storage-helpers.ts
+++ b/apps/studio/src/features/workflow/lib/workflow-storage-helpers.ts
@@ -135,9 +135,15 @@ export const toFlowEdges = (edges: WorkflowEdge[]): FlowEdge[] =>
 
 export const getWorkflowRouteRef = (
   workflow:
-    | Pick<ApiWorkflow, "id" | "handle">
-    | Pick<Workflow, "id" | "handle">,
-): string => workflow.handle ?? workflow.id;
+    | Pick<ApiWorkflow, "id" | "handle" | "team_id">
+    | Pick<Workflow, "id" | "handle" | "teamId">,
+): string => {
+  const teamId = "team_id" in workflow ? workflow.team_id : workflow.teamId;
+  if (teamId) {
+    return workflow.id;
+  }
+  return workflow.handle ?? workflow.id;
+};
 
 export const resolveWorkflowVersionMermaidSource = (
   version:

--- a/apps/studio/src/features/workflow/lib/workflow-storage-helpers.ts
+++ b/apps/studio/src/features/workflow/lib/workflow-storage-helpers.ts
@@ -351,6 +351,7 @@ export const toStoredWorkflow = (
   return {
     id: workflow.id,
     handle: workflow.handle ?? undefined,
+    teamId: workflow.team_id ?? undefined,
     name: workflow.name,
     description: workflow.description ?? undefined,
     avatarEmoji,

--- a/apps/studio/src/features/workflow/lib/workflow-storage.ts
+++ b/apps/studio/src/features/workflow/lib/workflow-storage.ts
@@ -458,8 +458,9 @@ export const deleteWorkflow = async (
 
 export const onboardCandidateAsWorkflow = async (
   candidateId: string,
+  teamId?: string,
 ): Promise<StoredWorkflow> => {
-  const apiWorkflow = await onboardCandidate(candidateId);
+  const apiWorkflow = await onboardCandidate(candidateId, teamId);
   invalidateWorkflowCache(apiWorkflow.id);
   const stored = await ensureWorkflow(apiWorkflow.id);
   if (!stored) {

--- a/apps/studio/src/features/workflow/lib/workflow-storage.types.ts
+++ b/apps/studio/src/features/workflow/lib/workflow-storage.types.ts
@@ -6,9 +6,17 @@ import type {
 import type { WorkflowDiffResult, WorkflowSnapshot } from "./workflow-diff";
 import type { RJSFSchema } from "@rjsf/utils";
 
+export interface ApiTeam {
+  id: string;
+  slug: string;
+  name: string;
+  is_default: boolean;
+}
+
 export interface ApiWorkflow {
   id: string;
   handle?: string | null;
+  team_id?: string | null;
   name: string;
   slug: string;
   description: string | null;
@@ -237,6 +245,7 @@ export interface WorkflowVersionRecord {
 
 export interface StoredWorkflow extends Workflow {
   versions: WorkflowVersionRecord[];
+  teamId?: string | null;
   draftAccess?: "personal" | "authenticated" | "workspace";
   isArchived?: boolean;
   isPublic?: boolean;

--- a/apps/studio/src/features/workflow/pages/workflow-gallery.tsx
+++ b/apps/studio/src/features/workflow/pages/workflow-gallery.tsx
@@ -4,6 +4,8 @@ import { getActiveWorkspace } from "@/lib/api";
 import useCredentialVault from "@/hooks/use-credential-vault";
 import { usePageContext } from "@/hooks/use-page-context";
 import { WorkflowGalleryTabs } from "@/features/workflow/pages/workflow-gallery/workflow-gallery-tabs";
+import { OnboardTeamDialog } from "@/features/workflow/pages/workflow-gallery/onboard-team-dialog";
+import { CreateTeamDialog } from "@/features/workflow/pages/workflow-gallery/create-team-dialog";
 import { useWorkflowGallery } from "@/features/workflow/pages/workflow-gallery/use-workflow-gallery";
 
 export default function WorkflowGallery() {
@@ -53,11 +55,19 @@ export default function WorkflowGallery() {
     sortedWorkflows,
     tabCounts,
     isTemplateView,
+    teams,
     handleUseTemplate,
     handleImportStarterPack,
     handleExportWorkflow,
     handleDeleteWorkflow,
     handleOpenWorkflow,
+    onboardTarget,
+    confirmOnboardTeam,
+    cancelOnboardTeam,
+    isCreateTeamOpen,
+    openCreateTeamDialog,
+    closeCreateTeamDialog,
+    handleCreateTeam,
   } = useWorkflowGallery();
 
   return (
@@ -80,6 +90,8 @@ export default function WorkflowGallery() {
             sortedWorkflows={sortedWorkflows}
             tabCounts={tabCounts}
             isTemplateView={isTemplateView}
+            teams={teams}
+            onCreateTeam={openCreateTeamDialog}
             workspaceLabel={workspaceLabel}
             searchQuery={searchQuery}
             onSearchQueryChange={setSearchQuery}
@@ -91,6 +103,26 @@ export default function WorkflowGallery() {
           />
         </div>
       </main>
+
+      <CreateTeamDialog
+        open={isCreateTeamOpen}
+        onOpenChange={(open) => {
+          if (!open) closeCreateTeamDialog();
+        }}
+        onCreate={handleCreateTeam}
+      />
+
+      <OnboardTeamDialog
+        open={onboardTarget !== null}
+        candidateName={onboardTarget?.candidateName ?? ""}
+        teams={teams}
+        onSelect={confirmOnboardTeam}
+        onOpenChange={(open) => {
+          if (!open) {
+            cancelOnboardTeam();
+          }
+        }}
+      />
     </div>
   );
 }

--- a/apps/studio/src/features/workflow/pages/workflow-gallery.tsx
+++ b/apps/studio/src/features/workflow/pages/workflow-gallery.tsx
@@ -3,6 +3,8 @@ import TopNavigation from "@features/shared/components/top-navigation";
 import { getActiveWorkspace } from "@/lib/api";
 import useCredentialVault from "@/hooks/use-credential-vault";
 import { usePageContext } from "@/hooks/use-page-context";
+import { Button } from "@/design-system/ui/button";
+import { Plus } from "lucide-react";
 import { WorkflowGalleryTabs } from "@/features/workflow/pages/workflow-gallery/workflow-gallery-tabs";
 import { OnboardTeamDialog } from "@/features/workflow/pages/workflow-gallery/onboard-team-dialog";
 import { CreateTeamDialog } from "@/features/workflow/pages/workflow-gallery/create-team-dialog";
@@ -68,6 +70,7 @@ export default function WorkflowGallery() {
     openCreateTeamDialog,
     closeCreateTeamDialog,
     handleCreateTeam,
+    handleDeleteTeam,
   } = useWorkflowGallery();
 
   return (
@@ -81,7 +84,7 @@ export default function WorkflowGallery() {
         onRevealCredentialSecret={onRevealCredentialSecret}
       />
 
-      <main className="flex flex-1 min-h-0 flex-col overflow-hidden">
+      <main className="relative flex flex-1 min-h-0 flex-col overflow-hidden">
         <div className="flex-1 overflow-auto">
           <WorkflowGalleryTabs
             selectedTab={selectedTab}
@@ -91,7 +94,6 @@ export default function WorkflowGallery() {
             tabCounts={tabCounts}
             isTemplateView={isTemplateView}
             teams={teams}
-            onCreateTeam={openCreateTeamDialog}
             workspaceLabel={workspaceLabel}
             searchQuery={searchQuery}
             onSearchQueryChange={setSearchQuery}
@@ -100,8 +102,18 @@ export default function WorkflowGallery() {
             onUseTemplate={handleUseTemplate}
             onExportWorkflow={handleExportWorkflow}
             onDeleteWorkflow={handleDeleteWorkflow}
+            onDeleteTeam={handleDeleteTeam}
           />
         </div>
+
+        {!isTemplateView && (
+          <div className="absolute bottom-4 left-4">
+            <Button variant="outline" size="sm" onClick={openCreateTeamDialog}>
+              <Plus className="mr-2 h-4 w-4" />
+              New team
+            </Button>
+          </div>
+        )}
       </main>
 
       <CreateTeamDialog

--- a/apps/studio/src/features/workflow/pages/workflow-gallery/create-team-dialog.tsx
+++ b/apps/studio/src/features/workflow/pages/workflow-gallery/create-team-dialog.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useState } from "react";
+import { Button } from "@/design-system/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/design-system/ui/dialog";
+import { Input } from "@/design-system/ui/input";
+import { Label } from "@/design-system/ui/label";
+
+interface CreateTeamDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreate: (name: string, slug: string) => Promise<void>;
+}
+
+const toSlug = (name: string): string =>
+  name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+export const CreateTeamDialog = ({
+  open,
+  onOpenChange,
+  onCreate,
+}: CreateTeamDialogProps) => {
+  const [name, setName] = useState("");
+  const [slug, setSlug] = useState("");
+  const [slugDirty, setSlugDirty] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      setName("");
+      setSlug("");
+      setSlugDirty(false);
+      setError(null);
+      setIsSubmitting(false);
+    }
+  }, [open]);
+
+  const handleNameChange = (value: string) => {
+    setName(value);
+    if (!slugDirty) {
+      setSlug(toSlug(value));
+    }
+  };
+
+  const handleSlugChange = (value: string) => {
+    setSlugDirty(true);
+    setSlug(value.toLowerCase().replace(/[^a-z0-9_-]/g, ""));
+  };
+
+  const handleSubmit = async () => {
+    const trimmedName = name.trim();
+    const trimmedSlug = slug.trim();
+    if (!trimmedName || !trimmedSlug) {
+      setError("Both name and slug are required.");
+      return;
+    }
+    setError(null);
+    setIsSubmitting(true);
+    try {
+      await onCreate(trimmedName, trimmedSlug);
+      onOpenChange(false);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to create team.",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>New team</DialogTitle>
+          <DialogDescription>
+            Create a team to group colleagues under a shared label.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4 py-2">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="team-name">Name</Label>
+            <Input
+              id="team-name"
+              placeholder="e.g. Sales"
+              value={name}
+              onChange={(e) => handleNameChange(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") void handleSubmit();
+              }}
+              autoFocus
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="team-slug">Slug</Label>
+            <Input
+              id="team-slug"
+              placeholder="e.g. sales"
+              value={slug}
+              onChange={(e) => handleSlugChange(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") void handleSubmit();
+              }}
+            />
+            <p className="text-xs text-muted-foreground">
+              Used in API references. Lowercase letters, numbers, hyphens, and
+              underscores only.
+            </p>
+          </div>
+          {error ? (
+            <p className="text-sm text-destructive">{error}</p>
+          ) : null}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={() => void handleSubmit()} disabled={isSubmitting}>
+            {isSubmitting ? "Creating…" : "Create team"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/apps/studio/src/features/workflow/pages/workflow-gallery/onboard-team-dialog.tsx
+++ b/apps/studio/src/features/workflow/pages/workflow-gallery/onboard-team-dialog.tsx
@@ -1,0 +1,57 @@
+import { Button } from "@/design-system/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/design-system/ui/dialog";
+import { type ApiTeam } from "@features/workflow/lib/workflow-storage-api";
+
+interface OnboardTeamDialogProps {
+  open: boolean;
+  candidateName: string;
+  teams: ApiTeam[];
+  onSelect: (teamId: string) => void;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Prompts which team to onboard a candidate into when the workspace has more
+ * than one team.
+ */
+export const OnboardTeamDialog = ({
+  open,
+  candidateName,
+  teams,
+  onSelect,
+  onOpenChange,
+}: OnboardTeamDialogProps) => {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Choose a team</DialogTitle>
+          <DialogDescription>
+            Select the team to onboard "{candidateName}" into.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-2">
+          {teams.map((team) => (
+            <Button
+              key={team.id}
+              variant="outline"
+              className="justify-between"
+              onClick={() => onSelect(team.id)}
+            >
+              <span>{team.name}</span>
+              {team.is_default ? (
+                <span className="text-xs text-muted-foreground">Default</span>
+              ) : null}
+            </Button>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/apps/studio/src/features/workflow/pages/workflow-gallery/team-section.tsx
+++ b/apps/studio/src/features/workflow/pages/workflow-gallery/team-section.tsx
@@ -1,0 +1,42 @@
+import { type ReactNode, useState } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+
+interface TeamSectionProps {
+  name: string;
+  count: number;
+  defaultOpen?: boolean;
+  children: ReactNode;
+}
+
+/**
+ * A vertically-stacked, individually collapsible section grouping the AI
+ * colleagues that belong to a single team.
+ */
+export const TeamSection = ({
+  name,
+  count,
+  defaultOpen = true,
+  children,
+}: TeamSectionProps) => {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+
+  return (
+    <section className="border-b border-border/60 pb-4 last:border-b-0">
+      <button
+        type="button"
+        aria-expanded={isOpen}
+        onClick={() => setIsOpen((open) => !open)}
+        className="flex w-full items-center gap-2 py-3 text-left"
+      >
+        {isOpen ? (
+          <ChevronDown className="h-4 w-4 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="h-4 w-4 text-muted-foreground" />
+        )}
+        <span className="text-sm font-semibold">{name}</span>
+        <span className="text-xs text-muted-foreground">{count}</span>
+      </button>
+      {isOpen ? children : null}
+    </section>
+  );
+};

--- a/apps/studio/src/features/workflow/pages/workflow-gallery/team-section.tsx
+++ b/apps/studio/src/features/workflow/pages/workflow-gallery/team-section.tsx
@@ -25,12 +25,12 @@ export const TeamSection = ({
 
   return (
     <section className="border-b border-border/60 pb-4 last:border-b-0">
-      <div className="group flex items-center">
+      <div className="group flex items-center py-3">
         <button
           type="button"
           aria-expanded={isOpen}
           onClick={() => setIsOpen((open) => !open)}
-          className="flex flex-1 items-center gap-2 py-3 text-left"
+          className="flex items-center gap-2 text-left"
         >
           {isOpen ? (
             <ChevronDown className="h-4 w-4 text-muted-foreground" />
@@ -44,7 +44,7 @@ export const TeamSection = ({
           <Button
             variant="ghost"
             size="icon"
-            className="h-7 w-7 opacity-0 group-hover:opacity-100"
+            className="ml-1 h-7 w-7 opacity-0 group-hover:opacity-100"
             onClick={onRemove}
             aria-label={`Remove team ${name}`}
           >

--- a/apps/studio/src/features/workflow/pages/workflow-gallery/team-section.tsx
+++ b/apps/studio/src/features/workflow/pages/workflow-gallery/team-section.tsx
@@ -1,10 +1,12 @@
 import { type ReactNode, useState } from "react";
-import { ChevronDown, ChevronRight } from "lucide-react";
+import { ChevronDown, ChevronRight, Trash2 } from "lucide-react";
+import { Button } from "@/design-system/ui/button";
 
 interface TeamSectionProps {
   name: string;
   count: number;
   defaultOpen?: boolean;
+  onRemove?: () => void;
   children: ReactNode;
 }
 
@@ -16,26 +18,40 @@ export const TeamSection = ({
   name,
   count,
   defaultOpen = true,
+  onRemove,
   children,
 }: TeamSectionProps) => {
   const [isOpen, setIsOpen] = useState(defaultOpen);
 
   return (
     <section className="border-b border-border/60 pb-4 last:border-b-0">
-      <button
-        type="button"
-        aria-expanded={isOpen}
-        onClick={() => setIsOpen((open) => !open)}
-        className="flex w-full items-center gap-2 py-3 text-left"
-      >
-        {isOpen ? (
-          <ChevronDown className="h-4 w-4 text-muted-foreground" />
-        ) : (
-          <ChevronRight className="h-4 w-4 text-muted-foreground" />
-        )}
-        <span className="text-sm font-semibold">{name}</span>
-        <span className="text-xs text-muted-foreground">{count}</span>
-      </button>
+      <div className="group flex items-center">
+        <button
+          type="button"
+          aria-expanded={isOpen}
+          onClick={() => setIsOpen((open) => !open)}
+          className="flex flex-1 items-center gap-2 py-3 text-left"
+        >
+          {isOpen ? (
+            <ChevronDown className="h-4 w-4 text-muted-foreground" />
+          ) : (
+            <ChevronRight className="h-4 w-4 text-muted-foreground" />
+          )}
+          <span className="text-sm font-semibold">{name}</span>
+          <span className="text-xs text-muted-foreground">{count}</span>
+        </button>
+        {onRemove ? (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 opacity-0 group-hover:opacity-100"
+            onClick={onRemove}
+            aria-label={`Remove team ${name}`}
+          >
+            <Trash2 className="h-3.5 w-3.5 text-muted-foreground" />
+          </Button>
+        ) : null}
+      </div>
       {isOpen ? children : null}
     </section>
   );

--- a/apps/studio/src/features/workflow/pages/workflow-gallery/use-workflow-gallery-actions.team.test.tsx
+++ b/apps/studio/src/features/workflow/pages/workflow-gallery/use-workflow-gallery-actions.team.test.tsx
@@ -1,0 +1,102 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { onboardCandidateAsWorkflow } from "@features/workflow/lib/workflow-storage";
+import { getCandidateBadgeDefinition } from "@features/workflow/data/templates/candidate-badges";
+import { useWorkflowGalleryActions } from "./use-workflow-gallery-actions";
+
+vi.mock("@features/workflow/lib/workflow-storage", () => ({
+  onboardCandidateAsWorkflow: vi.fn(),
+  deleteWorkflow: vi.fn(),
+}));
+
+vi.mock("@features/workflow/data/templates/candidate-badges", () => ({
+  getCandidateBadgeDefinition: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-toast", () => ({ toast: vi.fn() }));
+
+const mockedOnboard = vi.mocked(onboardCandidateAsWorkflow);
+const mockedBadge = vi.mocked(getCandidateBadgeDefinition);
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <MemoryRouter>{children}</MemoryRouter>
+);
+
+const DEFAULT_TEAM = {
+  id: "team-default",
+  slug: "acme",
+  name: "Acme",
+  is_default: true,
+};
+const SALES_TEAM = {
+  id: "team-sales",
+  slug: "sales",
+  name: "Sales",
+  is_default: false,
+};
+
+describe("useWorkflowGalleryActions onboarding", () => {
+  beforeEach(() => {
+    mockedOnboard.mockReset();
+    mockedOnboard.mockResolvedValue({
+      id: "wf-1",
+      name: "Insight Analyst",
+    } as never);
+    mockedBadge.mockReset();
+    mockedBadge.mockReturnValue({
+      candidateId: "insight-analyst",
+      name: "Insight Analyst",
+    } as never);
+  });
+
+  it("onboards directly into the default team when only one team exists", async () => {
+    const { result } = renderHook(
+      () =>
+        useWorkflowGalleryActions({
+          setSelectedTab: vi.fn(),
+          teams: [DEFAULT_TEAM],
+        }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.handleUseTemplate("template-insight");
+    });
+
+    expect(result.current.onboardTarget).toBeNull();
+    expect(mockedOnboard).toHaveBeenCalledWith("insight-analyst", undefined);
+  });
+
+  it("prompts for a team and onboards into the chosen one", async () => {
+    const { result } = renderHook(
+      () =>
+        useWorkflowGalleryActions({
+          setSelectedTab: vi.fn(),
+          teams: [DEFAULT_TEAM, SALES_TEAM],
+        }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.handleUseTemplate("template-insight");
+    });
+
+    // The prompt opens instead of onboarding immediately.
+    expect(mockedOnboard).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(result.current.onboardTarget).toEqual({
+        candidateId: "insight-analyst",
+        candidateName: "Insight Analyst",
+      }),
+    );
+
+    await act(async () => {
+      await result.current.confirmOnboardTeam("team-sales");
+    });
+
+    expect(mockedOnboard).toHaveBeenCalledWith("insight-analyst", "team-sales");
+    expect(result.current.onboardTarget).toBeNull();
+  });
+});

--- a/apps/studio/src/features/workflow/pages/workflow-gallery/use-workflow-gallery-actions.ts
+++ b/apps/studio/src/features/workflow/pages/workflow-gallery/use-workflow-gallery-actions.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "@/hooks/use-toast";
 import {
@@ -10,7 +10,11 @@ import {
   deleteWorkflow,
   onboardCandidateAsWorkflow,
 } from "@features/workflow/lib/workflow-storage";
-import { fetchWorkflowVersions } from "@features/workflow/lib/workflow-storage-api";
+import {
+  type ApiTeam,
+  createTeam,
+  fetchWorkflowVersions,
+} from "@features/workflow/lib/workflow-storage-api";
 import { getWorkflowRouteRef } from "@features/workflow/lib/workflow-storage-helpers";
 import { getSelectedWorkspaceSlug } from "@/lib/workspace-session";
 import { getWorkspaceWorkflowPath } from "@/lib/workspace-routing";
@@ -18,6 +22,13 @@ import { type WorkflowGalleryTab } from "./types";
 
 interface WorkflowGalleryActionsArgs {
   setSelectedTab: (value: WorkflowGalleryTab) => void;
+  teams: ApiTeam[];
+  refreshTeams: () => Promise<void>;
+}
+
+interface OnboardTarget {
+  candidateId: string;
+  candidateName: string;
 }
 
 const STARTER_TEMPLATE_IDS = ["template-python-agent"];
@@ -81,6 +92,10 @@ export const useWorkflowGalleryActions = (
   state: WorkflowGalleryActionsArgs,
 ) => {
   const navigate = useNavigate();
+  const [onboardTarget, setOnboardTarget] = useState<OnboardTarget | null>(
+    null,
+  );
+  const [isCreateTeamOpen, setIsCreateTeamOpen] = useState(false);
 
   const handleOpenWorkflow = useCallback(
     (workflowId: string) => {
@@ -91,20 +106,10 @@ export const useWorkflowGalleryActions = (
     [navigate],
   );
 
-  const handleUseTemplate = useCallback(
-    async (templateId: string) => {
+  const performOnboard = useCallback(
+    async (candidateId: string, teamId?: string) => {
       try {
-        const badge = getCandidateBadgeDefinition(templateId);
-        if (!badge?.candidateId) {
-          toast({
-            title: "Candidate unavailable",
-            description: "We couldn't find that candidate. Please try another.",
-            variant: "destructive",
-          });
-          return;
-        }
-
-        const workflow = await onboardCandidateAsWorkflow(badge.candidateId);
+        const workflow = await onboardCandidateAsWorkflow(candidateId, teamId);
 
         state.setSelectedTab("all");
 
@@ -125,6 +130,48 @@ export const useWorkflowGalleryActions = (
     },
     [handleOpenWorkflow, state],
   );
+
+  const handleUseTemplate = useCallback(
+    async (templateId: string) => {
+      const badge = getCandidateBadgeDefinition(templateId);
+      if (!badge?.candidateId) {
+        toast({
+          title: "Candidate unavailable",
+          description: "We couldn't find that candidate. Please try another.",
+          variant: "destructive",
+        });
+        return;
+      }
+
+      // With more than one team, ask which team to onboard into. Otherwise the
+      // server places the colleague in the workspace's default team.
+      if (state.teams.length > 1) {
+        setOnboardTarget({
+          candidateId: badge.candidateId,
+          candidateName: badge.name ?? badge.candidateId,
+        });
+        return;
+      }
+
+      await performOnboard(badge.candidateId);
+    },
+    [performOnboard, state.teams],
+  );
+
+  const confirmOnboardTeam = useCallback(
+    async (teamId: string) => {
+      const target = onboardTarget;
+      setOnboardTarget(null);
+      if (target) {
+        await performOnboard(target.candidateId, teamId);
+      }
+    },
+    [onboardTarget, performOnboard],
+  );
+
+  const cancelOnboardTeam = useCallback(() => {
+    setOnboardTarget(null);
+  }, []);
 
   const handleImportStarterPack = useCallback(async () => {
     try {
@@ -193,6 +240,18 @@ export const useWorkflowGalleryActions = (
     }
   }, []);
 
+  const handleCreateTeam = useCallback(
+    async (name: string, slug: string) => {
+      await createTeam({ name, slug });
+      await state.refreshTeams();
+      toast({
+        title: "Team created",
+        description: `"${name}" is ready to group colleagues.`,
+      });
+    },
+    [state],
+  );
+
   const handleDeleteWorkflow = useCallback(
     async (workflowId: string, workflowName: string) => {
       try {
@@ -213,11 +272,24 @@ export const useWorkflowGalleryActions = (
     [],
   );
 
+  const openCreateTeamDialog = useCallback(() => setIsCreateTeamOpen(true), []);
+  const closeCreateTeamDialog = useCallback(
+    () => setIsCreateTeamOpen(false),
+    [],
+  );
+
   return {
     handleOpenWorkflow,
     handleUseTemplate,
     handleImportStarterPack,
     handleExportWorkflow,
     handleDeleteWorkflow,
+    onboardTarget,
+    confirmOnboardTeam,
+    cancelOnboardTeam,
+    isCreateTeamOpen,
+    openCreateTeamDialog,
+    closeCreateTeamDialog,
+    handleCreateTeam,
   };
 };

--- a/apps/studio/src/features/workflow/pages/workflow-gallery/use-workflow-gallery-actions.ts
+++ b/apps/studio/src/features/workflow/pages/workflow-gallery/use-workflow-gallery-actions.ts
@@ -13,11 +13,15 @@ import {
 import {
   type ApiTeam,
   createTeam,
+  deleteTeam,
   fetchWorkflowVersions,
 } from "@features/workflow/lib/workflow-storage-api";
 import { getWorkflowRouteRef } from "@features/workflow/lib/workflow-storage-helpers";
 import { getSelectedWorkspaceSlug } from "@/lib/workspace-session";
-import { getWorkspaceWorkflowPath } from "@/lib/workspace-routing";
+import {
+  getWorkspaceTeamWorkflowPath,
+  getWorkspaceWorkflowPath,
+} from "@/lib/workspace-routing";
 import { type WorkflowGalleryTab } from "./types";
 
 interface WorkflowGalleryActionsArgs {
@@ -98,10 +102,13 @@ export const useWorkflowGalleryActions = (
   const [isCreateTeamOpen, setIsCreateTeamOpen] = useState(false);
 
   const handleOpenWorkflow = useCallback(
-    (workflowId: string) => {
-      navigate(
-        getWorkspaceWorkflowPath(getSelectedWorkspaceSlug(), workflowId),
-      );
+    (workflowId: string, teamSlug?: string) => {
+      const slug = getSelectedWorkspaceSlug();
+      const path =
+        teamSlug
+          ? getWorkspaceTeamWorkflowPath(slug, teamSlug, workflowId)
+          : getWorkspaceWorkflowPath(slug, workflowId);
+      navigate(path);
     },
     [navigate],
   );
@@ -118,7 +125,8 @@ export const useWorkflowGalleryActions = (
           description: `"${workflow.name}" has been onboarded to your workspace.`,
         });
 
-        handleOpenWorkflow(getWorkflowRouteRef(workflow));
+        const team = teamId ? state.teams.find((t) => t.id === teamId) : null;
+        handleOpenWorkflow(getWorkflowRouteRef(workflow), team?.slug);
       } catch (error) {
         toast({
           title: "Failed to onboard candidate",
@@ -252,6 +260,28 @@ export const useWorkflowGalleryActions = (
     [state],
   );
 
+  const handleDeleteTeam = useCallback(
+    async (teamId: string) => {
+      const team = state.teams.find((t) => t.id === teamId);
+      try {
+        await deleteTeam(teamId);
+        await state.refreshTeams();
+        toast({
+          title: "Team removed",
+          description: team ? `"${team.name}" has been removed.` : undefined,
+        });
+      } catch (error) {
+        toast({
+          title: "Cannot remove team",
+          description:
+            error instanceof Error ? error.message : "Unknown error occurred",
+          variant: "destructive",
+        });
+      }
+    },
+    [state],
+  );
+
   const handleDeleteWorkflow = useCallback(
     async (workflowId: string, workflowName: string) => {
       try {
@@ -291,5 +321,6 @@ export const useWorkflowGalleryActions = (
     openCreateTeamDialog,
     closeCreateTeamDialog,
     handleCreateTeam,
+    handleDeleteTeam,
   };
 };

--- a/apps/studio/src/features/workflow/pages/workflow-gallery/use-workflow-gallery-state.test.ts
+++ b/apps/studio/src/features/workflow/pages/workflow-gallery/use-workflow-gallery-state.test.ts
@@ -5,6 +5,7 @@ import type { StoredWorkflow } from "@features/workflow/lib/workflow-storage.typ
 import {
   type ApiCandidate,
   fetchCandidates,
+  fetchTeams,
 } from "@features/workflow/lib/workflow-storage-api";
 import { useWorkflowGalleryState } from "./use-workflow-gallery-state";
 
@@ -15,10 +16,12 @@ vi.mock("@features/workflow/lib/workflow-storage", () => ({
 
 vi.mock("@features/workflow/lib/workflow-storage-api", () => ({
   fetchCandidates: vi.fn(),
+  fetchTeams: vi.fn(),
 }));
 
 const mockedListWorkflows = vi.mocked(listWorkflows);
 const mockedFetchCandidates = vi.mocked(fetchCandidates);
+const mockedFetchTeams = vi.mocked(fetchTeams);
 
 const STORED_WORKFLOWS: StoredWorkflow[] = [
   {
@@ -115,6 +118,8 @@ describe("useWorkflowGalleryState", () => {
     mockedListWorkflows.mockResolvedValue(STORED_WORKFLOWS);
     mockedFetchCandidates.mockReset();
     mockedFetchCandidates.mockResolvedValue(CANDIDATES);
+    mockedFetchTeams.mockReset();
+    mockedFetchTeams.mockResolvedValue([]);
   });
 
   it("computes tab counts for workspace workflows and candidates", async () => {

--- a/apps/studio/src/features/workflow/pages/workflow-gallery/use-workflow-gallery-state.ts
+++ b/apps/studio/src/features/workflow/pages/workflow-gallery/use-workflow-gallery-state.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "@/hooks/use-toast";
 import {
   GALLERY_TEMPLATE_WORKFLOWS,
@@ -16,7 +16,9 @@ import {
 } from "@features/workflow/lib/workflow-storage";
 import {
   type ApiCandidate,
+  type ApiTeam,
   fetchCandidates,
+  fetchTeams,
 } from "@features/workflow/lib/workflow-storage-api";
 import {
   type WorkflowGalleryTab,
@@ -33,6 +35,8 @@ interface WorkflowGalleryStateSlice {
   tabCounts: WorkflowGalleryTabCounts;
   isTemplateView: boolean;
   templates: Workflow[];
+  teams: ApiTeam[];
+  refreshTeams: () => Promise<void>;
 }
 
 const toCandidateSpec = (candidate: ApiCandidate): CandidateBadgeSpec => ({
@@ -63,6 +67,7 @@ const matchesWorkflowSearch = (
 export const useWorkflowGalleryState = (): WorkflowGalleryStateSlice => {
   const [workflows, setWorkflows] = useState<StoredWorkflow[]>([]);
   const [candidateWorkflows, setCandidateWorkflows] = useState<Workflow[]>([]);
+  const [teams, setTeams] = useState<ApiTeam[]>([]);
   const [isLoadingWorkflows, setIsLoadingWorkflows] = useState(true);
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedTab, setSelectedTab] = useState<WorkflowGalleryTab>("all");
@@ -96,6 +101,15 @@ export const useWorkflowGalleryState = (): WorkflowGalleryStateSlice => {
     };
   }, []);
 
+  const refreshTeams = useCallback(async () => {
+    try {
+      const teamList = await fetchTeams();
+      setTeams(teamList);
+    } catch {
+      // non-fatal — teams list will stay stale
+    }
+  }, []);
+
   useEffect(() => {
     let isMounted = true;
 
@@ -104,9 +118,13 @@ export const useWorkflowGalleryState = (): WorkflowGalleryStateSlice => {
         setIsLoadingWorkflows(true);
       }
       try {
-        const items = await listWorkflows({ forceRefresh });
+        const [items, teamList] = await Promise.all([
+          listWorkflows({ forceRefresh }),
+          fetchTeams().catch(() => [] as ApiTeam[]),
+        ]);
         if (isMounted) {
           setWorkflows(items);
+          setTeams(teamList);
         }
       } catch (error) {
         if (!isMounted) {
@@ -202,5 +220,7 @@ export const useWorkflowGalleryState = (): WorkflowGalleryStateSlice => {
     tabCounts,
     isTemplateView,
     templates,
+    teams,
+    refreshTeams,
   };
 };

--- a/apps/studio/src/features/workflow/pages/workflow-gallery/use-workflow-gallery.ts
+++ b/apps/studio/src/features/workflow/pages/workflow-gallery/use-workflow-gallery.ts
@@ -5,6 +5,8 @@ export const useWorkflowGallery = () => {
   const state = useWorkflowGalleryState();
   const actions = useWorkflowGalleryActions({
     setSelectedTab: state.setSelectedTab,
+    teams: state.teams,
+    refreshTeams: state.refreshTeams,
   });
 
   return {

--- a/apps/studio/src/features/workflow/pages/workflow-gallery/workflow-card.test.tsx
+++ b/apps/studio/src/features/workflow/pages/workflow-gallery/workflow-card.test.tsx
@@ -30,6 +30,12 @@ const colleagueWorkflow = {
   edges: [],
 } satisfies Parameters<typeof WorkflowCard>[0]["workflow"];
 
+const teamScopedWorkflow = {
+  ...colleagueWorkflow,
+  id: "workflow-2",
+  teamId: "team-sales",
+} satisfies Parameters<typeof WorkflowCard>[0]["workflow"];
+
 const candidateWorkflow = {
   id: "template-insight-analyst",
   handle: "insight-analyst",
@@ -120,6 +126,24 @@ describe("WorkflowCard", () => {
     expect(handlers.onOpenWorkflow).toHaveBeenCalledWith(
       colleagueWorkflow.handle,
     );
+  });
+
+  it("opens team-scoped colleagues by immutable workflow id", async () => {
+    const user = userEvent.setup();
+    const handlers = createHandlers();
+
+    render(
+      <WorkflowCard
+        workflow={teamScopedWorkflow}
+        isTemplate={false}
+        workspaceLabel="AI Company"
+        {...handlers}
+      />,
+    );
+
+    await user.click(screen.getByTestId("workflow-card"));
+
+    expect(handlers.onOpenWorkflow).toHaveBeenCalledWith(teamScopedWorkflow.id);
   });
 
   it("renders colleague badge copy without creator metadata or edit actions", async () => {

--- a/apps/studio/src/features/workflow/pages/workflow-gallery/workflow-card.tsx
+++ b/apps/studio/src/features/workflow/pages/workflow-gallery/workflow-card.tsx
@@ -19,7 +19,10 @@ import {
 import { cn } from "@/lib/utils";
 import { resolveAvatarUrl } from "@/assets/avatars";
 import { ConfirmDeleteWorkflowDialog } from "@features/workflow/components/dialogs/confirm-delete-workflow-dialog";
-import { getCandidateBadgeDefinition } from "@features/workflow/data/templates/candidate-badges";
+import {
+  getCandidateBadgeByHandle,
+  getCandidateBadgeDefinition,
+} from "@features/workflow/data/templates/candidate-badges";
 import { type Workflow } from "@features/workflow/data/workflow-data";
 import { getWorkflowRouteRef } from "@features/workflow/lib/workflow-storage-helpers";
 import { WORKFLOW_GALLERY_CARD_ASPECT_CLASSNAME } from "./workflow-card-size";
@@ -37,6 +40,7 @@ const getWorkflowTemplateAvatar = (workflow: Workflow): string | undefined => {
 interface WorkflowCardProps {
   workflow: Workflow;
   isTemplate: boolean;
+  teamSlug?: string;
   workspaceLabel: string;
   onOpenWorkflow: (workflowId: string) => void;
   onUseTemplate: (workflowId: string) => void;
@@ -50,6 +54,7 @@ interface WorkflowCardProps {
 export const WorkflowCard = ({
   workflow,
   isTemplate,
+  teamSlug,
   workspaceLabel,
   onOpenWorkflow,
   onUseTemplate,
@@ -62,8 +67,24 @@ export const WorkflowCard = ({
   const candidateBadge = isTemplate
     ? getCandidateBadgeDefinition(workflow.id)
     : undefined;
+  const templateId = !isTemplate
+    ? workflow.versions?.at(-1)?.templateId
+    : undefined;
+  const templateBadge = !isTemplate
+    ? (templateId
+        ? getCandidateBadgeDefinition(templateId)
+        : workflow.handle
+          ? getCandidateBadgeByHandle(workflow.handle)
+          : undefined)
+    : undefined;
+  const displayBadge = candidateBadge ?? templateBadge;
   const headerLabel = isTemplate ? "Candidate" : workspaceLabel;
-  const workflowSlug = workflow.handle ?? workflow.id;
+  const rawHandle = workflow.handle ?? workflow.id;
+  const workflowSlug = isTemplate
+    ? rawHandle.replace(/^template-/, "").replace(/_/g, "-")
+    : rawHandle;
+  const displayHandle =
+    !isTemplate && teamSlug ? `${teamSlug}/${workflowSlug}` : workflowSlug;
   const avatarUrl = resolveAvatarUrl(
     workflow.avatarEmoji ?? getWorkflowTemplateAvatar(workflow),
     workflow.id,
@@ -271,15 +292,15 @@ export const WorkflowCard = ({
           </div>
 
           <div className="mt-1 shrink-0 font-mono text-[10px] tracking-[0.04em] text-muted-foreground">
-            @{workflowSlug}
+            @{displayHandle}
           </div>
 
           <div className="mt-3 flex min-h-0 w-full flex-1 flex-col items-center justify-start">
             <div className="h-px w-8 rounded-full bg-border/80" />
 
-            {candidateBadge?.subtitle ? (
+            {displayBadge?.subtitle ? (
               <div className="mt-1 shrink-0 font-mono text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
-                {candidateBadge.subtitle}
+                {displayBadge.subtitle}
               </div>
             ) : null}
 

--- a/apps/studio/src/features/workflow/pages/workflow-gallery/workflow-gallery-tabs.test.tsx
+++ b/apps/studio/src/features/workflow/pages/workflow-gallery/workflow-gallery-tabs.test.tsx
@@ -101,4 +101,84 @@ describe("WorkflowGalleryTabs", () => {
     expect(screen.getByRole("tab", { name: /candidates 20/i })).toBeTruthy();
     expect(screen.getByPlaceholderText(/search colleagues/i)).toBeTruthy();
   });
+
+  it("groups colleagues into collapsible team sections", async () => {
+    const baseWorkflow = {
+      name: "Colleague",
+      description: "",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      owner: { id: "owner-1", name: "Owner", avatar: "" },
+      tags: [],
+      nodes: [],
+      edges: [],
+    };
+    renderTabs(
+      <WorkflowGalleryTabs
+        selectedTab="all"
+        onSelectedTabChange={vi.fn()}
+        isLoading={false}
+        sortedWorkflows={[
+          { ...baseWorkflow, id: "wf-1", teamId: "team-default" },
+          { ...baseWorkflow, id: "wf-2", teamId: "team-sales" },
+        ]}
+        tabCounts={{ all: 2, pinned: 0, templates: 0 }}
+        isTemplateView={false}
+        teams={[
+          { id: "team-default", slug: "acme", name: "Acme", is_default: true },
+          { id: "team-sales", slug: "sales", name: "Sales", is_default: false },
+        ]}
+        workspaceLabel="Acme"
+        searchQuery=""
+        onSearchQueryChange={vi.fn()}
+        onImportStarterPack={vi.fn()}
+        onOpenWorkflow={vi.fn()}
+        onUseTemplate={vi.fn()}
+        onExportWorkflow={vi.fn()}
+        onDeleteWorkflow={vi.fn()}
+      />,
+    );
+
+    const acmeHeader = screen.getByRole("button", { name: /Acme 1/i });
+    const salesHeader = screen.getByRole("button", { name: /Sales 1/i });
+    expect(acmeHeader).toBeTruthy();
+    expect(salesHeader).toBeTruthy();
+    expect(screen.getAllByTestId("workflow-card")).toHaveLength(2);
+
+    // Collapsing a section hides its cards.
+    const { default: userEvent } = await import("@testing-library/user-event");
+    const user = userEvent.setup();
+    await user.click(acmeHeader);
+    expect(screen.getAllByTestId("workflow-card")).toHaveLength(1);
+  });
+
+  it("shows empty team sections with no cards inside", () => {
+    renderTabs(
+      <WorkflowGalleryTabs
+        selectedTab="all"
+        onSelectedTabChange={vi.fn()}
+        isLoading={false}
+        sortedWorkflows={[]}
+        tabCounts={{ all: 0, pinned: 0, templates: 0 }}
+        isTemplateView={false}
+        teams={[
+          { id: "team-default", slug: "acme", name: "Acme", is_default: true },
+          { id: "team-eng", slug: "engineering", name: "Engineering", is_default: false },
+        ]}
+        workspaceLabel="Acme"
+        searchQuery=""
+        onSearchQueryChange={vi.fn()}
+        onImportStarterPack={vi.fn()}
+        onOpenWorkflow={vi.fn()}
+        onUseTemplate={vi.fn()}
+        onExportWorkflow={vi.fn()}
+        onDeleteWorkflow={vi.fn()}
+      />,
+    );
+
+    // Both sections are rendered even though there are no workflows.
+    expect(screen.getByRole("button", { name: /Acme 0/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Engineering 0/i })).toBeTruthy();
+    expect(screen.queryByTestId("workflow-card")).toBeNull();
+  });
 });

--- a/apps/studio/src/features/workflow/pages/workflow-gallery/workflow-gallery-tabs.tsx
+++ b/apps/studio/src/features/workflow/pages/workflow-gallery/workflow-gallery-tabs.tsx
@@ -7,7 +7,7 @@ import {
   TabsList,
   TabsTrigger,
 } from "@/design-system/ui/tabs";
-import { Loader2, Plus, Search, Upload, Zap } from "lucide-react";
+import { Loader2, Search, Upload, Zap } from "lucide-react";
 import { type Workflow } from "@features/workflow/data/workflow-data";
 import { type ApiTeam } from "@features/workflow/lib/workflow-storage-api";
 import { UploadWorkflowDialog } from "@features/workflow/components/dialogs/upload-workflow-dialog";
@@ -27,18 +27,18 @@ interface WorkflowGalleryTabsProps {
   tabCounts: WorkflowGalleryTabCounts;
   isTemplateView: boolean;
   teams?: ApiTeam[];
-  onCreateTeam?: () => void;
   workspaceLabel: string;
   searchQuery: string;
   onSearchQueryChange: (value: string) => void;
   onImportStarterPack: () => void;
-  onOpenWorkflow: (workflowId: string) => void;
+  onOpenWorkflow: (workflowId: string, teamSlug?: string) => void;
   onUseTemplate: (workflowId: string) => void;
   onExportWorkflow: (workflow: Workflow) => void;
   onDeleteWorkflow: (
     workflowId: string,
     workflowName: string,
   ) => Promise<void> | void;
+  onDeleteTeam?: (teamId: string) => void;
 }
 
 export const WorkflowGalleryTabs = ({
@@ -49,7 +49,6 @@ export const WorkflowGalleryTabs = ({
   tabCounts,
   isTemplateView,
   teams = [],
-  onCreateTeam,
   workspaceLabel,
   searchQuery,
   onSearchQueryChange,
@@ -58,6 +57,7 @@ export const WorkflowGalleryTabs = ({
   onUseTemplate,
   onExportWorkflow,
   onDeleteWorkflow,
+  onDeleteTeam,
 }: WorkflowGalleryTabsProps) => {
   const [isUploadOpen, setIsUploadOpen] = useState(false);
   const uploadsAllowed = useUploadsAllowed();
@@ -66,7 +66,7 @@ export const WorkflowGalleryTabs = ({
     onSearchQueryChange(event.target.value);
   };
 
-  const renderGrid = (items: Workflow[]) => (
+  const renderGrid = (items: Workflow[], teamSlug?: string) => (
     <div className="grid grid-cols-1 gap-3 pb-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
       {items.map((workflow) => (
         <WorkflowCard
@@ -74,7 +74,7 @@ export const WorkflowGalleryTabs = ({
           workflow={workflow}
           isTemplate={isTemplateView}
           workspaceLabel={workspaceLabel}
-          onOpenWorkflow={onOpenWorkflow}
+          onOpenWorkflow={(id) => onOpenWorkflow(id, teamSlug)}
           onUseTemplate={onUseTemplate}
           onExportWorkflow={onExportWorkflow}
           onDeleteWorkflow={onDeleteWorkflow}
@@ -112,9 +112,15 @@ export const WorkflowGalleryTabs = ({
       (key) => key !== "__none__" && !teams.some((t) => t.id === key),
     );
     const sections = [
-      ...teams.map((team) => ({ key: team.id, name: team.name })),
-      ...leftovers.map((key) => ({ key, name: "Other" })),
-      ...(byTeam.has("__none__") ? [{ key: "__none__", name: "Ungrouped" }] : []),
+      ...teams.map((team) => ({
+        key: team.id,
+        name: team.name,
+        slug: team.slug,
+      })),
+      ...leftovers.map((key) => ({ key, name: "Other", slug: undefined })),
+      ...(byTeam.has("__none__")
+        ? [{ key: "__none__", name: "Ungrouped", slug: undefined }]
+        : []),
     ];
 
     return (
@@ -126,8 +132,13 @@ export const WorkflowGalleryTabs = ({
               key={section.key}
               name={section.name}
               count={items.length}
+              onRemove={
+                onDeleteTeam && section.slug !== undefined
+                  ? () => onDeleteTeam(section.key)
+                  : undefined
+              }
             >
-              {items.length > 0 ? renderGrid(items) : null}
+              {items.length > 0 ? renderGrid(items, section.slug) : null}
             </TeamSection>
           );
         })}
@@ -176,30 +187,22 @@ export const WorkflowGalleryTabs = ({
             />
           </div>
         </div>
-        <div className="flex items-center gap-2">
-          {!isTemplateView && onCreateTeam ? (
-            <Button variant="outline" size="sm" onClick={onCreateTeam}>
-              <Plus className="mr-2 h-4 w-4" />
-              New team
+        {uploadsAllowed === true && (
+          <>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setIsUploadOpen(true)}
+            >
+              <Upload className="mr-2 h-4 w-4" />
+              Upload
             </Button>
-          ) : null}
-          {uploadsAllowed === true && (
-            <>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setIsUploadOpen(true)}
-              >
-                <Upload className="mr-2 h-4 w-4" />
-                Upload
-              </Button>
-              <UploadWorkflowDialog
-                open={isUploadOpen}
-                onOpenChange={setIsUploadOpen}
-              />
-            </>
-          )}
-        </div>
+            <UploadWorkflowDialog
+              open={isUploadOpen}
+              onOpenChange={setIsUploadOpen}
+            />
+          </>
+        )}
       </div>
 
       <TabsContent value={selectedTab} className="mt-0">
@@ -215,7 +218,8 @@ export const WorkflowGalleryTabs = ({
               </p>
             </div>
           </div>
-        ) : sortedWorkflows.length === 0 && (isTemplateView || teams.length === 0) ? (
+        ) : sortedWorkflows.length === 0 &&
+          (isTemplateView || teams.length === 0) ? (
           <div className="flex flex-col items-center justify-center py-12 text-center">
             <div className="mb-4 rounded-full bg-muted p-4">
               <Zap className="h-8 w-8 text-muted-foreground" />

--- a/apps/studio/src/features/workflow/pages/workflow-gallery/workflow-gallery-tabs.tsx
+++ b/apps/studio/src/features/workflow/pages/workflow-gallery/workflow-gallery-tabs.tsx
@@ -73,6 +73,7 @@ export const WorkflowGalleryTabs = ({
           key={workflow.id}
           workflow={workflow}
           isTemplate={isTemplateView}
+          teamSlug={teamSlug}
           workspaceLabel={workspaceLabel}
           onOpenWorkflow={(id) => onOpenWorkflow(id, teamSlug)}
           onUseTemplate={onUseTemplate}

--- a/apps/studio/src/features/workflow/pages/workflow-gallery/workflow-gallery-tabs.tsx
+++ b/apps/studio/src/features/workflow/pages/workflow-gallery/workflow-gallery-tabs.tsx
@@ -7,11 +7,13 @@ import {
   TabsList,
   TabsTrigger,
 } from "@/design-system/ui/tabs";
-import { Loader2, Search, Upload, Zap } from "lucide-react";
+import { Loader2, Plus, Search, Upload, Zap } from "lucide-react";
 import { type Workflow } from "@features/workflow/data/workflow-data";
+import { type ApiTeam } from "@features/workflow/lib/workflow-storage-api";
 import { UploadWorkflowDialog } from "@features/workflow/components/dialogs/upload-workflow-dialog";
 import { useUploadsAllowed } from "@/hooks/use-uploads-allowed";
 import { WorkflowCard } from "./workflow-card";
+import { TeamSection } from "./team-section";
 import {
   type WorkflowGalleryTab,
   type WorkflowGalleryTabCounts,
@@ -24,6 +26,8 @@ interface WorkflowGalleryTabsProps {
   sortedWorkflows: Workflow[];
   tabCounts: WorkflowGalleryTabCounts;
   isTemplateView: boolean;
+  teams?: ApiTeam[];
+  onCreateTeam?: () => void;
   workspaceLabel: string;
   searchQuery: string;
   onSearchQueryChange: (value: string) => void;
@@ -44,6 +48,8 @@ export const WorkflowGalleryTabs = ({
   sortedWorkflows,
   tabCounts,
   isTemplateView,
+  teams = [],
+  onCreateTeam,
   workspaceLabel,
   searchQuery,
   onSearchQueryChange,
@@ -58,6 +64,75 @@ export const WorkflowGalleryTabs = ({
 
   const handleSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
     onSearchQueryChange(event.target.value);
+  };
+
+  const renderGrid = (items: Workflow[]) => (
+    <div className="grid grid-cols-1 gap-3 pb-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
+      {items.map((workflow) => (
+        <WorkflowCard
+          key={workflow.id}
+          workflow={workflow}
+          isTemplate={isTemplateView}
+          workspaceLabel={workspaceLabel}
+          onOpenWorkflow={onOpenWorkflow}
+          onUseTemplate={onUseTemplate}
+          onExportWorkflow={onExportWorkflow}
+          onDeleteWorkflow={onDeleteWorkflow}
+        />
+      ))}
+    </div>
+  );
+
+  // Group colleagues into vertical, collapsible team sections. Candidate
+  // (template) view stays flat since candidates are not yet assigned a team.
+  const renderColleagues = () => {
+    if (isTemplateView) {
+      return renderGrid(sortedWorkflows);
+    }
+
+    // No teams yet — fall back to flat grid (e.g. during first load).
+    if (teams.length === 0) {
+      return renderGrid(sortedWorkflows);
+    }
+
+    const byTeam = new Map<string, Workflow[]>();
+    for (const workflow of sortedWorkflows) {
+      const key = workflow.teamId ?? "__none__";
+      const bucket = byTeam.get(key);
+      if (bucket) {
+        bucket.push(workflow);
+      } else {
+        byTeam.set(key, [workflow]);
+      }
+    }
+
+    // All known teams, in default-first order from the server, then any
+    // orphaned workflows whose team no longer appears in the list.
+    const leftovers = [...byTeam.keys()].filter(
+      (key) => key !== "__none__" && !teams.some((t) => t.id === key),
+    );
+    const sections = [
+      ...teams.map((team) => ({ key: team.id, name: team.name })),
+      ...leftovers.map((key) => ({ key, name: "Other" })),
+      ...(byTeam.has("__none__") ? [{ key: "__none__", name: "Ungrouped" }] : []),
+    ];
+
+    return (
+      <div className="flex flex-col gap-1 pb-6">
+        {sections.map((section) => {
+          const items = byTeam.get(section.key) ?? [];
+          return (
+            <TeamSection
+              key={section.key}
+              name={section.name}
+              count={items.length}
+            >
+              {items.length > 0 ? renderGrid(items) : null}
+            </TeamSection>
+          );
+        })}
+      </div>
+    );
   };
 
   return (
@@ -101,22 +176,30 @@ export const WorkflowGalleryTabs = ({
             />
           </div>
         </div>
-        {uploadsAllowed === true && (
-          <>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setIsUploadOpen(true)}
-            >
-              <Upload className="mr-2 h-4 w-4" />
-              Upload
+        <div className="flex items-center gap-2">
+          {!isTemplateView && onCreateTeam ? (
+            <Button variant="outline" size="sm" onClick={onCreateTeam}>
+              <Plus className="mr-2 h-4 w-4" />
+              New team
             </Button>
-            <UploadWorkflowDialog
-              open={isUploadOpen}
-              onOpenChange={setIsUploadOpen}
-            />
-          </>
-        )}
+          ) : null}
+          {uploadsAllowed === true && (
+            <>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setIsUploadOpen(true)}
+              >
+                <Upload className="mr-2 h-4 w-4" />
+                Upload
+              </Button>
+              <UploadWorkflowDialog
+                open={isUploadOpen}
+                onOpenChange={setIsUploadOpen}
+              />
+            </>
+          )}
+        </div>
       </div>
 
       <TabsContent value={selectedTab} className="mt-0">
@@ -132,7 +215,7 @@ export const WorkflowGalleryTabs = ({
               </p>
             </div>
           </div>
-        ) : sortedWorkflows.length === 0 ? (
+        ) : sortedWorkflows.length === 0 && (isTemplateView || teams.length === 0) ? (
           <div className="flex flex-col items-center justify-center py-12 text-center">
             <div className="mb-4 rounded-full bg-muted p-4">
               <Zap className="h-8 w-8 text-muted-foreground" />
@@ -152,20 +235,7 @@ export const WorkflowGalleryTabs = ({
             </div>
           </div>
         ) : (
-          <div className="grid grid-cols-1 gap-3 pb-6 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
-            {sortedWorkflows.map((workflow) => (
-              <WorkflowCard
-                key={workflow.id}
-                workflow={workflow}
-                isTemplate={isTemplateView}
-                workspaceLabel={workspaceLabel}
-                onOpenWorkflow={onOpenWorkflow}
-                onUseTemplate={onUseTemplate}
-                onExportWorkflow={onExportWorkflow}
-                onDeleteWorkflow={onDeleteWorkflow}
-              />
-            ))}
-          </div>
+          renderColleagues()
         )}
       </TabsContent>
     </Tabs>

--- a/apps/studio/src/lib/api.test.ts
+++ b/apps/studio/src/lib/api.test.ts
@@ -277,6 +277,22 @@ describe("executeNode", () => {
     await expect(listWorkspaceMembers("acme")).rejects.toThrow("Forbidden");
   });
 
+  it("should extract message from structured error detail", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      status: 409,
+      json: async () => ({
+        detail: {
+          error: { code: "workspace.slug_conflict", message: "Workspace slug already exists: acme" },
+        },
+      }),
+    });
+
+    await expect(createWorkspace({ slug: "acme", name: "Acme" })).rejects.toThrow(
+      "Workspace slug already exists: acme",
+    );
+  });
+
   it("should add a workspace member", async () => {
     const mockMember = {
       id: "membership-2",

--- a/apps/studio/src/lib/api.ts
+++ b/apps/studio/src/lib/api.ts
@@ -244,7 +244,19 @@ async function requestSystemJson<T>(
     const errorData = await response.json().catch(() => ({
       detail: "Failed to complete request",
     }));
-    throw new Error(errorData.detail || `HTTP ${response.status}`);
+    const detail = errorData.detail;
+    let message: string;
+    if (typeof detail === "string") {
+      message = detail;
+    } else if (detail && typeof detail === "object" && "error" in detail) {
+      const err = detail.error as Record<string, unknown>;
+      message = typeof err.message === "string" ? err.message : `HTTP ${response.status}`;
+    } else if (Array.isArray(detail)) {
+      message = detail.map((e: Record<string, unknown>) => e.msg ?? JSON.stringify(e)).join("; ");
+    } else {
+      message = `HTTP ${response.status}`;
+    }
+    throw new Error(message);
   }
 
   return response.json();

--- a/apps/studio/src/lib/workspace-routing.ts
+++ b/apps/studio/src/lib/workspace-routing.ts
@@ -53,6 +53,21 @@ export const getWorkspaceWorkflowPath = (
   return slug ? `/${slug}/${ref}` : `/${ref}`;
 };
 
+export const getWorkspaceTeamWorkflowPath = (
+  workspaceSlug: string | null | undefined,
+  teamSlug: string,
+  workflowRef: string,
+): string => {
+  const slug = trimPathSegment(workspaceSlug);
+  const ref = workflowRef.trim();
+  if (!ref) {
+    return getWorkspaceGalleryPath(slug);
+  }
+  return slug
+    ? `/${slug}/team/${teamSlug}/${ref}`
+    : `/team/${teamSlug}/${ref}`;
+};
+
 export const getWorkspaceSlugFromPathname = (
   pathname: string,
 ): string | null => {

--- a/apps/studio/src/main.tsx
+++ b/apps/studio/src/main.tsx
@@ -3,7 +3,14 @@ import * as ReactDOM from "react-dom";
 import { createRoot } from "react-dom/client";
 import App from "./App";
 import "./index.css";
+import { buildBackendHttpUrl } from "./lib/config";
 import { initializeTheme, watchSystemTheme } from "./lib/theme";
+
+const chatkitScript = document.createElement("script");
+chatkitScript.src = buildBackendHttpUrl("/api/chatkit/assets/chatkit.js");
+chatkitScript.async = true;
+chatkitScript.crossOrigin = "anonymous";
+document.head.appendChild(chatkitScript);
 
 // Initialize theme before React renders to prevent flash of wrong theme
 initializeTheme();

--- a/deploy/stack/chatkit_widgets/Bounded number input.widget
+++ b/deploy/stack/chatkit_widgets/Bounded number input.widget
@@ -1,0 +1,95 @@
+{
+  "version": "1.0",
+  "name": "Bounded number input",
+  "template": "{\"type\":\"Card\",\"size\":\"sm\",\"asForm\":true,\"confirm\":{\"label\":\"Save\",\"action\":{\"type\":{{ (submitActionType) | tojson }}}},\"cancel\":{\"label\":\"Clear\",\"action\":{\"type\":{{ (clearActionType) | tojson }}}},\"children\":[{\"type\":\"Col\",\"gap\":2,\"children\":[{\"type\":\"Label\",\"value\":{{ (label) | tojson }},\"fieldName\":{{ (fieldName) | tojson }}},{\"type\":\"Input\",\"name\":{{ (fieldName) | tojson }},\"inputType\":\"number\",\"defaultValue\":{{ (defaultValue) | tojson }},\"placeholder\":{{ (hint) | tojson }},\"required\":true,\"pattern\":{{ (pattern) | tojson }}},{\"type\":\"Caption\",\"value\":{{ (hint) | tojson }},\"color\":\"secondary\"}]}]}",
+  "jsonSchema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "label": {
+        "type": "string"
+      },
+      "fieldName": {
+        "type": "string"
+      },
+      "min": {
+        "type": "number"
+      },
+      "max": {
+        "type": "number"
+      },
+      "defaultValue": {
+        "type": "string"
+      },
+      "pattern": {
+        "type": "string"
+      },
+      "hint": {
+        "type": "string"
+      },
+      "submitActionType": {
+        "type": "string"
+      },
+      "clearActionType": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "label",
+      "fieldName",
+      "min",
+      "max",
+      "defaultValue",
+      "pattern",
+      "hint",
+      "submitActionType",
+      "clearActionType"
+    ],
+    "additionalProperties": false
+  },
+  "outputJsonPreview": {
+    "type": "Card",
+    "size": "sm",
+    "asForm": true,
+    "confirm": {
+      "label": "Save",
+      "action": {
+        "type": "number.submit"
+      }
+    },
+    "cancel": {
+      "label": "Clear",
+      "action": {
+        "type": "number.clear"
+      }
+    },
+    "children": [
+      {
+        "type": "Col",
+        "gap": 2,
+        "children": [
+          {
+            "type": "Label",
+            "value": "Number (1–10)",
+            "fieldName": "number.value"
+          },
+          {
+            "type": "Input",
+            "name": "number.value",
+            "inputType": "number",
+            "defaultValue": "5",
+            "placeholder": "Enter an integer 1–10",
+            "required": true,
+            "pattern": "^(?:10|[1-9])$"
+          },
+          {
+            "type": "Caption",
+            "value": "Enter an integer 1–10",
+            "color": "secondary"
+          }
+        ]
+      }
+    ]
+  },
+  "encodedWidget": "eyJpZCI6Ijg4NjM4YTE4LWEwOGQtNDg4Zi1iYzlhLTkyOWMwNjdhMWQxMiIsIm5hbWUiOiJCb3VuZGVkIG51bWJlciBpbnB1dCIsInZpZXciOiI8Q2FyZFxuICBzaXplPVwic21cIlxuICBhc0Zvcm1cbiAgY29uZmlybT17eyBsYWJlbDogXCJTYXZlXCIsIGFjdGlvbjogeyB0eXBlOiBzdWJtaXRBY3Rpb25UeXBlIH0gfX1cbiAgY2FuY2VsPXt7IGxhYmVsOiBcIkNsZWFyXCIsIGFjdGlvbjogeyB0eXBlOiBjbGVhckFjdGlvblR5cGUgfSB9fVxuPlxuICA8Q29sIGdhcD17Mn0-XG4gICAgPExhYmVsIHZhbHVlPXtsYWJlbH0gZmllbGROYW1lPXtmaWVsZE5hbWV9IC8-XG4gICAgPElucHV0XG4gICAgICBuYW1lPXtmaWVsZE5hbWV9XG4gICAgICBpbnB1dFR5cGU9XCJudW1iZXJcIlxuICAgICAgZGVmYXVsdFZhbHVlPXtkZWZhdWx0VmFsdWV9XG4gICAgICBwbGFjZWhvbGRlcj17aGludH1cbiAgICAgIHJlcXVpcmVkXG4gICAgICBwYXR0ZXJuPXtwYXR0ZXJufVxuICAgIC8-XG4gICAgPENhcHRpb24gdmFsdWU9e2hpbnR9IGNvbG9yPVwic2Vjb25kYXJ5XCIgLz5cbiAgPC9Db2w-XG48L0NhcmQ-IiwiZGVmYXVsdFN0YXRlIjp7ImxhYmVsIjoiTnVtYmVyICgx4oCTMTApIiwiZmllbGROYW1lIjoibnVtYmVyLnZhbHVlIiwibWluIjoxLCJtYXgiOjEwLCJkZWZhdWx0VmFsdWUiOiI1IiwicGF0dGVybiI6Il4oPzoxMHxbMS05XSkkIiwiaGludCI6IkVudGVyIGFuIGludGVnZXIgMeKAkzEwIiwic3VibWl0QWN0aW9uVHlwZSI6Im51bWJlci5zdWJtaXQiLCJjbGVhckFjdGlvblR5cGUiOiJudW1iZXIuY2xlYXIifSwic3RhdGVzIjpbXSwic2NoZW1hIjoiaW1wb3J0IHsgeiB9IGZyb20gXCJ6b2RcIlxuXG5jb25zdCBXaWRnZXRTdGF0ZSA9IHouc3RyaWN0T2JqZWN0KHtcbiAgbGFiZWw6IHouc3RyaW5nKCksXG4gIGZpZWxkTmFtZTogei5zdHJpbmcoKSxcbiAgbWluOiB6Lm51bWJlcigpLFxuICBtYXg6IHoubnVtYmVyKCksXG4gIGRlZmF1bHRWYWx1ZTogei5zdHJpbmcoKSxcbiAgcGF0dGVybjogei5zdHJpbmcoKSxcbiAgaGludDogei5zdHJpbmcoKSxcbiAgc3VibWl0QWN0aW9uVHlwZTogei5zdHJpbmcoKSxcbiAgY2xlYXJBY3Rpb25UeXBlOiB6LnN0cmluZygpLFxufSlcblxuZXhwb3J0IGRlZmF1bHQgV2lkZ2V0U3RhdGUiLCJqc29uU2NoZW1hIjp7fSwic2NoZW1hTW9kZSI6InpvZCIsInNjaGVtYVZhbGlkaXR5IjoidmFsaWQiLCJ2aWV3VmFsaWRpdHkiOiJ2YWxpZCIsImRlZmF1bHRTdGF0ZVZhbGlkaXR5IjoidmFsaWQifQ"
+}

--- a/deploy/stack/chatkit_widgets/Bounded number slider.widget
+++ b/deploy/stack/chatkit_widgets/Bounded number slider.widget
@@ -1,0 +1,161 @@
+{
+  "version": "1.0",
+  "name": "Bounded number slider",
+  "template": "{\"type\":\"Card\",\"size\":\"sm\",\"asForm\":true,\"confirm\":{\"label\":\"Set\",\"action\":{\"type\":\"slider.set\"}},\"children\":[{\"type\":\"Col\",\"gap\":3,\"children\":[{\"type\":\"Row\",\"children\":[{\"type\":\"Text\",\"value\":{{ (label) | tojson }},\"size\":\"sm\",\"color\":\"secondary\"},{\"type\":\"Spacer\"},{\"type\":\"Text\",\"value\":{{ (valueText) | tojson }},\"weight\":\"semibold\"}]},{\"type\":\"Row\",\"align\":\"center\",\"gap\":2,\"children\":[{\"type\":\"Caption\",\"value\":{{ (minLabel) | tojson }},\"color\":\"tertiary\"},{\"type\":\"Box\",\"flex\":\"auto\",\"height\":8,\"radius\":\"xl\",\"background\":\"surface-secondary\",\"children\":[{\"type\":\"Box\",\"width\":{{ (percent) | tojson }},\"height\":\"100%\",\"radius\":\"xl\",\"background\":\"blue-500\"}]},{\"type\":\"Caption\",\"value\":{{ (maxLabel) | tojson }},\"color\":\"tertiary\"}]},{\"type\":\"Row\",\"gap\":2,\"children\":[{\"type\":\"Button\",\"iconStart\":\"chevron-left\",\"uniform\":true,\"onClickAction\":{\"type\":\"slider.adjust\",\"payload\":{\"delta\":{{ (stepNeg) | tojson }},\"min\":{{ (min) | tojson }},\"max\":{{ (max) | tojson }}}}},{\"type\":\"Input\",\"name\":\"slider.value\",\"inputType\":\"number\",\"defaultValue\":{{ (valueText) | tojson }},\"variant\":\"outline\"},{\"type\":\"Button\",\"iconStart\":\"chevron-right\",\"uniform\":true,\"onClickAction\":{\"type\":\"slider.adjust\",\"payload\":{\"delta\":{{ (step) | tojson }},\"min\":{{ (min) | tojson }},\"max\":{{ (max) | tojson }}}}}]}]}]}",
+  "jsonSchema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "label": {
+        "type": "string"
+      },
+      "min": {
+        "type": "number"
+      },
+      "max": {
+        "type": "number"
+      },
+      "step": {
+        "type": "number"
+      },
+      "stepNeg": {
+        "type": "number"
+      },
+      "valueText": {
+        "type": "string"
+      },
+      "minLabel": {
+        "type": "string"
+      },
+      "maxLabel": {
+        "type": "string"
+      },
+      "percent": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "label",
+      "min",
+      "max",
+      "step",
+      "stepNeg",
+      "valueText",
+      "minLabel",
+      "maxLabel",
+      "percent"
+    ],
+    "additionalProperties": false
+  },
+  "outputJsonPreview": {
+    "type": "Card",
+    "size": "sm",
+    "asForm": true,
+    "confirm": {
+      "label": "Set",
+      "action": {
+        "type": "slider.set"
+      }
+    },
+    "children": [
+      {
+        "type": "Col",
+        "gap": 3,
+        "children": [
+          {
+            "type": "Row",
+            "children": [
+              {
+                "type": "Text",
+                "value": "Select a number",
+                "size": "sm",
+                "color": "secondary"
+              },
+              {
+                "type": "Spacer"
+              },
+              {
+                "type": "Text",
+                "value": "50",
+                "weight": "semibold"
+              }
+            ]
+          },
+          {
+            "type": "Row",
+            "align": "center",
+            "gap": 2,
+            "children": [
+              {
+                "type": "Caption",
+                "value": "0",
+                "color": "tertiary"
+              },
+              {
+                "type": "Box",
+                "flex": "auto",
+                "height": 8,
+                "radius": "xl",
+                "background": "surface-secondary",
+                "children": [
+                  {
+                    "type": "Box",
+                    "width": "50%",
+                    "height": "100%",
+                    "radius": "xl",
+                    "background": "blue-500"
+                  }
+                ]
+              },
+              {
+                "type": "Caption",
+                "value": "100",
+                "color": "tertiary"
+              }
+            ]
+          },
+          {
+            "type": "Row",
+            "gap": 2,
+            "children": [
+              {
+                "type": "Button",
+                "iconStart": "chevron-left",
+                "uniform": true,
+                "onClickAction": {
+                  "type": "slider.adjust",
+                  "payload": {
+                    "delta": -5,
+                    "min": 0,
+                    "max": 100
+                  }
+                }
+              },
+              {
+                "type": "Input",
+                "name": "slider.value",
+                "inputType": "number",
+                "defaultValue": "50",
+                "variant": "outline"
+              },
+              {
+                "type": "Button",
+                "iconStart": "chevron-right",
+                "uniform": true,
+                "onClickAction": {
+                  "type": "slider.adjust",
+                  "payload": {
+                    "delta": 5,
+                    "min": 0,
+                    "max": 100
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "encodedWidget": "eyJpZCI6IjliMGViYTUzLTA5NDAtNDc4NC05OTcyLTE0NTQ5NmYwZmQ1YiIsIm5hbWUiOiJCb3VuZGVkIG51bWJlciBzbGlkZXIiLCJ2aWV3IjoiPENhcmRcbiAgc2l6ZT1cInNtXCJcbiAgYXNGb3JtXG4gIGNvbmZpcm09e3sgbGFiZWw6IFwiU2V0XCIsIGFjdGlvbjogeyB0eXBlOiBcInNsaWRlci5zZXRcIiB9IH19XG4-XG4gIDxDb2wgZ2FwPXszfT5cbiAgICA8Um93PlxuICAgICAgPFRleHQgdmFsdWU9e2xhYmVsfSBzaXplPVwic21cIiBjb2xvcj1cInNlY29uZGFyeVwiIC8-XG4gICAgICA8U3BhY2VyIC8-XG4gICAgICA8VGV4dCB2YWx1ZT17dmFsdWVUZXh0fSB3ZWlnaHQ9XCJzZW1pYm9sZFwiIC8-XG4gICAgPC9Sb3c-XG5cbiAgICA8Um93IGFsaWduPVwiY2VudGVyXCIgZ2FwPXsyfT5cbiAgICAgIDxDYXB0aW9uIHZhbHVlPXttaW5MYWJlbH0gY29sb3I9XCJ0ZXJ0aWFyeVwiIC8-XG4gICAgICA8Qm94IGZsZXg9XCJhdXRvXCIgaGVpZ2h0PXs4fSByYWRpdXM9XCJ4bFwiIGJhY2tncm91bmQ9XCJzdXJmYWNlLXNlY29uZGFyeVwiPlxuICAgICAgICA8Qm94IHdpZHRoPXtwZXJjZW50fSBoZWlnaHQ9XCIxMDAlXCIgcmFkaXVzPVwieGxcIiBiYWNrZ3JvdW5kPVwiYmx1ZS01MDBcIiAvPlxuICAgICAgPC9Cb3g-XG4gICAgICA8Q2FwdGlvbiB2YWx1ZT17bWF4TGFiZWx9IGNvbG9yPVwidGVydGlhcnlcIiAvPlxuICAgIDwvUm93PlxuXG4gICAgPFJvdyBnYXA9ezJ9PlxuICAgICAgPEJ1dHRvblxuICAgICAgICBpY29uU3RhcnQ9XCJjaGV2cm9uLWxlZnRcIlxuICAgICAgICB1bmlmb3JtXG4gICAgICAgIG9uQ2xpY2tBY3Rpb249e3tcbiAgICAgICAgICB0eXBlOiBcInNsaWRlci5hZGp1c3RcIixcbiAgICAgICAgICBwYXlsb2FkOiB7IGRlbHRhOiBzdGVwTmVnLCBtaW4sIG1heCB9LFxuICAgICAgICB9fVxuICAgICAgLz5cbiAgICAgIDxJbnB1dFxuICAgICAgICBuYW1lPVwic2xpZGVyLnZhbHVlXCJcbiAgICAgICAgaW5wdXRUeXBlPVwibnVtYmVyXCJcbiAgICAgICAgZGVmYXVsdFZhbHVlPXt2YWx1ZVRleHR9XG4gICAgICAgIHZhcmlhbnQ9XCJvdXRsaW5lXCJcbiAgICAgIC8-XG4gICAgICA8QnV0dG9uXG4gICAgICAgIGljb25TdGFydD1cImNoZXZyb24tcmlnaHRcIlxuICAgICAgICB1bmlmb3JtXG4gICAgICAgIG9uQ2xpY2tBY3Rpb249e3tcbiAgICAgICAgICB0eXBlOiBcInNsaWRlci5hZGp1c3RcIixcbiAgICAgICAgICBwYXlsb2FkOiB7IGRlbHRhOiBzdGVwLCBtaW4sIG1heCB9LFxuICAgICAgICB9fVxuICAgICAgLz5cbiAgICA8L1Jvdz5cbiAgPC9Db2w-XG48L0NhcmQ-IiwiZGVmYXVsdFN0YXRlIjp7ImxhYmVsIjoiU2VsZWN0IGEgbnVtYmVyIiwibWluIjowLCJtYXgiOjEwMCwic3RlcCI6NSwic3RlcE5lZyI6LTUsInZhbHVlVGV4dCI6IjUwIiwibWluTGFiZWwiOiIwIiwibWF4TGFiZWwiOiIxMDAiLCJwZXJjZW50IjoiNTAlIn0sInN0YXRlcyI6W10sInNjaGVtYSI6ImltcG9ydCB7IHogfSBmcm9tIFwiem9kXCJcblxuY29uc3QgV2lkZ2V0U3RhdGUgPSB6LnN0cmljdE9iamVjdCh7XG4gIGxhYmVsOiB6LnN0cmluZygpLFxuICBtaW46IHoubnVtYmVyKCksXG4gIG1heDogei5udW1iZXIoKSxcbiAgc3RlcDogei5udW1iZXIoKSxcbiAgc3RlcE5lZzogei5udW1iZXIoKSxcbiAgdmFsdWVUZXh0OiB6LnN0cmluZygpLFxuICBtaW5MYWJlbDogei5zdHJpbmcoKSxcbiAgbWF4TGFiZWw6IHouc3RyaW5nKCksXG4gIHBlcmNlbnQ6IHouc3RyaW5nKCksXG59KVxuXG5leHBvcnQgZGVmYXVsdCBXaWRnZXRTdGF0ZSIsImpzb25TY2hlbWEiOnt9LCJzY2hlbWFNb2RlIjoiem9kIiwic2NoZW1hVmFsaWRpdHkiOiJ2YWxpZCIsInZpZXdWYWxpZGl0eSI6InZhbGlkIiwiZGVmYXVsdFN0YXRlVmFsaWRpdHkiOiJ2YWxpZCJ9"
+}

--- a/deploy/stack/chatkit_widgets/Conjoint - 3 concepts.widget
+++ b/deploy/stack/chatkit_widgets/Conjoint - 3 concepts.widget
@@ -1,0 +1,477 @@
+{
+  "version": "1.0",
+  "name": "Conjoint – 3 concepts",
+  "template": "{\"type\":\"Card\",\"size\":\"md\",\"asForm\":true,\"confirm\":{\"label\":\"Submit\",\"action\":{\"type\":\"conjoint.submit\"}},\"cancel\":{\"label\":\"Clear\",\"action\":{\"type\":\"conjoint.clear\"}},\"children\":[{\"type\":\"Col\",\"gap\":3,\"children\":[{\"type\":\"Title\",\"value\":{{ (title) | tojson }},\"size\":\"sm\"},{\"type\":\"Row\",\"align\":\"stretch\",\"gap\":3,\"children\":[{%- set _c -%}{%-for c in concepts -%},{\"type\":\"Col\",\"key\":{{ (c.id) | tojson }},\"gap\":2,\"padding\":3,\"border\":{\"size\":1},\"radius\":\"lg\",\"background\":\"surface-secondary\",\"flex\":1,\"children\":[{%- set _c -%},{\"type\":\"Row\",\"gap\":2,\"align\":\"center\",\"children\":[{\"type\":\"Box\",\"width\":4,\"height\":4,\"radius\":\"full\",\"background\":{{ (c.accent) | tojson }}},{\"type\":\"Title\",\"value\":{{ (c.name) | tojson }},\"size\":\"sm\"},{\"type\":\"Spacer\"}]},{\"type\":\"Row\",\"gap\":2,\"align\":\"center\",\"children\":[{\"type\":\"Badge\",\"label\":{{ (c.price) | tojson }}}]}{%-for attr in c.attributes -%}{%-set idx = loop.index0 -%},{\"type\":\"Row\",\"key\":{{ (idx) | tojson }},\"gap\":2,\"align\":\"center\",\"children\":[{\"type\":\"Icon\",\"name\":\"check-circle\",\"color\":{{ (c.accent) | tojson }},\"size\":\"sm\"},{\"type\":\"Text\",\"value\":{{ (attr) | tojson }},\"size\":\"sm\"}]}{%-endfor-%}{%- endset -%}{{- (_c[1:] if _c and _c[0] == ',' else _c) -}}]}{%-endfor-%}{%- endset -%}{{- (_c[1:] if _c and _c[0] == ',' else _c) -}}]},{\"type\":\"Divider\"},{\"type\":\"Row\",\"align\":\"center\",\"gap\":3,\"children\":[{\"type\":\"Label\",\"value\":\"Your pick\",\"fieldName\":\"choice\"},{\"type\":\"Spacer\"},{\"type\":\"RadioGroup\",\"name\":\"choice\",\"options\":{{ (options) | tojson }},\"direction\":\"row\",\"required\":true}]}]}]}",
+  "jsonSchema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "title": {
+        "type": "string"
+      },
+      "concepts": {
+        "minItems": 3,
+        "maxItems": 3,
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "price": {
+              "type": "string"
+            },
+            "accent": {
+              "type": "string",
+              "enum": [
+                "blue",
+                "green",
+                "purple",
+                "orange",
+                "red"
+              ]
+            },
+            "attributes": {
+              "minItems": 1,
+              "maxItems": 5,
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "required": [
+            "id",
+            "name",
+            "price",
+            "accent",
+            "attributes"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "options": {
+        "minItems": 3,
+        "maxItems": 3,
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "label": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            },
+            "disabled": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "label",
+            "value"
+          ],
+          "additionalProperties": false
+        }
+      }
+    },
+    "required": [
+      "title",
+      "concepts",
+      "options"
+    ],
+    "additionalProperties": false
+  },
+  "outputJsonPreview": {
+    "type": "Card",
+    "size": "md",
+    "asForm": true,
+    "confirm": {
+      "label": "Submit",
+      "action": {
+        "type": "conjoint.submit"
+      }
+    },
+    "cancel": {
+      "label": "Clear",
+      "action": {
+        "type": "conjoint.clear"
+      }
+    },
+    "children": [
+      {
+        "type": "Col",
+        "gap": 3,
+        "children": [
+          {
+            "type": "Title",
+            "value": "Conjoint: pick a concept",
+            "size": "sm"
+          },
+          {
+            "type": "Row",
+            "align": "stretch",
+            "gap": 3,
+            "children": [
+              {
+                "type": "Col",
+                "key": "A",
+                "gap": 2,
+                "padding": 3,
+                "border": {
+                  "size": 1
+                },
+                "radius": "lg",
+                "background": "surface-secondary",
+                "flex": 1,
+                "children": [
+                  {
+                    "type": "Row",
+                    "gap": 2,
+                    "align": "center",
+                    "children": [
+                      {
+                        "type": "Box",
+                        "width": 4,
+                        "height": 4,
+                        "radius": "full",
+                        "background": "blue"
+                      },
+                      {
+                        "type": "Title",
+                        "value": "Concept A",
+                        "size": "sm"
+                      },
+                      {
+                        "type": "Spacer"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "Row",
+                    "gap": 2,
+                    "align": "center",
+                    "children": [
+                      {
+                        "type": "Badge",
+                        "label": "$19"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "Row",
+                    "key": 0,
+                    "gap": 2,
+                    "align": "center",
+                    "children": [
+                      {
+                        "type": "Icon",
+                        "name": "check-circle",
+                        "color": "blue",
+                        "size": "sm"
+                      },
+                      {
+                        "type": "Text",
+                        "value": "Fast shipping",
+                        "size": "sm"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "Row",
+                    "key": 1,
+                    "gap": 2,
+                    "align": "center",
+                    "children": [
+                      {
+                        "type": "Icon",
+                        "name": "check-circle",
+                        "color": "blue",
+                        "size": "sm"
+                      },
+                      {
+                        "type": "Text",
+                        "value": "Matte finish",
+                        "size": "sm"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "Row",
+                    "key": 2,
+                    "gap": 2,
+                    "align": "center",
+                    "children": [
+                      {
+                        "type": "Icon",
+                        "name": "check-circle",
+                        "color": "blue",
+                        "size": "sm"
+                      },
+                      {
+                        "type": "Text",
+                        "value": "1-year warranty",
+                        "size": "sm"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "Col",
+                "key": "B",
+                "gap": 2,
+                "padding": 3,
+                "border": {
+                  "size": 1
+                },
+                "radius": "lg",
+                "background": "surface-secondary",
+                "flex": 1,
+                "children": [
+                  {
+                    "type": "Row",
+                    "gap": 2,
+                    "align": "center",
+                    "children": [
+                      {
+                        "type": "Box",
+                        "width": 4,
+                        "height": 4,
+                        "radius": "full",
+                        "background": "green"
+                      },
+                      {
+                        "type": "Title",
+                        "value": "Concept B",
+                        "size": "sm"
+                      },
+                      {
+                        "type": "Spacer"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "Row",
+                    "gap": 2,
+                    "align": "center",
+                    "children": [
+                      {
+                        "type": "Badge",
+                        "label": "$24"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "Row",
+                    "key": 0,
+                    "gap": 2,
+                    "align": "center",
+                    "children": [
+                      {
+                        "type": "Icon",
+                        "name": "check-circle",
+                        "color": "green",
+                        "size": "sm"
+                      },
+                      {
+                        "type": "Text",
+                        "value": "Eco materials",
+                        "size": "sm"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "Row",
+                    "key": 1,
+                    "gap": 2,
+                    "align": "center",
+                    "children": [
+                      {
+                        "type": "Icon",
+                        "name": "check-circle",
+                        "color": "green",
+                        "size": "sm"
+                      },
+                      {
+                        "type": "Text",
+                        "value": "Gloss finish",
+                        "size": "sm"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "Row",
+                    "key": 2,
+                    "gap": 2,
+                    "align": "center",
+                    "children": [
+                      {
+                        "type": "Icon",
+                        "name": "check-circle",
+                        "color": "green",
+                        "size": "sm"
+                      },
+                      {
+                        "type": "Text",
+                        "value": "2-year warranty",
+                        "size": "sm"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "Col",
+                "key": "C",
+                "gap": 2,
+                "padding": 3,
+                "border": {
+                  "size": 1
+                },
+                "radius": "lg",
+                "background": "surface-secondary",
+                "flex": 1,
+                "children": [
+                  {
+                    "type": "Row",
+                    "gap": 2,
+                    "align": "center",
+                    "children": [
+                      {
+                        "type": "Box",
+                        "width": 4,
+                        "height": 4,
+                        "radius": "full",
+                        "background": "purple"
+                      },
+                      {
+                        "type": "Title",
+                        "value": "Concept C",
+                        "size": "sm"
+                      },
+                      {
+                        "type": "Spacer"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "Row",
+                    "gap": 2,
+                    "align": "center",
+                    "children": [
+                      {
+                        "type": "Badge",
+                        "label": "$17"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "Row",
+                    "key": 0,
+                    "gap": 2,
+                    "align": "center",
+                    "children": [
+                      {
+                        "type": "Icon",
+                        "name": "check-circle",
+                        "color": "purple",
+                        "size": "sm"
+                      },
+                      {
+                        "type": "Text",
+                        "value": "Budget friendly",
+                        "size": "sm"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "Row",
+                    "key": 1,
+                    "gap": 2,
+                    "align": "center",
+                    "children": [
+                      {
+                        "type": "Icon",
+                        "name": "check-circle",
+                        "color": "purple",
+                        "size": "sm"
+                      },
+                      {
+                        "type": "Text",
+                        "value": "Matte finish",
+                        "size": "sm"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "Row",
+                    "key": 2,
+                    "gap": 2,
+                    "align": "center",
+                    "children": [
+                      {
+                        "type": "Icon",
+                        "name": "check-circle",
+                        "color": "purple",
+                        "size": "sm"
+                      },
+                      {
+                        "type": "Text",
+                        "value": "30-day returns",
+                        "size": "sm"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "Divider"
+          },
+          {
+            "type": "Row",
+            "align": "center",
+            "gap": 3,
+            "children": [
+              {
+                "type": "Label",
+                "value": "Your pick",
+                "fieldName": "choice"
+              },
+              {
+                "type": "Spacer"
+              },
+              {
+                "type": "RadioGroup",
+                "name": "choice",
+                "options": [
+                  {
+                    "label": "Concept A",
+                    "value": "A"
+                  },
+                  {
+                    "label": "Concept B",
+                    "value": "B"
+                  },
+                  {
+                    "label": "Concept C",
+                    "value": "C"
+                  }
+                ],
+                "direction": "row",
+                "required": true
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "encodedWidget": "eyJpZCI6Ijk1YjU1OWJiLTBjZjItNGE3MS04N2FhLTU5OGM1NjU4ZDAwMCIsIm5hbWUiOiJDb25qb2ludCDigJMgMyBjb25jZXB0cyIsInZpZXciOiI8Q2FyZFxuICBzaXplPVwibWRcIlxuICBhc0Zvcm1cbiAgY29uZmlybT17eyBsYWJlbDogXCJTdWJtaXRcIiwgYWN0aW9uOiB7IHR5cGU6IFwiY29uam9pbnQuc3VibWl0XCIgfSB9fVxuICBjYW5jZWw9e3sgbGFiZWw6IFwiQ2xlYXJcIiwgYWN0aW9uOiB7IHR5cGU6IFwiY29uam9pbnQuY2xlYXJcIiB9IH19XG4-XG4gIDxDb2wgZ2FwPXszfT5cbiAgICA8VGl0bGUgdmFsdWU9e3RpdGxlfSBzaXplPVwic21cIiAvPlxuXG4gICAgPFJvdyBhbGlnbj1cInN0cmV0Y2hcIiBnYXA9ezN9PlxuICAgICAge2NvbmNlcHRzLm1hcCgoYykgPT4gKFxuICAgICAgICA8Q29sXG4gICAgICAgICAga2V5PXtjLmlkfVxuICAgICAgICAgIGdhcD17Mn1cbiAgICAgICAgICBwYWRkaW5nPXszfVxuICAgICAgICAgIGJvcmRlcj17eyBzaXplOiAxIH19XG4gICAgICAgICAgcmFkaXVzPVwibGdcIlxuICAgICAgICAgIGJhY2tncm91bmQ9XCJzdXJmYWNlLXNlY29uZGFyeVwiXG4gICAgICAgICAgZmxleD17MX1cbiAgICAgICAgPlxuICAgICAgICAgIDxSb3cgZ2FwPXsyfSBhbGlnbj1cImNlbnRlclwiPlxuICAgICAgICAgICAgPEJveCB3aWR0aD17NH0gaGVpZ2h0PXs0fSByYWRpdXM9XCJmdWxsXCIgYmFja2dyb3VuZD17Yy5hY2NlbnR9IC8-XG4gICAgICAgICAgICA8VGl0bGUgdmFsdWU9e2MubmFtZX0gc2l6ZT1cInNtXCIgLz5cbiAgICAgICAgICAgIDxTcGFjZXIgLz5cbiAgICAgICAgICA8L1Jvdz5cbiAgICAgICAgICA8Um93IGdhcD17Mn0gYWxpZ249XCJjZW50ZXJcIj5cbiAgICAgICAgICAgIDxCYWRnZSBsYWJlbD17Yy5wcmljZX0gLz5cbiAgICAgICAgICA8L1Jvdz5cbiAgICAgICAgICB7Yy5hdHRyaWJ1dGVzLm1hcCgoYXR0ciwgaWR4KSA9PiAoXG4gICAgICAgICAgICA8Um93IGtleT17aWR4fSBnYXA9ezJ9IGFsaWduPVwiY2VudGVyXCI-XG4gICAgICAgICAgICAgIDxJY29uIG5hbWU9XCJjaGVjay1jaXJjbGVcIiBjb2xvcj17Yy5hY2NlbnR9IHNpemU9XCJzbVwiIC8-XG4gICAgICAgICAgICAgIDxUZXh0IHZhbHVlPXthdHRyfSBzaXplPVwic21cIiAvPlxuICAgICAgICAgICAgPC9Sb3c-XG4gICAgICAgICAgKSl9XG4gICAgICAgIDwvQ29sPlxuICAgICAgKSl9XG4gICAgPC9Sb3c-XG5cbiAgICA8RGl2aWRlciAvPlxuICAgIDxSb3cgYWxpZ249XCJjZW50ZXJcIiBnYXA9ezN9PlxuICAgICAgPExhYmVsIHZhbHVlPVwiWW91ciBwaWNrXCIgZmllbGROYW1lPVwiY2hvaWNlXCIgLz5cbiAgICAgIDxTcGFjZXIgLz5cbiAgICAgIDxSYWRpb0dyb3VwIG5hbWU9XCJjaG9pY2VcIiBvcHRpb25zPXtvcHRpb25zfSBkaXJlY3Rpb249XCJyb3dcIiByZXF1aXJlZCAvPlxuICAgIDwvUm93PlxuICA8L0NvbD5cbjwvQ2FyZD4iLCJkZWZhdWx0U3RhdGUiOnsidGl0bGUiOiJDb25qb2ludDogcGljayBhIGNvbmNlcHQiLCJjb25jZXB0cyI6W3siaWQiOiJBIiwibmFtZSI6IkNvbmNlcHQgQSIsInByaWNlIjoiJDE5IiwiYWNjZW50IjoiYmx1ZSIsImF0dHJpYnV0ZXMiOlsiRmFzdCBzaGlwcGluZyIsIk1hdHRlIGZpbmlzaCIsIjEteWVhciB3YXJyYW50eSJdfSx7ImlkIjoiQiIsIm5hbWUiOiJDb25jZXB0IEIiLCJwcmljZSI6IiQyNCIsImFjY2VudCI6ImdyZWVuIiwiYXR0cmlidXRlcyI6WyJFY28gbWF0ZXJpYWxzIiwiR2xvc3MgZmluaXNoIiwiMi15ZWFyIHdhcnJhbnR5Il19LHsiaWQiOiJDIiwibmFtZSI6IkNvbmNlcHQgQyIsInByaWNlIjoiJDE3IiwiYWNjZW50IjoicHVycGxlIiwiYXR0cmlidXRlcyI6WyJCdWRnZXQgZnJpZW5kbHkiLCJNYXR0ZSBmaW5pc2giLCIzMC1kYXkgcmV0dXJucyJdfV0sIm9wdGlvbnMiOlt7ImxhYmVsIjoiQ29uY2VwdCBBIiwidmFsdWUiOiJBIn0seyJsYWJlbCI6IkNvbmNlcHQgQiIsInZhbHVlIjoiQiJ9LHsibGFiZWwiOiJDb25jZXB0IEMiLCJ2YWx1ZSI6IkMifV19LCJzdGF0ZXMiOltdLCJzY2hlbWEiOiJpbXBvcnQgeyB6IH0gZnJvbSBcInpvZFwiXG5cbmNvbnN0IE9wdGlvbiA9IHouc3RyaWN0T2JqZWN0KHtcbiAgbGFiZWw6IHouc3RyaW5nKCksXG4gIHZhbHVlOiB6LnN0cmluZygpLFxuICBkaXNhYmxlZDogei5ib29sZWFuKCkub3B0aW9uYWwoKSxcbn0pXG5cbmNvbnN0IENvbmNlcHQgPSB6LnN0cmljdE9iamVjdCh7XG4gIGlkOiB6LnN0cmluZygpLFxuICBuYW1lOiB6LnN0cmluZygpLFxuICBwcmljZTogei5zdHJpbmcoKSxcbiAgYWNjZW50OiB6LmVudW0oW1wiYmx1ZVwiLCBcImdyZWVuXCIsIFwicHVycGxlXCIsIFwib3JhbmdlXCIsIFwicmVkXCJdKSxcbiAgYXR0cmlidXRlczogei5hcnJheSh6LnN0cmluZygpKS5taW4oMSkubWF4KDUpLFxufSlcblxuY29uc3QgV2lkZ2V0U3RhdGUgPSB6LnN0cmljdE9iamVjdCh7XG4gIHRpdGxlOiB6LnN0cmluZygpLFxuICBjb25jZXB0czogei5hcnJheShDb25jZXB0KS5sZW5ndGgoMyksXG4gIG9wdGlvbnM6IHouYXJyYXkoT3B0aW9uKS5sZW5ndGgoMyksXG59KVxuXG5leHBvcnQgZGVmYXVsdCBXaWRnZXRTdGF0ZSIsImpzb25TY2hlbWEiOnt9LCJzY2hlbWFNb2RlIjoiem9kIiwic2NoZW1hVmFsaWRpdHkiOiJ2YWxpZCIsInZpZXdWYWxpZGl0eSI6InZhbGlkIiwiZGVmYXVsdFN0YXRlVmFsaWRpdHkiOiJ2YWxpZCJ9"
+}

--- a/deploy/stack/chatkit_widgets/Conjoint Choice.widget
+++ b/deploy/stack/chatkit_widgets/Conjoint Choice.widget
@@ -1,0 +1,527 @@
+{
+  "version": "1.0",
+  "name": "Conjoint Choice",
+  "template": "{\"type\":\"Card\",\"size\":\"md\",\"children\":[{\"type\":\"Col\",\"gap\":2,\"children\":[{\"type\":\"Title\",\"value\":{{ (title) | tojson }},\"size\":\"md\"},{\"type\":\"Text\",\"value\":{{ (context) | tojson }},\"size\":\"sm\",\"color\":\"secondary\"}]},{\"type\":\"Divider\",\"flush\":true},{\"type\":\"Row\",\"gap\":3,\"align\":\"stretch\",\"children\":[{%- set _c -%}{%-for p in profiles -%},{\"type\":\"Col\",\"key\":{{ (p.key) | tojson }},\"flex\":1,\"gap\":3,\"padding\":3,\"border\":{\"size\":1},\"radius\":\"xl\",\"background\":\"surface-secondary\",\"children\":[{\"type\":\"Row\",\"gap\":2,\"align\":\"center\",\"children\":[{\"type\":\"Box\",\"size\":28,\"radius\":\"full\",\"background\":{{ (p.accent) | tojson }}},{\"type\":\"Title\",\"value\":{{ (p.heading) | tojson }},\"size\":\"sm\"},{\"type\":\"Spacer\"},{\"type\":\"Badge\",\"label\":{{ (p.key) | tojson }},\"color\":\"discovery\"}]},{\"type\":\"Col\",\"gap\":2,\"children\":[{%- set _c -%}{%-for f in p.features -%}{%-set idx = loop.index0 -%},{\"type\":\"Row\",\"key\":{{ ((p.key ~ \"-\" ~ idx)) | tojson }},\"gap\":2,\"align\":\"center\",\"children\":[{\"type\":\"Icon\",\"name\":\"check-circle\",\"color\":{{ (p.accent) | tojson }},\"size\":\"sm\"},{\"type\":\"Col\",\"gap\":0,\"children\":[{\"type\":\"Caption\",\"value\":{{ (f.name) | tojson }}},{\"type\":\"Text\",\"value\":{{ (f.value) | tojson }},\"size\":\"sm\",\"weight\":\"semibold\",\"maxLines\":1}]}]}{%-endfor-%}{%- endset -%}{{- (_c[1:] if _c and _c[0] == ',' else _c) -}}]},{\"type\":\"Divider\"},{\"type\":\"Row\",\"children\":[{\"type\":\"Badge\",\"label\":{{ (p.price) | tojson }},\"color\":\"info\",\"size\":\"md\"},{\"type\":\"Spacer\"},{\"type\":\"Button\",\"label\":{{ ((\"Choose \" ~ p.key)) | tojson }},\"style\":\"primary\",\"onClickAction\":{\"type\":\"conjoint.select\",\"payload\":{\"questionId\":{{ (questionId) | tojson }},\"choice\":{{ (p.key) | tojson }}}}}]}]}{%-endfor-%}{%- endset -%}{{- (_c[1:] if _c and _c[0] == ',' else _c) -}}]},{\"type\":\"Divider\"},{\"type\":\"Button\",\"label\":\"No preference\",\"variant\":\"outline\",\"block\":true,\"onClickAction\":{\"type\":\"conjoint.select\",\"payload\":{\"questionId\":{{ (questionId) | tojson }},\"choice\":\"tie\"}}}]}",
+  "jsonSchema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "questionId": {
+        "type": "string"
+      },
+      "title": {
+        "type": "string"
+      },
+      "context": {
+        "type": "string"
+      },
+      "profiles": {
+        "type": "array",
+        "prefixItems": [
+          {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string",
+                "enum": [
+                  "A",
+                  "B"
+                ]
+              },
+              "heading": {
+                "type": "string"
+              },
+              "accent": {
+                "type": "string",
+                "enum": [
+                  "blue",
+                  "purple",
+                  "green",
+                  "red"
+                ]
+              },
+              "price": {
+                "type": "string"
+              },
+              "features": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "value"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "key",
+              "heading",
+              "accent",
+              "price",
+              "features"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string",
+                "enum": [
+                  "A",
+                  "B"
+                ]
+              },
+              "heading": {
+                "type": "string"
+              },
+              "accent": {
+                "type": "string",
+                "enum": [
+                  "blue",
+                  "purple",
+                  "green",
+                  "red"
+                ]
+              },
+              "price": {
+                "type": "string"
+              },
+              "features": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "value"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "key",
+              "heading",
+              "accent",
+              "price",
+              "features"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "required": [
+      "questionId",
+      "title",
+      "context",
+      "profiles"
+    ],
+    "additionalProperties": false
+  },
+  "outputJsonPreview": {
+    "type": "Card",
+    "size": "md",
+    "children": [
+      {
+        "type": "Col",
+        "gap": 2,
+        "children": [
+          {
+            "type": "Title",
+            "value": "Which offer would you choose?",
+            "size": "md"
+          },
+          {
+            "type": "Text",
+            "value": "Smartphone bundle",
+            "size": "sm",
+            "color": "secondary"
+          }
+        ]
+      },
+      {
+        "type": "Divider",
+        "flush": true
+      },
+      {
+        "type": "Row",
+        "gap": 3,
+        "align": "stretch",
+        "children": [
+          {
+            "type": "Col",
+            "key": "A",
+            "flex": 1,
+            "gap": 3,
+            "padding": 3,
+            "border": {
+              "size": 1
+            },
+            "radius": "xl",
+            "background": "surface-secondary",
+            "children": [
+              {
+                "type": "Row",
+                "gap": 2,
+                "align": "center",
+                "children": [
+                  {
+                    "type": "Box",
+                    "size": 28,
+                    "radius": "full",
+                    "background": "blue"
+                  },
+                  {
+                    "type": "Title",
+                    "value": "Option A",
+                    "size": "sm"
+                  },
+                  {
+                    "type": "Spacer"
+                  },
+                  {
+                    "type": "Badge",
+                    "label": "A",
+                    "color": "discovery"
+                  }
+                ]
+              },
+              {
+                "type": "Col",
+                "gap": 2,
+                "children": [
+                  {
+                    "type": "Row",
+                    "key": "A-0",
+                    "gap": 2,
+                    "align": "center",
+                    "children": [
+                      {
+                        "type": "Icon",
+                        "name": "check-circle",
+                        "color": "blue",
+                        "size": "sm"
+                      },
+                      {
+                        "type": "Col",
+                        "gap": 0,
+                        "children": [
+                          {
+                            "type": "Caption",
+                            "value": "Storage"
+                          },
+                          {
+                            "type": "Text",
+                            "value": "256 GB",
+                            "size": "sm",
+                            "weight": "semibold",
+                            "maxLines": 1
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "Row",
+                    "key": "A-1",
+                    "gap": 2,
+                    "align": "center",
+                    "children": [
+                      {
+                        "type": "Icon",
+                        "name": "check-circle",
+                        "color": "blue",
+                        "size": "sm"
+                      },
+                      {
+                        "type": "Col",
+                        "gap": 0,
+                        "children": [
+                          {
+                            "type": "Caption",
+                            "value": "Color"
+                          },
+                          {
+                            "type": "Text",
+                            "value": "Midnight",
+                            "size": "sm",
+                            "weight": "semibold",
+                            "maxLines": 1
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "Row",
+                    "key": "A-2",
+                    "gap": 2,
+                    "align": "center",
+                    "children": [
+                      {
+                        "type": "Icon",
+                        "name": "check-circle",
+                        "color": "blue",
+                        "size": "sm"
+                      },
+                      {
+                        "type": "Col",
+                        "gap": 0,
+                        "children": [
+                          {
+                            "type": "Caption",
+                            "value": "Warranty"
+                          },
+                          {
+                            "type": "Text",
+                            "value": "1 year",
+                            "size": "sm",
+                            "weight": "semibold",
+                            "maxLines": 1
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "Divider"
+              },
+              {
+                "type": "Row",
+                "children": [
+                  {
+                    "type": "Badge",
+                    "label": "$699",
+                    "color": "info",
+                    "size": "md"
+                  },
+                  {
+                    "type": "Spacer"
+                  },
+                  {
+                    "type": "Button",
+                    "label": "Choose A",
+                    "style": "primary",
+                    "onClickAction": {
+                      "type": "conjoint.select",
+                      "payload": {
+                        "questionId": "q-001",
+                        "choice": "A"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "Col",
+            "key": "B",
+            "flex": 1,
+            "gap": 3,
+            "padding": 3,
+            "border": {
+              "size": 1
+            },
+            "radius": "xl",
+            "background": "surface-secondary",
+            "children": [
+              {
+                "type": "Row",
+                "gap": 2,
+                "align": "center",
+                "children": [
+                  {
+                    "type": "Box",
+                    "size": 28,
+                    "radius": "full",
+                    "background": "purple"
+                  },
+                  {
+                    "type": "Title",
+                    "value": "Option B",
+                    "size": "sm"
+                  },
+                  {
+                    "type": "Spacer"
+                  },
+                  {
+                    "type": "Badge",
+                    "label": "B",
+                    "color": "discovery"
+                  }
+                ]
+              },
+              {
+                "type": "Col",
+                "gap": 2,
+                "children": [
+                  {
+                    "type": "Row",
+                    "key": "B-0",
+                    "gap": 2,
+                    "align": "center",
+                    "children": [
+                      {
+                        "type": "Icon",
+                        "name": "check-circle",
+                        "color": "purple",
+                        "size": "sm"
+                      },
+                      {
+                        "type": "Col",
+                        "gap": 0,
+                        "children": [
+                          {
+                            "type": "Caption",
+                            "value": "Storage"
+                          },
+                          {
+                            "type": "Text",
+                            "value": "128 GB",
+                            "size": "sm",
+                            "weight": "semibold",
+                            "maxLines": 1
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "Row",
+                    "key": "B-1",
+                    "gap": 2,
+                    "align": "center",
+                    "children": [
+                      {
+                        "type": "Icon",
+                        "name": "check-circle",
+                        "color": "purple",
+                        "size": "sm"
+                      },
+                      {
+                        "type": "Col",
+                        "gap": 0,
+                        "children": [
+                          {
+                            "type": "Caption",
+                            "value": "Color"
+                          },
+                          {
+                            "type": "Text",
+                            "value": "Starlight",
+                            "size": "sm",
+                            "weight": "semibold",
+                            "maxLines": 1
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "Row",
+                    "key": "B-2",
+                    "gap": 2,
+                    "align": "center",
+                    "children": [
+                      {
+                        "type": "Icon",
+                        "name": "check-circle",
+                        "color": "purple",
+                        "size": "sm"
+                      },
+                      {
+                        "type": "Col",
+                        "gap": 0,
+                        "children": [
+                          {
+                            "type": "Caption",
+                            "value": "Warranty"
+                          },
+                          {
+                            "type": "Text",
+                            "value": "2 years",
+                            "size": "sm",
+                            "weight": "semibold",
+                            "maxLines": 1
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "Divider"
+              },
+              {
+                "type": "Row",
+                "children": [
+                  {
+                    "type": "Badge",
+                    "label": "$649",
+                    "color": "info",
+                    "size": "md"
+                  },
+                  {
+                    "type": "Spacer"
+                  },
+                  {
+                    "type": "Button",
+                    "label": "Choose B",
+                    "style": "primary",
+                    "onClickAction": {
+                      "type": "conjoint.select",
+                      "payload": {
+                        "questionId": "q-001",
+                        "choice": "B"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "Divider"
+      },
+      {
+        "type": "Button",
+        "label": "No preference",
+        "variant": "outline",
+        "block": true,
+        "onClickAction": {
+          "type": "conjoint.select",
+          "payload": {
+            "questionId": "q-001",
+            "choice": "tie"
+          }
+        }
+      }
+    ]
+  },
+  "encodedWidget": "eyJpZCI6IjQzNjM2ZDVlLTM3MWEtNGQyNi1hMDgzLTRiZTBjMzI0NWNlNyIsIm5hbWUiOiJDb25qb2ludCBDaG9pY2UiLCJ2aWV3IjoiPENhcmQgc2l6ZT1cIm1kXCI-XG4gIDxDb2wgZ2FwPXsyfT5cbiAgICA8VGl0bGUgdmFsdWU9e3RpdGxlfSBzaXplPVwibWRcIiAvPlxuICAgIDxUZXh0IHZhbHVlPXtjb250ZXh0fSBzaXplPVwic21cIiBjb2xvcj1cInNlY29uZGFyeVwiIC8-XG4gIDwvQ29sPlxuICA8RGl2aWRlciBmbHVzaCAvPlxuICA8Um93IGdhcD17M30gYWxpZ249XCJzdHJldGNoXCI-XG4gICAge3Byb2ZpbGVzLm1hcCgocCkgPT4gKFxuICAgICAgPENvbFxuICAgICAgICBrZXk9e3Aua2V5fVxuICAgICAgICBmbGV4PXsxfVxuICAgICAgICBnYXA9ezN9XG4gICAgICAgIHBhZGRpbmc9ezN9XG4gICAgICAgIGJvcmRlcj17eyBzaXplOiAxIH19XG4gICAgICAgIHJhZGl1cz1cInhsXCJcbiAgICAgICAgYmFja2dyb3VuZD1cInN1cmZhY2Utc2Vjb25kYXJ5XCJcbiAgICAgID5cbiAgICAgICAgPFJvdyBnYXA9ezJ9IGFsaWduPVwiY2VudGVyXCI-XG4gICAgICAgICAgPEJveCBzaXplPXsyOH0gcmFkaXVzPVwiZnVsbFwiIGJhY2tncm91bmQ9e3AuYWNjZW50fSAvPlxuICAgICAgICAgIDxUaXRsZSB2YWx1ZT17cC5oZWFkaW5nfSBzaXplPVwic21cIiAvPlxuICAgICAgICAgIDxTcGFjZXIgLz5cbiAgICAgICAgICA8QmFkZ2UgbGFiZWw9e3Aua2V5fSBjb2xvcj1cImRpc2NvdmVyeVwiIC8-XG4gICAgICAgIDwvUm93PlxuICAgICAgICA8Q29sIGdhcD17Mn0-XG4gICAgICAgICAge3AuZmVhdHVyZXMubWFwKChmLCBpZHgpID0-IChcbiAgICAgICAgICAgIDxSb3cga2V5PXtgJHtwLmtleX0tJHtpZHh9YH0gZ2FwPXsyfSBhbGlnbj1cImNlbnRlclwiPlxuICAgICAgICAgICAgICA8SWNvbiBuYW1lPVwiY2hlY2stY2lyY2xlXCIgY29sb3I9e3AuYWNjZW50fSBzaXplPVwic21cIiAvPlxuICAgICAgICAgICAgICA8Q29sIGdhcD17MH0-XG4gICAgICAgICAgICAgICAgPENhcHRpb24gdmFsdWU9e2YubmFtZX0gLz5cbiAgICAgICAgICAgICAgICA8VGV4dFxuICAgICAgICAgICAgICAgICAgdmFsdWU9e2YudmFsdWV9XG4gICAgICAgICAgICAgICAgICBzaXplPVwic21cIlxuICAgICAgICAgICAgICAgICAgd2VpZ2h0PVwic2VtaWJvbGRcIlxuICAgICAgICAgICAgICAgICAgbWF4TGluZXM9ezF9XG4gICAgICAgICAgICAgICAgLz5cbiAgICAgICAgICAgICAgPC9Db2w-XG4gICAgICAgICAgICA8L1Jvdz5cbiAgICAgICAgICApKX1cbiAgICAgICAgPC9Db2w-XG4gICAgICAgIDxEaXZpZGVyIC8-XG4gICAgICAgIDxSb3c-XG4gICAgICAgICAgPEJhZGdlIGxhYmVsPXtwLnByaWNlfSBjb2xvcj1cImluZm9cIiBzaXplPVwibWRcIiAvPlxuICAgICAgICAgIDxTcGFjZXIgLz5cbiAgICAgICAgICA8QnV0dG9uXG4gICAgICAgICAgICBsYWJlbD17YENob29zZSAke3Aua2V5fWB9XG4gICAgICAgICAgICBzdHlsZT1cInByaW1hcnlcIlxuICAgICAgICAgICAgb25DbGlja0FjdGlvbj17e1xuICAgICAgICAgICAgICB0eXBlOiBcImNvbmpvaW50LnNlbGVjdFwiLFxuICAgICAgICAgICAgICBwYXlsb2FkOiB7IHF1ZXN0aW9uSWQsIGNob2ljZTogcC5rZXkgfSxcbiAgICAgICAgICAgIH19XG4gICAgICAgICAgLz5cbiAgICAgICAgPC9Sb3c-XG4gICAgICA8L0NvbD5cbiAgICApKX1cbiAgPC9Sb3c-XG4gIDxEaXZpZGVyIC8-XG4gIDxCdXR0b25cbiAgICBsYWJlbD1cIk5vIHByZWZlcmVuY2VcIlxuICAgIHZhcmlhbnQ9XCJvdXRsaW5lXCJcbiAgICBibG9ja1xuICAgIG9uQ2xpY2tBY3Rpb249e3tcbiAgICAgIHR5cGU6IFwiY29uam9pbnQuc2VsZWN0XCIsXG4gICAgICBwYXlsb2FkOiB7IHF1ZXN0aW9uSWQsIGNob2ljZTogXCJ0aWVcIiB9LFxuICAgIH19XG4gIC8-XG48L0NhcmQ-IiwiZGVmYXVsdFN0YXRlIjp7InF1ZXN0aW9uSWQiOiJxLTAwMSIsInRpdGxlIjoiV2hpY2ggb2ZmZXIgd291bGQgeW91IGNob29zZT8iLCJjb250ZXh0IjoiU21hcnRwaG9uZSBidW5kbGUiLCJwcm9maWxlcyI6W3sia2V5IjoiQSIsImhlYWRpbmciOiJPcHRpb24gQSIsImFjY2VudCI6ImJsdWUiLCJwcmljZSI6IiQ2OTkiLCJmZWF0dXJlcyI6W3sibmFtZSI6IlN0b3JhZ2UiLCJ2YWx1ZSI6IjI1NiBHQiJ9LHsibmFtZSI6IkNvbG9yIiwidmFsdWUiOiJNaWRuaWdodCJ9LHsibmFtZSI6IldhcnJhbnR5IiwidmFsdWUiOiIxIHllYXIifV19LHsia2V5IjoiQiIsImhlYWRpbmciOiJPcHRpb24gQiIsImFjY2VudCI6InB1cnBsZSIsInByaWNlIjoiJDY0OSIsImZlYXR1cmVzIjpbeyJuYW1lIjoiU3RvcmFnZSIsInZhbHVlIjoiMTI4IEdCIn0seyJuYW1lIjoiQ29sb3IiLCJ2YWx1ZSI6IlN0YXJsaWdodCJ9LHsibmFtZSI6IldhcnJhbnR5IiwidmFsdWUiOiIyIHllYXJzIn1dfV19LCJzdGF0ZXMiOltdLCJzY2hlbWEiOiJpbXBvcnQgeyB6IH0gZnJvbSBcInpvZFwiXG5cbmNvbnN0IEZlYXR1cmUgPSB6LnN0cmljdE9iamVjdCh7XG4gIG5hbWU6IHouc3RyaW5nKCksXG4gIHZhbHVlOiB6LnN0cmluZygpLFxufSlcblxuY29uc3QgUHJvZmlsZSA9IHouc3RyaWN0T2JqZWN0KHtcbiAga2V5OiB6LmVudW0oW1wiQVwiLCBcIkJcIl0pLFxuICBoZWFkaW5nOiB6LnN0cmluZygpLFxuICBhY2NlbnQ6IHouZW51bShbXCJibHVlXCIsIFwicHVycGxlXCIsIFwiZ3JlZW5cIiwgXCJyZWRcIl0pLFxuICBwcmljZTogei5zdHJpbmcoKSxcbiAgZmVhdHVyZXM6IHouYXJyYXkoRmVhdHVyZSksXG59KVxuXG5jb25zdCBXaWRnZXRTdGF0ZSA9IHouc3RyaWN0T2JqZWN0KHtcbiAgcXVlc3Rpb25JZDogei5zdHJpbmcoKSxcbiAgdGl0bGU6IHouc3RyaW5nKCksXG4gIGNvbnRleHQ6IHouc3RyaW5nKCksXG4gIHByb2ZpbGVzOiB6LnR1cGxlKFtQcm9maWxlLCBQcm9maWxlXSksXG59KVxuXG5leHBvcnQgZGVmYXVsdCBXaWRnZXRTdGF0ZSIsImpzb25TY2hlbWEiOnt9LCJzY2hlbWFNb2RlIjoiem9kIiwic2NoZW1hVmFsaWRpdHkiOiJ2YWxpZCIsInZpZXdWYWxpZGl0eSI6InZhbGlkIiwiZGVmYXVsdFN0YXRlVmFsaWRpdHkiOiJ2YWxpZCJ9"
+}

--- a/deploy/stack/chatkit_widgets/Conjoint carousel.widget
+++ b/deploy/stack/chatkit_widgets/Conjoint carousel.widget
@@ -1,0 +1,254 @@
+{
+  "version": "1.0",
+  "name": "Conjoint carousel",
+  "template": "{\"type\":\"Card\",\"size\":\"sm\",\"children\":[{\"type\":\"Row\",\"align\":\"center\",\"gap\":2,\"children\":[{\"type\":\"Button\",\"uniform\":true,\"variant\":\"outline\",\"iconStart\":\"chevron-left\",\"onClickAction\":{\"type\":\"conjoint.carousel\",\"payload\":{\"direction\":\"prev\",\"index\":{{ (index) | tojson }}}},\"disabled\":{{ ((index == 0)) | tojson }}},{\"type\":\"Col\",\"flex\":\"auto\",\"gap\":1,\"children\":[{\"type\":\"Caption\",\"value\":\"Choose one\"},{\"type\":\"Title\",\"value\":{{ (options[index].name) | tojson }},\"size\":\"md\"},{\"type\":\"Row\",\"gap\":2,\"children\":[{\"type\":\"Badge\",\"label\":{{ (options[index].price) | tojson }},\"color\":\"info\"}]},{\"type\":\"Col\",\"gap\":1,\"children\":[{%- set _c -%}{%-for attr in options[index].attributes -%},{\"type\":\"Row\",\"key\":{{ (attr.label) | tojson }},\"gap\":2,\"children\":[{\"type\":\"Text\",\"value\":{{ (attr.label) | tojson }},\"size\":\"sm\",\"color\":\"secondary\"},{\"type\":\"Spacer\"},{\"type\":\"Text\",\"value\":{{ (attr.value) | tojson }},\"size\":\"sm\"}]}{%-endfor-%}{%- endset -%}{{- (_c[1:] if _c and _c[0] == ',' else _c) -}}]}]},{\"type\":\"Button\",\"uniform\":true,\"variant\":\"outline\",\"iconStart\":\"chevron-right\",\"onClickAction\":{\"type\":\"conjoint.carousel\",\"payload\":{\"direction\":\"next\",\"index\":{{ (index) | tojson }}}},\"disabled\":{{ ((index == (options | length) - 1)) | tojson }}}]},{\"type\":\"Divider\"},{\"type\":\"Row\",\"align\":\"center\",\"children\":[{\"type\":\"Row\",\"gap\":1,\"children\":[{%- set _c -%}{%-for _ in options -%}{%-set i = loop.index0 -%},{\"type\":\"Box\",\"key\":{{ ((\"dot-\" ~ i)) | tojson }},\"size\":8,\"radius\":\"full\",\"background\":{% if i === index %}\"blue-500\"{% else %}\"alpha-10\"{% endif %}}{%-endfor-%}{%- endset -%}{{- (_c[1:] if _c and _c[0] == ',' else _c) -}}]},{\"type\":\"Spacer\"},{\"type\":\"Button\",\"label\":\"Select\",\"style\":\"primary\",\"onClickAction\":{\"type\":\"conjoint.select\",\"payload\":{\"id\":{{ (options[index].id) | tojson }}}}}]}]}",
+  "jsonSchema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "index": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 2
+      },
+      "options": {
+        "minItems": 3,
+        "maxItems": 3,
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "price": {
+              "type": "string"
+            },
+            "attributes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "label": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "label",
+                  "value"
+                ],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": [
+            "id",
+            "name",
+            "price",
+            "attributes"
+          ],
+          "additionalProperties": false
+        }
+      }
+    },
+    "required": [
+      "index",
+      "options"
+    ],
+    "additionalProperties": false
+  },
+  "outputJsonPreview": {
+    "type": "Card",
+    "size": "sm",
+    "children": [
+      {
+        "type": "Row",
+        "align": "center",
+        "gap": 2,
+        "children": [
+          {
+            "type": "Button",
+            "uniform": true,
+            "variant": "outline",
+            "iconStart": "chevron-left",
+            "onClickAction": {
+              "type": "conjoint.carousel",
+              "payload": {
+                "direction": "prev",
+                "index": 0
+              }
+            },
+            "disabled": true
+          },
+          {
+            "type": "Col",
+            "flex": "auto",
+            "gap": 1,
+            "children": [
+              {
+                "type": "Caption",
+                "value": "Choose one"
+              },
+              {
+                "type": "Title",
+                "value": "Saver",
+                "size": "md"
+              },
+              {
+                "type": "Row",
+                "gap": 2,
+                "children": [
+                  {
+                    "type": "Badge",
+                    "label": "$29/mo",
+                    "color": "info"
+                  }
+                ]
+              },
+              {
+                "type": "Col",
+                "gap": 1,
+                "children": [
+                  {
+                    "type": "Row",
+                    "key": "Speed",
+                    "gap": 2,
+                    "children": [
+                      {
+                        "type": "Text",
+                        "value": "Speed",
+                        "size": "sm",
+                        "color": "secondary"
+                      },
+                      {
+                        "type": "Spacer"
+                      },
+                      {
+                        "type": "Text",
+                        "value": "Basic",
+                        "size": "sm"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "Row",
+                    "key": "Storage",
+                    "gap": 2,
+                    "children": [
+                      {
+                        "type": "Text",
+                        "value": "Storage",
+                        "size": "sm",
+                        "color": "secondary"
+                      },
+                      {
+                        "type": "Spacer"
+                      },
+                      {
+                        "type": "Text",
+                        "value": "50 GB",
+                        "size": "sm"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "Row",
+                    "key": "Support",
+                    "gap": 2,
+                    "children": [
+                      {
+                        "type": "Text",
+                        "value": "Support",
+                        "size": "sm",
+                        "color": "secondary"
+                      },
+                      {
+                        "type": "Spacer"
+                      },
+                      {
+                        "type": "Text",
+                        "value": "Email",
+                        "size": "sm"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "Button",
+            "uniform": true,
+            "variant": "outline",
+            "iconStart": "chevron-right",
+            "onClickAction": {
+              "type": "conjoint.carousel",
+              "payload": {
+                "direction": "next",
+                "index": 0
+              }
+            },
+            "disabled": false
+          }
+        ]
+      },
+      {
+        "type": "Divider"
+      },
+      {
+        "type": "Row",
+        "align": "center",
+        "children": [
+          {
+            "type": "Row",
+            "gap": 1,
+            "children": [
+              {
+                "type": "Box",
+                "key": "dot-0",
+                "size": 8,
+                "radius": "full",
+                "background": "blue-500"
+              },
+              {
+                "type": "Box",
+                "key": "dot-1",
+                "size": 8,
+                "radius": "full",
+                "background": "alpha-10"
+              },
+              {
+                "type": "Box",
+                "key": "dot-2",
+                "size": 8,
+                "radius": "full",
+                "background": "alpha-10"
+              }
+            ]
+          },
+          {
+            "type": "Spacer"
+          },
+          {
+            "type": "Button",
+            "label": "Select",
+            "style": "primary",
+            "onClickAction": {
+              "type": "conjoint.select",
+              "payload": {
+                "id": "saver"
+              }
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "encodedWidget": "eyJpZCI6IjlmNzNjMmE5LTkwZDktNGQ4MC1iMzY4LWUwZWM0MWE1YWRlNSIsIm5hbWUiOiJDb25qb2ludCBjYXJvdXNlbCIsInZpZXciOiI8Q2FyZCBzaXplPVwic21cIj5cbiAgPFJvdyBhbGlnbj1cImNlbnRlclwiIGdhcD17Mn0-XG4gICAgPEJ1dHRvblxuICAgICAgdW5pZm9ybVxuICAgICAgdmFyaWFudD1cIm91dGxpbmVcIlxuICAgICAgaWNvblN0YXJ0PVwiY2hldnJvbi1sZWZ0XCJcbiAgICAgIG9uQ2xpY2tBY3Rpb249e3tcbiAgICAgICAgdHlwZTogXCJjb25qb2ludC5jYXJvdXNlbFwiLFxuICAgICAgICBwYXlsb2FkOiB7IGRpcmVjdGlvbjogXCJwcmV2XCIsIGluZGV4IH0sXG4gICAgICB9fVxuICAgICAgZGlzYWJsZWQ9e2luZGV4ID09PSAwfVxuICAgIC8-XG5cbiAgICA8Q29sIGZsZXg9XCJhdXRvXCIgZ2FwPXsxfT5cbiAgICAgIDxDYXB0aW9uIHZhbHVlPVwiQ2hvb3NlIG9uZVwiIC8-XG4gICAgICA8VGl0bGUgdmFsdWU9e29wdGlvbnNbaW5kZXhdLm5hbWV9IHNpemU9XCJtZFwiIC8-XG4gICAgICA8Um93IGdhcD17Mn0-XG4gICAgICAgIDxCYWRnZSBsYWJlbD17b3B0aW9uc1tpbmRleF0ucHJpY2V9IGNvbG9yPVwiaW5mb1wiIC8-XG4gICAgICA8L1Jvdz5cbiAgICAgIDxDb2wgZ2FwPXsxfT5cbiAgICAgICAge29wdGlvbnNbaW5kZXhdLmF0dHJpYnV0ZXMubWFwKChhdHRyKSA9PiAoXG4gICAgICAgICAgPFJvdyBrZXk9e2F0dHIubGFiZWx9IGdhcD17Mn0-XG4gICAgICAgICAgICA8VGV4dCB2YWx1ZT17YXR0ci5sYWJlbH0gc2l6ZT1cInNtXCIgY29sb3I9XCJzZWNvbmRhcnlcIiAvPlxuICAgICAgICAgICAgPFNwYWNlciAvPlxuICAgICAgICAgICAgPFRleHQgdmFsdWU9e2F0dHIudmFsdWV9IHNpemU9XCJzbVwiIC8-XG4gICAgICAgICAgPC9Sb3c-XG4gICAgICAgICkpfVxuICAgICAgPC9Db2w-XG4gICAgPC9Db2w-XG5cbiAgICA8QnV0dG9uXG4gICAgICB1bmlmb3JtXG4gICAgICB2YXJpYW50PVwib3V0bGluZVwiXG4gICAgICBpY29uU3RhcnQ9XCJjaGV2cm9uLXJpZ2h0XCJcbiAgICAgIG9uQ2xpY2tBY3Rpb249e3tcbiAgICAgICAgdHlwZTogXCJjb25qb2ludC5jYXJvdXNlbFwiLFxuICAgICAgICBwYXlsb2FkOiB7IGRpcmVjdGlvbjogXCJuZXh0XCIsIGluZGV4IH0sXG4gICAgICB9fVxuICAgICAgZGlzYWJsZWQ9e2luZGV4ID09PSBvcHRpb25zLmxlbmd0aCAtIDF9XG4gICAgLz5cbiAgPC9Sb3c-XG5cbiAgPERpdmlkZXIgLz5cblxuICA8Um93IGFsaWduPVwiY2VudGVyXCI-XG4gICAgPFJvdyBnYXA9ezF9PlxuICAgICAge29wdGlvbnMubWFwKChfLCBpKSA9PiAoXG4gICAgICAgIDxCb3hcbiAgICAgICAgICBrZXk9e2Bkb3QtJHtpfWB9XG4gICAgICAgICAgc2l6ZT17OH1cbiAgICAgICAgICByYWRpdXM9XCJmdWxsXCJcbiAgICAgICAgICBiYWNrZ3JvdW5kPXtpID09PSBpbmRleCA_IFwiYmx1ZS01MDBcIiA6IFwiYWxwaGEtMTBcIn1cbiAgICAgICAgLz5cbiAgICAgICkpfVxuICAgIDwvUm93PlxuICAgIDxTcGFjZXIgLz5cbiAgICA8QnV0dG9uXG4gICAgICBsYWJlbD1cIlNlbGVjdFwiXG4gICAgICBzdHlsZT1cInByaW1hcnlcIlxuICAgICAgb25DbGlja0FjdGlvbj17e1xuICAgICAgICB0eXBlOiBcImNvbmpvaW50LnNlbGVjdFwiLFxuICAgICAgICBwYXlsb2FkOiB7IGlkOiBvcHRpb25zW2luZGV4XS5pZCB9LFxuICAgICAgfX1cbiAgICAvPlxuICA8L1Jvdz5cbjwvQ2FyZD4iLCJkZWZhdWx0U3RhdGUiOnsiaW5kZXgiOjAsIm9wdGlvbnMiOlt7ImlkIjoic2F2ZXIiLCJuYW1lIjoiU2F2ZXIiLCJwcmljZSI6IiQyOS9tbyIsImF0dHJpYnV0ZXMiOlt7ImxhYmVsIjoiU3BlZWQiLCJ2YWx1ZSI6IkJhc2ljIn0seyJsYWJlbCI6IlN0b3JhZ2UiLCJ2YWx1ZSI6IjUwIEdCIn0seyJsYWJlbCI6IlN1cHBvcnQiLCJ2YWx1ZSI6IkVtYWlsIn1dfSx7ImlkIjoic3RhbmRhcmQiLCJuYW1lIjoiU3RhbmRhcmQiLCJwcmljZSI6IiQ0OS9tbyIsImF0dHJpYnV0ZXMiOlt7ImxhYmVsIjoiU3BlZWQiLCJ2YWx1ZSI6IkZhc3QifSx7ImxhYmVsIjoiU3RvcmFnZSIsInZhbHVlIjoiMjAwIEdCIn0seyJsYWJlbCI6IlN1cHBvcnQiLCJ2YWx1ZSI6IkNoYXQifV19LHsiaWQiOiJwcm8iLCJuYW1lIjoiUHJvIiwicHJpY2UiOiIkNzkvbW8iLCJhdHRyaWJ1dGVzIjpbeyJsYWJlbCI6IlNwZWVkIiwidmFsdWUiOiJGYXN0ZXN0In0seyJsYWJlbCI6IlN0b3JhZ2UiLCJ2YWx1ZSI6IjIgVEIifSx7ImxhYmVsIjoiU3VwcG9ydCIsInZhbHVlIjoiMjQvNyJ9XX1dfSwic3RhdGVzIjpbXSwic2NoZW1hIjoiaW1wb3J0IHsgeiB9IGZyb20gXCJ6b2RcIlxuXG5jb25zdCBBdHRyaWJ1dGUgPSB6LnN0cmljdE9iamVjdCh7XG4gIGxhYmVsOiB6LnN0cmluZygpLFxuICB2YWx1ZTogei5zdHJpbmcoKSxcbn0pXG5cbmNvbnN0IE9wdGlvbiA9IHouc3RyaWN0T2JqZWN0KHtcbiAgaWQ6IHouc3RyaW5nKCksXG4gIG5hbWU6IHouc3RyaW5nKCksXG4gIHByaWNlOiB6LnN0cmluZygpLFxuICBhdHRyaWJ1dGVzOiB6LmFycmF5KEF0dHJpYnV0ZSksXG59KVxuXG5jb25zdCBXaWRnZXRTdGF0ZSA9IHouc3RyaWN0T2JqZWN0KHtcbiAgaW5kZXg6IHoubnVtYmVyKCkuaW50KCkubWluKDApLm1heCgyKSxcbiAgb3B0aW9uczogei5hcnJheShPcHRpb24pLmxlbmd0aCgzKSxcbn0pXG5cbmV4cG9ydCBkZWZhdWx0IFdpZGdldFN0YXRlIiwianNvblNjaGVtYSI6e30sInNjaGVtYU1vZGUiOiJ6b2QiLCJzY2hlbWFWYWxpZGl0eSI6InZhbGlkIiwidmlld1ZhbGlkaXR5IjoidmFsaWQiLCJkZWZhdWx0U3RhdGVWYWxpZGl0eSI6InZhbGlkIn0"
+}

--- a/deploy/stack/chatkit_widgets/Multi-choice Selector.widget
+++ b/deploy/stack/chatkit_widgets/Multi-choice Selector.widget
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "name": "Multi-choice Selector",
-  "template": "{\"type\":\"Card\",\"asForm\":true,\"size\":\"md\",\"confirm\":{\"label\":\"Submit\",\"action\":{\"type\":\"submit\",\"payload\":{\"max\":{{ (maxSelections) | tojson }}},\"requestAssistantResponse\":true}},\"children\":[{\"type\":\"Col\",\"gap\":2,\"children\":[{\"type\":\"Title\",\"value\":{{ (title) | tojson }},\"size\":\"sm\"},{\"type\":\"Row\",\"children\":[{\"type\":\"Caption\",\"value\":{{ ((\"Select up to \" ~ maxSelections)) | tojson }}},{\"type\":\"Spacer\"},{\"type\":\"Caption\",\"value\":{{ ((selectedCount ~ \"/\" ~ maxSelections ~ \" selected\")) | tojson }},\"color\":\"emphasis\"}]}]},{\"type\":\"Divider\",\"flush\":true},{\"type\":\"ListView\",\"limit\":30,\"children\":[{%- set _c -%}{%-for item in options -%},{\"type\":\"ListViewItem\",\"key\":{{ (item.id) | tojson }},\"align\":\"center\",\"children\":[{\"type\":\"Checkbox\",\"name\":{{ ((\"choices.\" ~ item.id)) | tojson }},\"label\":{{ (item.label) | tojson }},\"defaultChecked\":{{ (item.checked) | tojson }},\"disabled\":{{ ((selectedCount >= maxSelections) and (not item.checked)) | tojson }},\"onChangeAction\":{\"type\":\"choices.toggle\",\"payload\":{\"id\":{{ (item.id) | tojson }}}}}]}{%-endfor-%}{%- endset -%}{{- (_c[1:] if _c and _c[0] == ',' else _c) -}}]}]}",
+  "template": "{\"type\":\"Card\",\"asForm\":true,\"size\":\"md\",\"confirm\":{\"label\":\"Done\",\"action\":{\"type\":\"choices.submit\",\"payload\":{\"max\":{{ (maxSelections) | tojson }}}}},\"children\":[{\"type\":\"Col\",\"gap\":2,\"children\":[{\"type\":\"Title\",\"value\":{{ (title) | tojson }},\"size\":\"sm\"},{\"type\":\"Row\",\"children\":[{\"type\":\"Caption\",\"value\":{{ ((\"Select up to \" ~ maxSelections)) | tojson }}},{\"type\":\"Spacer\"},{\"type\":\"Caption\",\"value\":{{ ((selectedCount ~ \"/\" ~ maxSelections ~ \" selected\")) | tojson }},\"color\":\"emphasis\"}]}]},{\"type\":\"Divider\",\"flush\":true},{\"type\":\"ListView\",\"limit\":30,\"children\":[{%- set _c -%}{%-for item in options -%},{\"type\":\"ListViewItem\",\"key\":{{ (item.id) | tojson }},\"align\":\"center\",\"children\":[{\"type\":\"Checkbox\",\"name\":{{ ((\"choices.\" ~ item.id)) | tojson }},\"label\":{{ (item.label) | tojson }},\"defaultChecked\":{{ (item.checked) | tojson }},\"disabled\":{{ ((selectedCount >= maxSelections) and (not item.checked)) | tojson }},\"onChangeAction\":{\"type\":\"choices.toggle\",\"payload\":{\"id\":{{ (item.id) | tojson }}}}}]}{%-endfor-%}{%- endset -%}{{- (_c[1:] if _c and _c[0] == ',' else _c) -}}]}]}",
   "jsonSchema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
@@ -58,13 +58,12 @@
     "asForm": true,
     "size": "md",
     "confirm": {
-      "label": "Submit",
+      "label": "Done",
       "action": {
-        "type": "submit",
+        "type": "choices.submit",
         "payload": {
           "max": 3
-        },
-        "requestAssistantResponse": true
+        }
       }
     },
     "children": [

--- a/deploy/stack/chatkit_widgets/Single-choice list.widget
+++ b/deploy/stack/chatkit_widgets/Single-choice list.widget
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "name": "Single-choice list",
-  "template": "{\"type\":\"Card\",\"size\":\"sm\",\"asForm\":true,\"confirm\":{\"label\":\"Submit\",\"action\":{\"type\":\"submit\",\"requestAssistantResponse\":true}},\"children\":[{\"type\":\"Col\",\"gap\":2,\"children\":[{\"type\":\"Title\",\"value\":{{ (title) | tojson }},\"size\":\"sm\"},{\"type\":\"RadioGroup\",\"name\":\"choice\",\"options\":{{ (options) | tojson }},\"direction\":\"col\",\"defaultValue\":{{ (defaultValue) | tojson }},\"required\":true}]}]}",
+  "template": "{\"type\":\"Card\",\"size\":\"sm\",\"children\":[{\"type\":\"Col\",\"gap\":2,\"children\":[{\"type\":\"Title\",\"value\":{{ (title) | tojson }},\"size\":\"sm\"},{\"type\":\"RadioGroup\",\"name\":\"choice\",\"options\":{{ (options) | tojson }},\"direction\":\"col\",\"onChangeAction\":{\"type\":{{ (actionType) | tojson }}},\"defaultValue\":{{ (defaultValue) | tojson }},\"required\":true}]}]}",
   "jsonSchema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
@@ -49,14 +49,6 @@
   "outputJsonPreview": {
     "type": "Card",
     "size": "sm",
-    "asForm": true,
-    "confirm": {
-      "label": "Submit",
-      "action": {
-        "type": "submit",
-        "requestAssistantResponse": true
-      }
-    },
     "children": [
       {
         "type": "Col",
@@ -90,6 +82,9 @@
               }
             ],
             "direction": "col",
+            "onChangeAction": {
+              "type": "choice.select"
+            },
             "defaultValue": "A",
             "required": true
           }

--- a/deploy/stack/chatkit_widgets/Todo list.widget
+++ b/deploy/stack/chatkit_widgets/Todo list.widget
@@ -1,0 +1,198 @@
+{
+  "version": "1.0",
+  "name": "Todo list",
+  "template": "{\"type\":\"Card\",\"size\":\"sm\",\"children\":[{\"type\":\"Col\",\"gap\":2,\"children\":[{\"type\":\"Row\",\"children\":[{\"type\":\"Title\",\"value\":\"To-do\",\"size\":\"md\"},{\"type\":\"Spacer\"},{\"type\":\"Badge\",\"label\":{{ ((length ~ \" left\")) | tojson }},\"color\":\"info\"}]},{\"type\":\"Divider\"},{\"type\":\"Col\",\"gap\":2,\"children\":[{%- set _c -%}{%-for item in items -%},{\"type\":\"Row\",\"key\":{{ (item.id) | tojson }},\"gap\":2,\"align\":\"center\",\"children\":[{\"type\":\"Checkbox\",\"name\":{{ ((\"todo.done.\" ~ item.id)) | tojson }},\"defaultChecked\":{{ (item.done) | tojson }},\"onChangeAction\":{\"type\":\"todo.toggle\",\"payload\":{\"id\":{{ (item.id) | tojson }}}}},{\"type\":\"Text\",\"value\":{{ (item.title) | tojson }},\"size\":\"sm\",\"lineThrough\":{{ (item.done) | tojson }}}]}{%-endfor-%}{%-if (items | length) === 0 -%},{\"type\":\"Text\",\"value\":\"No tasks yet\",\"size\":\"sm\",\"color\":\"secondary\",\"textAlign\":\"center\"}{%-else-%}{%-endif-%}{%- endset -%}{{- (_c[1:] if _c and _c[0] == ',' else _c) -}}]},{\"type\":\"Divider\"},{\"type\":\"Form\",\"onSubmitAction\":{\"type\":\"todo.add\"},\"children\":[{\"type\":\"Row\",\"gap\":2,\"children\":[{\"type\":\"Input\",\"name\":\"todo.title\",\"placeholder\":{{ (newItemPlaceholder) | tojson }},\"required\":true},{\"type\":\"Button\",\"submit\":true,\"label\":\"Add\",\"style\":\"primary\"},{\"type\":\"Spacer\"},{\"type\":\"Button\",\"label\":\"Clear completed\",\"variant\":\"outline\",\"onClickAction\":{\"type\":\"todo.clearCompleted\"},\"disabled\":{{ ((none.length == 0)) | tojson }}}]}]}]}]}",
+  "jsonSchema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "done": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "id",
+            "title",
+            "done"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "newItemPlaceholder": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "items",
+      "newItemPlaceholder"
+    ],
+    "additionalProperties": false
+  },
+  "outputJsonPreview": {
+    "type": "Card",
+    "size": "sm",
+    "children": [
+      {
+        "type": "Col",
+        "gap": 2,
+        "children": [
+          {
+            "type": "Row",
+            "children": [
+              {
+                "type": "Title",
+                "value": "To-do",
+                "size": "md"
+              },
+              {
+                "type": "Spacer"
+              },
+              {
+                "type": "Badge",
+                "label": "2 left",
+                "color": "info"
+              }
+            ]
+          },
+          {
+            "type": "Divider"
+          },
+          {
+            "type": "Col",
+            "gap": 2,
+            "children": [
+              {
+                "type": "Row",
+                "key": "1",
+                "gap": 2,
+                "align": "center",
+                "children": [
+                  {
+                    "type": "Checkbox",
+                    "name": "todo.done.1",
+                    "defaultChecked": false,
+                    "onChangeAction": {
+                      "type": "todo.toggle",
+                      "payload": {
+                        "id": "1"
+                      }
+                    }
+                  },
+                  {
+                    "type": "Text",
+                    "value": "Buy milk",
+                    "size": "sm",
+                    "lineThrough": false
+                  }
+                ]
+              },
+              {
+                "type": "Row",
+                "key": "2",
+                "gap": 2,
+                "align": "center",
+                "children": [
+                  {
+                    "type": "Checkbox",
+                    "name": "todo.done.2",
+                    "defaultChecked": true,
+                    "onChangeAction": {
+                      "type": "todo.toggle",
+                      "payload": {
+                        "id": "2"
+                      }
+                    }
+                  },
+                  {
+                    "type": "Text",
+                    "value": "Email Alex re: meeting",
+                    "size": "sm",
+                    "lineThrough": true
+                  }
+                ]
+              },
+              {
+                "type": "Row",
+                "key": "3",
+                "gap": 2,
+                "align": "center",
+                "children": [
+                  {
+                    "type": "Checkbox",
+                    "name": "todo.done.3",
+                    "defaultChecked": false,
+                    "onChangeAction": {
+                      "type": "todo.toggle",
+                      "payload": {
+                        "id": "3"
+                      }
+                    }
+                  },
+                  {
+                    "type": "Text",
+                    "value": "Plan weekend hike",
+                    "size": "sm",
+                    "lineThrough": false
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "Divider"
+          },
+          {
+            "type": "Form",
+            "onSubmitAction": {
+              "type": "todo.add"
+            },
+            "children": [
+              {
+                "type": "Row",
+                "gap": 2,
+                "children": [
+                  {
+                    "type": "Input",
+                    "name": "todo.title",
+                    "placeholder": "Add a task...",
+                    "required": true
+                  },
+                  {
+                    "type": "Button",
+                    "submit": true,
+                    "label": "Add",
+                    "style": "primary"
+                  },
+                  {
+                    "type": "Spacer"
+                  },
+                  {
+                    "type": "Button",
+                    "label": "Clear completed",
+                    "variant": "outline",
+                    "onClickAction": {
+                      "type": "todo.clearCompleted"
+                    },
+                    "disabled": false
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "encodedWidget": "eyJpZCI6ImNmN2NiN2NiLTYyZGItNDMyYy1hMGQzLWY0MDllMThmMTliYiIsIm5hbWUiOiJUb2RvIGxpc3QiLCJ2aWV3IjoiPENhcmQgc2l6ZT1cInNtXCI-XG4gIDxDb2wgZ2FwPXsyfT5cbiAgICA8Um93PlxuICAgICAgPFRpdGxlIHZhbHVlPVwiVG8tZG9cIiBzaXplPVwibWRcIiAvPlxuICAgICAgPFNwYWNlciAvPlxuICAgICAgPEJhZGdlXG4gICAgICAgIGxhYmVsPXtgJHtpdGVtcy5maWx0ZXIoKGkpID0-ICFpLmRvbmUpLmxlbmd0aH0gbGVmdGB9XG4gICAgICAgIGNvbG9yPVwiaW5mb1wiXG4gICAgICAvPlxuICAgIDwvUm93PlxuICAgIDxEaXZpZGVyIC8-XG4gICAgPENvbCBnYXA9ezJ9PlxuICAgICAge2l0ZW1zLm1hcCgoaXRlbSkgPT4gKFxuICAgICAgICA8Um93IGtleT17aXRlbS5pZH0gZ2FwPXsyfSBhbGlnbj1cImNlbnRlclwiPlxuICAgICAgICAgIDxDaGVja2JveFxuICAgICAgICAgICAgbmFtZT17YHRvZG8uZG9uZS4ke2l0ZW0uaWR9YH1cbiAgICAgICAgICAgIGRlZmF1bHRDaGVja2VkPXtpdGVtLmRvbmV9XG4gICAgICAgICAgICBvbkNoYW5nZUFjdGlvbj17eyB0eXBlOiBcInRvZG8udG9nZ2xlXCIsIHBheWxvYWQ6IHsgaWQ6IGl0ZW0uaWQgfSB9fVxuICAgICAgICAgIC8-XG4gICAgICAgICAgPFRleHQgdmFsdWU9e2l0ZW0udGl0bGV9IHNpemU9XCJzbVwiIGxpbmVUaHJvdWdoPXtpdGVtLmRvbmV9IC8-XG4gICAgICAgIDwvUm93PlxuICAgICAgKSl9XG4gICAgICB7aXRlbXMubGVuZ3RoID09PSAwICYmIChcbiAgICAgICAgPFRleHRcbiAgICAgICAgICB2YWx1ZT1cIk5vIHRhc2tzIHlldFwiXG4gICAgICAgICAgc2l6ZT1cInNtXCJcbiAgICAgICAgICBjb2xvcj1cInNlY29uZGFyeVwiXG4gICAgICAgICAgdGV4dEFsaWduPVwiY2VudGVyXCJcbiAgICAgICAgLz5cbiAgICAgICl9XG4gICAgPC9Db2w-XG4gICAgPERpdmlkZXIgLz5cbiAgICA8Rm9ybSBvblN1Ym1pdEFjdGlvbj17eyB0eXBlOiBcInRvZG8uYWRkXCIgfX0-XG4gICAgICA8Um93IGdhcD17Mn0-XG4gICAgICAgIDxJbnB1dCBuYW1lPVwidG9kby50aXRsZVwiIHBsYWNlaG9sZGVyPXtuZXdJdGVtUGxhY2Vob2xkZXJ9IHJlcXVpcmVkIC8-XG4gICAgICAgIDxCdXR0b24gc3VibWl0IGxhYmVsPVwiQWRkXCIgc3R5bGU9XCJwcmltYXJ5XCIgLz5cbiAgICAgICAgPFNwYWNlciAvPlxuICAgICAgICA8QnV0dG9uXG4gICAgICAgICAgbGFiZWw9XCJDbGVhciBjb21wbGV0ZWRcIlxuICAgICAgICAgIHZhcmlhbnQ9XCJvdXRsaW5lXCJcbiAgICAgICAgICBvbkNsaWNrQWN0aW9uPXt7IHR5cGU6IFwidG9kby5jbGVhckNvbXBsZXRlZFwiIH19XG4gICAgICAgICAgZGlzYWJsZWQ9e2l0ZW1zLmZpbHRlcigoaSkgPT4gaS5kb25lKS5sZW5ndGggPT09IDB9XG4gICAgICAgIC8-XG4gICAgICA8L1Jvdz5cbiAgICA8L0Zvcm0-XG4gIDwvQ29sPlxuPC9DYXJkPiIsImRlZmF1bHRTdGF0ZSI6eyJpdGVtcyI6W3siaWQiOiIxIiwidGl0bGUiOiJCdXkgbWlsayIsImRvbmUiOmZhbHNlfSx7ImlkIjoiMiIsInRpdGxlIjoiRW1haWwgQWxleCByZTogbWVldGluZyIsImRvbmUiOnRydWV9LHsiaWQiOiIzIiwidGl0bGUiOiJQbGFuIHdlZWtlbmQgaGlrZSIsImRvbmUiOmZhbHNlfV0sIm5ld0l0ZW1QbGFjZWhvbGRlciI6IkFkZCBhIHRhc2suLi4ifSwic3RhdGVzIjpbXSwic2NoZW1hIjoiaW1wb3J0IHsgeiB9IGZyb20gXCJ6b2RcIlxuXG5jb25zdCBUb2RvID0gei5zdHJpY3RPYmplY3Qoe1xuICBpZDogei5zdHJpbmcoKSxcbiAgdGl0bGU6IHouc3RyaW5nKCksXG4gIGRvbmU6IHouYm9vbGVhbigpLFxufSlcblxuY29uc3QgV2lkZ2V0U3RhdGUgPSB6LnN0cmljdE9iamVjdCh7XG4gIGl0ZW1zOiB6LmFycmF5KFRvZG8pLFxuICBuZXdJdGVtUGxhY2Vob2xkZXI6IHouc3RyaW5nKCksXG59KVxuXG5leHBvcnQgZGVmYXVsdCBXaWRnZXRTdGF0ZSIsImpzb25TY2hlbWEiOnt9LCJzY2hlbWFNb2RlIjoiem9kIiwic2NoZW1hVmFsaWRpdHkiOiJ2YWxpZCIsInZpZXdWYWxpZGl0eSI6InZhbGlkIiwiZGVmYXVsdFN0YXRlVmFsaWRpdHkiOiJ2YWxpZCJ9"
+}

--- a/src/orcheo/models/__init__.py
+++ b/src/orcheo/models/__init__.py
@@ -21,6 +21,7 @@ from orcheo.models.secret_governance import (
     SecretGovernanceAlert,
     SecretGovernanceAlertSeverity,
 )
+from orcheo.models.team import Team, normalize_team_slug
 from orcheo.models.workflow_entities import (
     ChatKitStartScreenPrompt,
     ChatKitSupportedModel,
@@ -55,8 +56,10 @@ __all__ = [
     "OrcheoBaseModel",
     "SecretGovernanceAlert",
     "SecretGovernanceAlertSeverity",
+    "Team",
     "TimestampedAuditModel",
     "Workflow",
+    "normalize_team_slug",
     "WorkflowChatKitConfig",
     "WorkflowDraftAccess",
     "WorkflowRun",

--- a/src/orcheo/models/team.py
+++ b/src/orcheo/models/team.py
@@ -1,0 +1,57 @@
+"""Team model — a logical grouping of onboarded colleagues within a workspace.
+
+A team is *not* an isolation boundary. Credentials, the vault, quotas, and audit
+all remain workspace-scoped. A team only groups workflows (AI colleagues) for
+display and management, and scopes colleague handle-uniqueness so the same
+candidate can be onboarded into more than one team within a workspace.
+"""
+
+from __future__ import annotations
+from datetime import datetime
+from uuid import UUID, uuid4
+from pydantic import Field, field_validator
+from orcheo.models.base import OrcheoBaseModel, _utcnow
+
+
+__all__ = ["Team", "normalize_team_slug"]
+
+
+def normalize_team_slug(value: str) -> str:
+    """Normalize a team slug to a stable, URL-safe form."""
+    candidate = str(value).strip().lower()
+    if not candidate:
+        msg = "Team slug must not be empty."
+        raise ValueError(msg)
+    if not all(ch.isalnum() or ch in {"-", "_"} for ch in candidate):
+        msg = (
+            "Team slug must contain only alphanumeric characters, "
+            "hyphens, or underscores."
+        )
+        raise ValueError(msg)
+    return candidate
+
+
+class Team(OrcheoBaseModel):
+    """A named group of onboarded colleagues scoped to a single workspace."""
+
+    id: UUID = Field(default_factory=uuid4)
+    workspace_id: str
+    slug: str
+    name: str
+    is_default: bool = False
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime = Field(default_factory=_utcnow)
+
+    @field_validator("slug", mode="before")
+    @classmethod
+    def _coerce_slug(cls, value: object) -> str:
+        return normalize_team_slug(str(value))
+
+    @field_validator("name", mode="before")
+    @classmethod
+    def _coerce_name(cls, value: object) -> str:
+        candidate = str(value).strip()
+        if not candidate:
+            msg = "Team name must not be empty."
+            raise ValueError(msg)
+        return candidate

--- a/src/orcheo/models/workflow_entities.py
+++ b/src/orcheo/models/workflow_entities.py
@@ -132,6 +132,7 @@ class Workflow(TimestampedAuditModel):
     name: str = Field(min_length=1, max_length=128)
     handle: str | None = Field(default=None, max_length=64)
     workspace_id: str | None = None
+    team_id: str | None = None
     slug: str = ""
     description: str | None = Field(default=None, max_length=1024)
     tags: list[str] = Field(default_factory=list)

--- a/tests/backend/api/test_workflow_publish.py
+++ b/tests/backend/api/test_workflow_publish.py
@@ -72,7 +72,7 @@ def test_publish_workflow_includes_share_url(
 
     assert response.status_code == 201
     payload = response.json()
-    expected_url = f"https://orcheo-studio.ai-colleagues.com/chat/{workflow_id}"
+    expected_url = f"https://orcheo-studio.ai-colleagues.com/chat/default/{workflow_id}"
     assert payload["share_url"] == expected_url
     assert payload["workflow"]["share_url"] == expected_url
 

--- a/tests/backend/repository/test_postgres_repository_additional.py
+++ b/tests/backend/repository/test_postgres_repository_additional.py
@@ -1667,6 +1667,26 @@ async def test_persistence_resolve_workflow_ref_locked_workspace_not_found_in_bo
 
 
 @pytest.mark.asyncio
+async def test_persistence_delete_team_ignores_archived_workflows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Team deletion should only count active workflows in the workspace."""
+    team_id = uuid4()
+    responses: list[Any] = [
+        {"row": {"name": "Temp Team"}},
+        {"row": {"cnt": 0}},
+    ]
+    repo = make_repository(monkeypatch, responses)
+
+    await repo.delete_team(team_id, workspace_id="ws-a")
+
+    query, params = repo._pool._connection.queries[1]  # noqa: SLF001
+    assert "workspace_id = %s" in query
+    assert "is_archived = FALSE" in query
+    assert params == (str(team_id), "ws-a")
+
+
+@pytest.mark.asyncio
 async def test_versions_list_versions_dict_payload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/backend/repository/test_postgres_repository_additional.py
+++ b/tests/backend/repository/test_postgres_repository_additional.py
@@ -20,6 +20,9 @@ from orcheo.triggers.webhook import WebhookTriggerConfig
 from orcheo.vault.oauth import CredentialHealthError, CredentialHealthReport
 from orcheo_backend.app.errors import WorkspaceQuotaExceededError
 from orcheo_backend.app.repository.errors import (
+    TeamNotEmptyError,
+    TeamNotFoundError,
+    TeamSlugConflictError,
     WorkflowHandleConflictError,
     WorkflowNotFoundError,
     WorkflowRunNotFoundError,
@@ -2725,3 +2728,378 @@ async def test_workflows_maybe_disable_listeners_sync_method(
         uuid4(), should_disable=True, actor="admin", conn=None
     )
     assert calls == ["called"]
+
+
+# ---------------------------------------------------------------------------
+# _persistence.py: team_id injection and team-scoped ref resolution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_persistence_ensure_handle_available_locked_skips_when_handle_is_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_ensure_handle_available_locked returns immediately when handle is None."""
+    repo = make_repository(monkeypatch, [])
+
+    await repo._ensure_handle_available_locked(
+        None,
+        workflow_id=None,
+        is_archived=False,
+    )
+
+    assert len(repo._pool._connection.queries) == 0  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_persistence_ensure_handle_available_locked_global_update_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Handle validation uses the global update path when workspace_id is None and
+    workflow_id is provided (updating an existing unscoped workflow)."""
+    workflow_id = uuid4()
+    responses: list[Any] = [{"rows": []}]
+    repo = make_repository(monkeypatch, responses)
+
+    await repo._ensure_handle_available_locked(
+        "my-handle",
+        workflow_id=workflow_id,
+        is_archived=False,
+        workspace_id=None,
+    )
+
+    query, params = repo._pool._connection.queries[0]  # noqa: SLF001
+    assert "workspace_id IS NULL" in query
+    assert "id !=" in query
+    assert params == ("my-handle", str(workflow_id))
+
+
+@pytest.mark.asyncio
+async def test_persistence_deserialize_workflow_explicit_team_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit team_id argument is injected into the workflow payload."""
+    workflow_id = uuid4()
+    payload = _workflow_payload(workflow_id)
+
+    repo = make_repository(monkeypatch, [])
+    workflow = repo._deserialize_workflow(payload, team_id="team-abc")
+
+    assert workflow.team_id == "team-abc"
+
+
+@pytest.mark.asyncio
+async def test_persistence_resolve_workflow_ref_in_team_locked_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_resolve_workflow_ref_in_team_locked returns the UUID when the handle is found."""
+    workflow_id = uuid4()
+    responses: list[Any] = [{"row": {"id": str(workflow_id)}}]
+    repo = make_repository(monkeypatch, responses)
+
+    result = await repo._resolve_workflow_ref_in_team_locked(
+        "some-handle",
+        include_archived=False,
+        workspace_id="ws-a",
+        team_id="team-1",
+    )
+
+    assert result == workflow_id
+    query, params = repo._pool._connection.queries[0]  # noqa: SLF001
+    assert "COALESCE(team_id" in query
+    assert params == ("some-handle", "ws-a", "team-1", False)
+
+
+@pytest.mark.asyncio
+async def test_persistence_resolve_workflow_ref_in_team_locked_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_resolve_workflow_ref_in_team_locked raises WorkflowNotFoundError when no match."""
+    responses: list[Any] = [{"row": None}]
+    repo = make_repository(monkeypatch, responses)
+
+    with pytest.raises(WorkflowNotFoundError, match="missing-handle"):
+        await repo._resolve_workflow_ref_in_team_locked(
+            "missing-handle",
+            include_archived=True,
+            workspace_id="ws-a",
+            team_id="team-1",
+        )
+
+
+@pytest.mark.asyncio
+async def test_persistence_resolve_workflow_ref_locked_team_scope_delegates_to_helper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When both team_id and workspace_id are provided, resolution is scoped to the team
+    and delegates directly to _resolve_workflow_ref_in_team_locked."""
+    workflow_id = uuid4()
+    responses: list[Any] = [{"row": {"id": str(workflow_id)}}]
+    repo = make_repository(monkeypatch, responses)
+
+    result = await repo._resolve_workflow_ref_locked(
+        "some-handle",
+        workspace_id="ws-a",
+        team_id="team-1",
+    )
+
+    assert result == workflow_id
+    # Exactly one query: the team-scoped lookup; no global fallback
+    assert len(repo._pool._connection.queries) == 1  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# _teams.py: full coverage of all TeamRepositoryMixin methods
+# ---------------------------------------------------------------------------
+
+
+def _team_row(team_id: UUID, workspace_id: str, **overrides: Any) -> dict[str, Any]:
+    """Return a fake team database row."""
+    now = datetime.now(tz=UTC)
+    base: dict[str, Any] = {
+        "id": str(team_id),
+        "workspace_id": workspace_id,
+        "slug": "default",
+        "name": "Default",
+        "is_default": False,
+        "created_at": now,
+        "updated_at": now,
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.asyncio
+async def test_teams_row_to_team_builds_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_row_to_team converts a raw row dict into a Team model."""
+    team_id = uuid4()
+    repo = make_repository(monkeypatch, [])
+    row = _team_row(team_id, "ws-a", slug="sales", name="Sales", is_default=True)
+    team = repo._row_to_team(row)
+
+    assert team.id == team_id
+    assert team.workspace_id == "ws-a"
+    assert team.slug == "sales"
+    assert team.name == "Sales"
+    assert team.is_default is True
+
+
+@pytest.mark.asyncio
+async def test_teams_list_teams_returns_ordered_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """list_teams issues a workspace-scoped query and maps rows to Team models."""
+    team_a = uuid4()
+    team_b = uuid4()
+    responses: list[Any] = [
+        {
+            "rows": [
+                _team_row(team_a, "ws-a", slug="acme", name="Acme", is_default=True),
+                _team_row(team_b, "ws-a", slug="sales", name="Sales"),
+            ]
+        }
+    ]
+    repo = make_repository(monkeypatch, responses)
+
+    teams = await repo.list_teams(workspace_id="ws-a")
+
+    assert len(teams) == 2
+    assert teams[0].id == team_a
+    assert teams[0].is_default is True
+    assert teams[1].id == team_b
+    query, params = repo._pool._connection.queries[0]  # noqa: SLF001
+    assert "workspace_id = %s" in query
+    assert params == ("ws-a",)
+
+
+@pytest.mark.asyncio
+async def test_teams_get_team_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """get_team returns the team when a matching row exists."""
+    team_id = uuid4()
+    responses: list[Any] = [
+        {"row": _team_row(team_id, "ws-a", slug="acme", name="Acme")}
+    ]
+    repo = make_repository(monkeypatch, responses)
+
+    team = await repo.get_team(team_id, workspace_id="ws-a")
+
+    assert team.id == team_id
+    assert team.workspace_id == "ws-a"
+
+
+@pytest.mark.asyncio
+async def test_teams_get_team_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """get_team raises TeamNotFoundError when no matching row exists."""
+    team_id = uuid4()
+    responses: list[Any] = [{"row": None}]
+    repo = make_repository(monkeypatch, responses)
+
+    with pytest.raises(TeamNotFoundError):
+        await repo.get_team(team_id, workspace_id="ws-a")
+
+
+@pytest.mark.asyncio
+async def test_teams_get_team_by_slug_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """get_team_by_slug returns the team by normalized slug."""
+    team_id = uuid4()
+    responses: list[Any] = [
+        {"row": _team_row(team_id, "ws-a", slug="sales", name="Sales")}
+    ]
+    repo = make_repository(monkeypatch, responses)
+
+    # Slug is normalized to lowercase before querying
+    team = await repo.get_team_by_slug("Sales", workspace_id="ws-a")
+
+    assert team.id == team_id
+    assert team.slug == "sales"
+    query, params = repo._pool._connection.queries[0]  # noqa: SLF001
+    assert params == ("sales", "ws-a")
+
+
+@pytest.mark.asyncio
+async def test_teams_get_team_by_slug_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """get_team_by_slug raises TeamNotFoundError when no matching row exists."""
+    responses: list[Any] = [{"row": None}]
+    repo = make_repository(monkeypatch, responses)
+
+    with pytest.raises(TeamNotFoundError):
+        await repo.get_team_by_slug("missing", workspace_id="ws-a")
+
+
+@pytest.mark.asyncio
+async def test_teams_create_team_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """create_team inserts a row and returns the new Team model."""
+    responses: list[Any] = [{}]  # INSERT succeeds
+    repo = make_repository(monkeypatch, responses)
+
+    team = await repo.create_team(workspace_id="ws-a", name="Sales", slug="Sales")
+
+    assert team.name == "Sales"
+    assert team.slug == "sales"  # normalized to lowercase
+    assert team.workspace_id == "ws-a"
+    assert team.is_default is False
+    query, _ = repo._pool._connection.queries[0]  # noqa: SLF001
+    assert "INSERT INTO teams" in query
+
+
+@pytest.mark.asyncio
+async def test_teams_create_team_slug_conflict_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """create_team raises TeamSlugConflictError on a unique constraint violation."""
+
+    class _SlugConflictConnection(FakeConnection):
+        async def execute(self, query: str, params: Any = None) -> FakeCursor:
+            self.queries.append((query.strip(), params))
+            if "INSERT INTO teams" in query:
+                raise Exception(
+                    "duplicate key value violates unique constraint "
+                    '"teams_workspace_id_slug_key"'
+                )
+            return FakeCursor()
+
+    repo = make_repository(monkeypatch, [])
+    repo._pool = FakePool(_SlugConflictConnection([]))  # type: ignore[arg-type]
+
+    with pytest.raises(TeamSlugConflictError, match="sales"):
+        await repo.create_team(workspace_id="ws-a", name="Sales", slug="sales")
+
+
+@pytest.mark.asyncio
+async def test_teams_create_team_propagates_non_unique_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """create_team re-raises DB exceptions that are not slug conflicts."""
+
+    class _BoomConnection(FakeConnection):
+        async def execute(self, query: str, params: Any = None) -> FakeCursor:
+            self.queries.append((query.strip(), params))
+            if "INSERT INTO teams" in query:
+                raise RuntimeError("disk full")
+            return FakeCursor()
+
+    repo = make_repository(monkeypatch, [])
+    repo._pool = FakePool(_BoomConnection([]))  # type: ignore[arg-type]
+
+    with pytest.raises(RuntimeError, match="disk full"):
+        await repo.create_team(workspace_id="ws-a", name="Sales", slug="sales")
+
+
+@pytest.mark.asyncio
+async def test_teams_ensure_default_team_returns_existing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ensure_default_team returns the existing default team when one is found."""
+    team_id = uuid4()
+    responses: list[Any] = [
+        {"row": _team_row(team_id, "ws-a", slug="acme", name="Acme", is_default=True)}
+    ]
+    repo = make_repository(monkeypatch, responses)
+
+    team = await repo.ensure_default_team(workspace_id="ws-a", name="Acme", slug="acme")
+
+    assert team.id == team_id
+    assert team.is_default is True
+    # Only the SELECT was issued; no INSERT
+    assert len(repo._pool._connection.queries) == 1  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_teams_ensure_default_team_creates_when_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ensure_default_team creates and returns a new default team when none exists."""
+    responses: list[Any] = [
+        {"row": None},  # SELECT: no default team found
+        {},  # INSERT: succeeds
+    ]
+    repo = make_repository(monkeypatch, responses)
+
+    team = await repo.ensure_default_team(workspace_id="ws-a", name="Acme", slug="acme")
+
+    assert team.name == "Acme"
+    assert team.slug == "acme"
+    assert team.is_default is True
+    queries = [q for q, _ in repo._pool._connection.queries]  # noqa: SLF001
+    assert any("INSERT INTO teams" in q for q in queries)
+
+
+@pytest.mark.asyncio
+async def test_teams_delete_team_not_found_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """delete_team raises TeamNotFoundError when the team does not exist."""
+    team_id = uuid4()
+    responses: list[Any] = [{"row": None}]
+    repo = make_repository(monkeypatch, responses)
+
+    with pytest.raises(TeamNotFoundError):
+        await repo.delete_team(team_id, workspace_id="ws-a")
+
+
+@pytest.mark.asyncio
+async def test_teams_delete_team_not_empty_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """delete_team raises TeamNotEmptyError when the team still has active colleagues."""
+    team_id = uuid4()
+    responses: list[Any] = [
+        {"row": {"name": "Sales"}},  # SELECT team name — found
+        {"row": {"cnt": 2}},  # SELECT count of active workflows — non-zero
+    ]
+    repo = make_repository(monkeypatch, responses)
+
+    with pytest.raises(TeamNotEmptyError, match="Sales"):
+        await repo.delete_team(team_id, workspace_id="ws-a")

--- a/tests/backend/repository/test_postgres_repository_additional.py
+++ b/tests/backend/repository/test_postgres_repository_additional.py
@@ -605,8 +605,7 @@ async def test_postgres_ensure_initialized_creates_workspace_indexes(
         for query in queries
     )
     assert any(
-        "CREATE UNIQUE INDEX IF NOT EXISTS idx_workflows_active_handle_workspace"
-        in query
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_workflows_active_handle_team" in query
         for query in queries
     )
     assert any(
@@ -1600,8 +1599,9 @@ async def test_persistence_ensure_handle_available_locked_workspace_create_path(
 
     query, params = repo._pool._connection.queries[0]  # noqa: SLF001
     assert "workspace_id = %s" in query
+    assert "COALESCE(team_id, '') = COALESCE(%s, '')" in query
     assert "id !=" not in query
-    assert params == ("scoped-handle", "ws-a")
+    assert params == ("scoped-handle", "ws-a", None)
 
 
 @pytest.mark.asyncio
@@ -1622,8 +1622,9 @@ async def test_persistence_ensure_handle_available_locked_workspace_update_path(
 
     query, params = repo._pool._connection.queries[0]  # noqa: SLF001
     assert "workspace_id = %s" in query
+    assert "COALESCE(team_id, '') = COALESCE(%s, '')" in query
     assert "id !=" in query
-    assert params == ("scoped-handle", "ws-a", str(workflow_id))
+    assert params == ("scoped-handle", "ws-a", None, str(workflow_id))
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_app_workflow_crud.py
+++ b/tests/backend/test_app_workflow_crud.py
@@ -230,7 +230,12 @@ async def test_resolve_workflow_id_rejects_workspace_mismatch() -> None:
 
     class Repository:
         async def resolve_workflow_ref(
-            self, workflow_ref, *, include_archived=True, workspace_id=None
+            self,
+            workflow_ref,
+            *,
+            include_archived=True,
+            workspace_id=None,
+            team_id=None,
         ):
             del include_archived
             if workspace_id is not None and workspace_id != str(other_workspace):
@@ -267,9 +272,14 @@ async def test_load_workflow_for_request_rejects_workspace_mismatch() -> None:
 
     class Repository:
         async def resolve_workflow_ref(
-            self, workflow_ref, *, include_archived=True, workspace_id=None
+            self,
+            workflow_ref,
+            *,
+            include_archived=True,
+            workspace_id=None,
+            team_id=None,
         ):
-            del workflow_ref, include_archived, workspace_id
+            del workflow_ref, include_archived, workspace_id, team_id
             return workflow_id
 
         async def get_workflow(self, wf_id, *, workspace_id=None):
@@ -411,7 +421,12 @@ async def test_get_workflow_returns_workflow() -> None:
 
     class Repository:
         async def resolve_workflow_ref(
-            self, workflow_ref, *, include_archived=True, workspace_id=None
+            self,
+            workflow_ref,
+            *,
+            include_archived=True,
+            workspace_id=None,
+            team_id=None,
         ):
             del workflow_ref, include_archived
             return workflow_id
@@ -438,7 +453,12 @@ async def test_get_workflow_not_found() -> None:
 
     class Repository:
         async def resolve_workflow_ref(
-            self, workflow_ref, *, include_archived=True, workspace_id=None
+            self,
+            workflow_ref,
+            *,
+            include_archived=True,
+            workspace_id=None,
+            team_id=None,
         ):
             del workflow_ref, include_archived
             return workflow_id
@@ -473,7 +493,12 @@ async def test_get_workflow_returns_compact_versions() -> None:
 
     class Repository:
         async def resolve_workflow_ref(
-            self, workflow_ref, *, include_archived=True, workspace_id=None
+            self,
+            workflow_ref,
+            *,
+            include_archived=True,
+            workspace_id=None,
+            team_id=None,
         ):
             del workflow_ref, include_archived
             return workflow_id
@@ -506,7 +531,12 @@ async def test_update_workflow_returns_updated() -> None:
 
     class Repository:
         async def resolve_workflow_ref(
-            self, workflow_ref, *, include_archived=True, workspace_id=None
+            self,
+            workflow_ref,
+            *,
+            include_archived=True,
+            workspace_id=None,
+            team_id=None,
         ):
             del workflow_ref, include_archived
             return workflow_id
@@ -568,7 +598,12 @@ async def test_update_workflow_not_found() -> None:
 
     class Repository:
         async def resolve_workflow_ref(
-            self, workflow_ref, *, include_archived=True, workspace_id=None
+            self,
+            workflow_ref,
+            *,
+            include_archived=True,
+            workspace_id=None,
+            team_id=None,
         ):
             del workflow_ref, include_archived
             return workflow_id
@@ -611,7 +646,12 @@ async def test_update_workflow_translates_handle_conflicts() -> None:
 
     class Repository:
         async def resolve_workflow_ref(
-            self, workflow_ref, *, include_archived=True, workspace_id=None
+            self,
+            workflow_ref,
+            *,
+            include_archived=True,
+            workspace_id=None,
+            team_id=None,
         ):
             del workflow_ref, include_archived
             return workflow_id
@@ -663,7 +703,12 @@ async def test_archive_workflow_returns_archived() -> None:
 
     class Repository:
         async def resolve_workflow_ref(
-            self, workflow_ref, *, include_archived=True, workspace_id=None
+            self,
+            workflow_ref,
+            *,
+            include_archived=True,
+            workspace_id=None,
+            team_id=None,
         ):
             del workflow_ref, include_archived
             return workflow_id
@@ -703,7 +748,12 @@ async def test_archive_workflow_not_found() -> None:
 
     class Repository:
         async def resolve_workflow_ref(
-            self, workflow_ref, *, include_archived=True, workspace_id=None
+            self,
+            workflow_ref,
+            *,
+            include_archived=True,
+            workspace_id=None,
+            team_id=None,
         ):
             del workflow_ref, include_archived
             return workflow_id
@@ -727,7 +777,12 @@ async def test_archive_workflow_allows_managed_vibe_workflow() -> None:
 
     class Repository:
         async def resolve_workflow_ref(
-            self, workflow_ref, *, include_archived=True, workspace_id=None
+            self,
+            workflow_ref,
+            *,
+            include_archived=True,
+            workspace_id=None,
+            team_id=None,
         ):
             del workflow_ref, include_archived
             return workflow_id

--- a/tests/backend/test_app_workflow_crud.py
+++ b/tests/backend/test_app_workflow_crud.py
@@ -35,6 +35,7 @@ _MOCK_WORKSPACE = SimpleNamespace(
     workspace_id=uuid4(),
     user_id="test-user",
     slug="test-workspace",
+    workspace_slug="test-workspace",
     quotas=SimpleNamespace(
         max_credentials=1000,
         max_workflows=1000,

--- a/tests/backend/test_app_workflow_crud.py
+++ b/tests/backend/test_app_workflow_crud.py
@@ -102,6 +102,10 @@ async def test_list_workflows_returns_all() -> None:
             del include_archived
             return [workflow1, workflow2]
 
+        async def list_teams(self, *, workspace_id=None):
+            del workspace_id
+            return []
+
         async def get_latest_version(self, workflow_id):
             del workflow_id
             raise WorkflowVersionNotFoundError("No versions")
@@ -147,6 +151,10 @@ async def test_list_workflows_fetches_metadata_concurrently() -> None:
         ):
             del include_archived
             return [workflow1, workflow2]
+
+        async def list_teams(self, *, workspace_id=None):
+            del workspace_id
+            return []
 
         async def get_latest_version(self, workflow_id):
             del workflow_id
@@ -781,6 +789,10 @@ async def test_list_workflows_excludes_archived_managed_workflow_by_default(
             del include_archived, workspace_id
             return []
 
+        async def list_teams(self, *, workspace_id=None):
+            del workspace_id
+            return []
+
         async def get_latest_version(self, workflow_id):
             del workflow_id
             raise WorkflowVersionNotFoundError("No versions")
@@ -819,6 +831,10 @@ async def test_list_workflows_includes_archived_managed_workflow_when_requested(
     class Repository:
         async def list_workflows(self, *, include_archived=False, workspace_id=None):
             del include_archived, workspace_id
+            return []
+
+        async def list_teams(self, *, workspace_id=None):
+            del workspace_id
             return []
 
         async def get_latest_version(self, workflow_id):

--- a/tests/backend/test_routers_candidates.py
+++ b/tests/backend/test_routers_candidates.py
@@ -28,7 +28,7 @@ _SAMPLE = CandidateItem(
     entrypoint="graph",
 )
 
-_MOCK_WORKSPACE = SimpleNamespace(workspace_id=uuid4())
+_MOCK_WORKSPACE = SimpleNamespace(workspace_id=uuid4(), workspace_slug="acme")
 
 
 @pytest.fixture(autouse=True)
@@ -108,7 +108,7 @@ class _Repository:
         self.last_runnable_config: dict | None = None
 
     async def resolve_workflow_ref(
-        self, workflow_ref, *, include_archived=True, workspace_id=None
+        self, workflow_ref, *, include_archived=True, workspace_id=None, team_id=None
     ) -> UUID:
         from orcheo_backend.app.repository import WorkflowNotFoundError
 
@@ -119,6 +119,16 @@ class _Repository:
     async def get_workflow(self, workflow_id, *, workspace_id=None) -> Workflow:
         assert self._existing is not None
         return self._existing
+
+    async def ensure_default_team(self, *, workspace_id, name, slug):
+        from orcheo.models import Team
+
+        return Team(workspace_id=workspace_id, name=name, slug=slug, is_default=True)
+
+    async def get_team(self, team_id, *, workspace_id):
+        from orcheo.models import Team
+
+        return Team(id=team_id, workspace_id=workspace_id, name="Team", slug="team")
 
     async def create_workflow(
         self,
@@ -131,6 +141,7 @@ class _Repository:
         draft_access,
         actor,
         workspace_id=None,
+        team_id=None,
     ) -> Workflow:  # noqa: PLR0913
         wf = _make_workflow(uuid4(), name=name)
         self.created_workflow = wf

--- a/tests/backend/test_team_model.py
+++ b/tests/backend/test_team_model.py
@@ -1,0 +1,44 @@
+"""Coverage for the team model and slug normalization helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from orcheo.models import Team, normalize_team_slug
+
+
+def test_normalize_team_slug_trims_and_lowercases() -> None:
+    assert normalize_team_slug("  Sales-Team  ") == "sales-team"
+
+
+@pytest.mark.parametrize(
+    ("value", "message"),
+    [
+        ("   ", "Team slug must not be empty."),
+        (
+            "sales/team",
+            "Team slug must contain only alphanumeric characters, hyphens, or underscores.",
+        ),
+    ],
+)
+def test_normalize_team_slug_rejects_invalid_values(value: str, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        normalize_team_slug(value)
+
+
+def test_team_model_coerces_slug_and_name() -> None:
+    team = Team(
+        workspace_id="workspace-1",
+        name="  Sales Team  ",
+        slug="  SALES-Team  ",
+        is_default=True,
+    )
+
+    assert team.name == "Sales Team"
+    assert team.slug == "sales-team"
+    assert team.is_default is True
+
+
+def test_team_model_rejects_empty_name() -> None:
+    with pytest.raises(ValueError, match="Team name must not be empty."):
+        Team(workspace_id="workspace-1", name="   ", slug="sales")

--- a/tests/backend/test_teams.py
+++ b/tests/backend/test_teams.py
@@ -157,6 +157,32 @@ async def test_create_team_endpoint_then_conflict() -> None:
     assert exc.value.status_code == 409
 
 
+@pytest.mark.asyncio
+async def test_create_team_endpoint_rejects_invalid_payload() -> None:
+    repo = InMemoryWorkflowRepository()
+    from orcheo_backend.app.schemas.teams import TeamCreateRequest
+
+    with pytest.raises(HTTPException) as exc:
+        await teams_router.create_team(
+            TeamCreateRequest(name="   ", slug="sales"),
+            repo,
+            WORKSPACE,  # type: ignore[arg-type]
+        )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail["code"] == "team.invalid"
+
+
+@pytest.mark.asyncio
+async def test_delete_team_endpoint_maps_missing_team_to_404() -> None:
+    repo = InMemoryWorkflowRepository()
+    with pytest.raises(HTTPException) as exc:
+        await teams_router.delete_team(uuid4(), repo, WORKSPACE)  # type: ignore[arg-type]
+
+    assert exc.value.status_code == 404
+    assert exc.value.detail["code"] == "team.not_found"
+
+
 # ---------------------------------------------------------------------------
 # Team-aware onboarding
 # ---------------------------------------------------------------------------
@@ -299,3 +325,60 @@ async def test_delete_team_endpoint_returns_409_when_not_empty(
     with pytest.raises(HTTPException) as exc:
         await teams_router.delete_team(team_id, repo, WORKSPACE)  # type: ignore[arg-type]
     assert exc.value.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# Additional in-memory coverage: get_team_by_slug, ensure_default_team orphan,
+# and delete_team default-tracking cleanup
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_team_by_slug_returns_matching_team() -> None:
+    repo = InMemoryWorkflowRepository()
+    await repo.create_team(workspace_id=WS, name="Sales", slug="sales")
+    team = await repo.get_team_by_slug("sales", workspace_id=WS)
+    assert team.slug == "sales"
+    assert team.name == "Sales"
+
+
+@pytest.mark.asyncio
+async def test_get_team_by_slug_skips_non_matching_teams() -> None:
+    """get_team_by_slug iterates past non-matching teams to find the right one."""
+    repo = InMemoryWorkflowRepository()
+    await repo.create_team(workspace_id=WS, name="Acme", slug="acme")
+    await repo.create_team(workspace_id=WS, name="Sales", slug="sales")
+    team = await repo.get_team_by_slug("sales", workspace_id=WS)
+    assert team.slug == "sales"
+
+
+@pytest.mark.asyncio
+async def test_get_team_by_slug_raises_when_not_found() -> None:
+    """get_team_by_slug raises TeamNotFoundError when the slug does not exist."""
+    repo = InMemoryWorkflowRepository()
+    with pytest.raises(TeamNotFoundError):
+        await repo.get_team_by_slug("nonexistent", workspace_id=WS)
+
+
+@pytest.mark.asyncio
+async def test_ensure_default_team_recreates_when_reference_is_orphaned() -> None:
+    """ensure_default_team creates a fresh team when the tracked ID is stale."""
+    from uuid import uuid4
+
+    repo = InMemoryWorkflowRepository()
+    orphan_id = str(uuid4())
+    # Inject an orphaned pointer — the UUID doesn't exist in _teams
+    repo._default_team_by_workspace[WS] = orphan_id
+    team = await repo.ensure_default_team(workspace_id=WS, name="Acme", slug="acme")
+    assert str(team.id) != orphan_id
+    assert team.is_default is True
+
+
+@pytest.mark.asyncio
+async def test_delete_default_team_clears_workspace_default_tracking() -> None:
+    """Deleting the default team removes the workspace entry from default tracking."""
+    repo = InMemoryWorkflowRepository()
+    team = await repo.ensure_default_team(workspace_id=WS, name="Acme", slug="acme")
+    assert repo._default_team_by_workspace.get(WS) == str(team.id)
+    await repo.delete_team(team.id, workspace_id=WS)
+    assert WS not in repo._default_team_by_workspace

--- a/tests/backend/test_teams.py
+++ b/tests/backend/test_teams.py
@@ -263,6 +263,19 @@ async def test_delete_team_with_colleagues_raises() -> None:
 
 
 @pytest.mark.asyncio
+async def test_delete_team_ignores_archived_colleagues() -> None:
+    repo = InMemoryWorkflowRepository()
+    team = await repo.create_team(workspace_id=WS, name="Temp", slug="temp")
+    colleague = await _new_colleague(repo, "bot", str(team.id))
+    await repo.archive_workflow(colleague.id, actor="tester")
+
+    await repo.delete_team(team.id, workspace_id=WS)
+
+    teams = await repo.list_teams(workspace_id=WS)
+    assert not any(t.id == team.id for t in teams)
+
+
+@pytest.mark.asyncio
 async def test_delete_unknown_team_raises() -> None:
     repo = InMemoryWorkflowRepository()
     with pytest.raises(TeamNotFoundError):

--- a/tests/backend/test_teams.py
+++ b/tests/backend/test_teams.py
@@ -1,0 +1,237 @@
+"""Tests for team grouping: repository semantics, endpoints, and onboarding."""
+
+from __future__ import annotations
+from types import SimpleNamespace
+from uuid import uuid4
+import pytest
+from fastapi import HTTPException
+from orcheo.models import WorkflowDraftAccess
+from orcheo_backend.app.repository import (
+    InMemoryWorkflowRepository,
+    TeamSlugConflictError,
+    WorkflowHandleConflictError,
+    WorkflowNotFoundError,
+)
+from orcheo_backend.app.routers import candidates as candidates_router
+from orcheo_backend.app.routers import teams as teams_router
+from orcheo_backend.app.routers.candidates import CandidateOnboardRequest
+from orcheo_backend.app.schemas.candidates import CandidateItem
+
+
+WS = "11111111-1111-1111-1111-111111111111"
+WORKSPACE = SimpleNamespace(workspace_id=WS, workspace_slug="acme")
+
+
+_CANDIDATE = CandidateItem(
+    id="insight-analyst",
+    handle="insight-analyst",
+    name="Insight Analyst",
+    description="An analyst agent.",
+    script=(
+        "from langgraph.graph import StateGraph\n"
+        "graph = StateGraph(dict)\n"
+        "graph.add_node('run', lambda x: x)"
+    ),
+    entrypoint="graph",
+)
+
+
+async def _new_colleague(repo, handle, team_id):
+    return await repo.create_workflow(
+        name=handle,
+        handle=handle,
+        slug=None,
+        description=None,
+        tags=None,
+        draft_access=WorkflowDraftAccess.WORKSPACE,
+        actor="t",
+        workspace_id=WS,
+        team_id=team_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Repository semantics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_default_team_is_created_once_and_listed_first() -> None:
+    repo = InMemoryWorkflowRepository()
+    first = await repo.ensure_default_team(workspace_id=WS, name="Acme", slug="acme")
+    again = await repo.ensure_default_team(workspace_id=WS, name="Acme", slug="acme")
+    assert first.id == again.id
+    assert first.is_default is True
+
+    await repo.create_team(workspace_id=WS, name="Sales", slug="sales")
+    teams = await repo.list_teams(workspace_id=WS)
+    assert [t.slug for t in teams] == ["acme", "sales"]
+    assert teams[0].is_default is True
+
+
+@pytest.mark.asyncio
+async def test_same_handle_allowed_across_teams_but_not_within_team() -> None:
+    repo = InMemoryWorkflowRepository()
+    default = await repo.ensure_default_team(workspace_id=WS, name="Acme", slug="acme")
+    sales = await repo.create_team(workspace_id=WS, name="Sales", slug="sales")
+
+    a = await _new_colleague(repo, "bot", str(default.id))
+    b = await _new_colleague(repo, "bot", str(sales.id))
+    assert a.id != b.id
+
+    with pytest.raises(WorkflowHandleConflictError):
+        await _new_colleague(repo, "bot", str(sales.id))
+
+
+@pytest.mark.asyncio
+async def test_bare_handle_resolves_to_default_team() -> None:
+    repo = InMemoryWorkflowRepository()
+    default = await repo.ensure_default_team(workspace_id=WS, name="Acme", slug="acme")
+    sales = await repo.create_team(workspace_id=WS, name="Sales", slug="sales")
+
+    default_wf = await _new_colleague(repo, "bot", str(default.id))
+    await _new_colleague(repo, "bot", str(sales.id))
+
+    resolved = await repo.resolve_workflow_ref(
+        "bot", workspace_id=WS, include_archived=False
+    )
+    assert resolved == default_wf.id
+
+
+@pytest.mark.asyncio
+async def test_team_scoped_resolution_misses_other_teams() -> None:
+    repo = InMemoryWorkflowRepository()
+    default = await repo.ensure_default_team(workspace_id=WS, name="Acme", slug="acme")
+    sales = await repo.create_team(workspace_id=WS, name="Sales", slug="sales")
+    await _new_colleague(repo, "bot", str(default.id))
+
+    with pytest.raises(WorkflowNotFoundError):
+        await repo.resolve_workflow_ref(
+            "bot", workspace_id=WS, team_id=str(sales.id), include_archived=False
+        )
+
+
+@pytest.mark.asyncio
+async def test_duplicate_team_slug_conflicts() -> None:
+    repo = InMemoryWorkflowRepository()
+    await repo.create_team(workspace_id=WS, name="Sales", slug="sales")
+    with pytest.raises(TeamSlugConflictError):
+        await repo.create_team(workspace_id=WS, name="Sales 2", slug="sales")
+
+
+# ---------------------------------------------------------------------------
+# /teams endpoints
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_teams_provisions_default_team() -> None:
+    repo = InMemoryWorkflowRepository()
+    result = await teams_router.list_teams(repo, WORKSPACE)  # type: ignore[arg-type]
+    assert len(result) == 1
+    assert result[0].is_default is True
+    assert result[0].slug == "acme"
+
+
+@pytest.mark.asyncio
+async def test_create_team_endpoint_then_conflict() -> None:
+    repo = InMemoryWorkflowRepository()
+    from orcheo_backend.app.schemas.teams import TeamCreateRequest
+
+    created = await teams_router.create_team(
+        TeamCreateRequest(name="Sales", slug="sales"),
+        repo,
+        WORKSPACE,  # type: ignore[arg-type]
+    )
+    assert created.slug == "sales"
+    assert created.is_default is False
+
+    with pytest.raises(HTTPException) as exc:
+        await teams_router.create_team(
+            TeamCreateRequest(name="Sales", slug="sales"),
+            repo,
+            WORKSPACE,  # type: ignore[arg-type]
+        )
+    assert exc.value.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# Team-aware onboarding
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def _patch_onboarding(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_get_candidates() -> list[CandidateItem]:
+        return [_CANDIDATE]
+
+    async def _no_quota(repository, workspace) -> None:  # noqa: ARG001
+        return None
+
+    monkeypatch.setattr(candidates_router, "get_candidates", fake_get_candidates)
+    monkeypatch.setattr(candidates_router, "ensure_workspace_workflow_quota", _no_quota)
+
+
+@pytest.mark.asyncio
+async def test_onboard_defaults_to_default_team(
+    _patch_onboarding: None,
+) -> None:
+    repo = InMemoryWorkflowRepository()
+    request = CandidateOnboardRequest(id="insight-analyst")
+    wf = await candidates_router.onboard_candidate(request, repo, WORKSPACE)  # type: ignore[arg-type]
+
+    default = await repo.ensure_default_team(workspace_id=WS, name="acme", slug="acme")
+    stored = await repo.get_workflow(wf.id, workspace_id=WS)
+    assert stored.team_id == str(default.id)
+
+
+@pytest.mark.asyncio
+async def test_onboard_same_candidate_into_two_teams_creates_two_colleagues(
+    _patch_onboarding: None,
+) -> None:
+    repo = InMemoryWorkflowRepository()
+    sales = await repo.create_team(workspace_id=WS, name="Sales", slug="sales")
+
+    default_wf = await candidates_router.onboard_candidate(
+        CandidateOnboardRequest(id="insight-analyst"),
+        repo,
+        WORKSPACE,  # type: ignore[arg-type]
+    )
+    sales_wf = await candidates_router.onboard_candidate(
+        CandidateOnboardRequest(id="insight-analyst", team_id=str(sales.id)),
+        repo,
+        WORKSPACE,  # type: ignore[arg-type]
+    )
+    assert default_wf.id != sales_wf.id
+
+    workflows = await repo.list_workflows(workspace_id=WS)
+    assert len(workflows) == 2
+
+
+@pytest.mark.asyncio
+async def test_reonboard_same_team_bumps_version(_patch_onboarding: None) -> None:
+    repo = InMemoryWorkflowRepository()
+    first = await candidates_router.onboard_candidate(
+        CandidateOnboardRequest(id="insight-analyst"),
+        repo,
+        WORKSPACE,  # type: ignore[arg-type]
+    )
+    second = await candidates_router.onboard_candidate(
+        CandidateOnboardRequest(id="insight-analyst"),
+        repo,
+        WORKSPACE,  # type: ignore[arg-type]
+    )
+    assert first.id == second.id
+    versions = await repo.list_versions(first.id)
+    assert len(versions) == 2
+
+
+@pytest.mark.asyncio
+async def test_onboard_into_unknown_team_returns_404(
+    _patch_onboarding: None,
+) -> None:
+    repo = InMemoryWorkflowRepository()
+    request = CandidateOnboardRequest(id="insight-analyst", team_id=str(uuid4()))
+    with pytest.raises(HTTPException) as exc:
+        await candidates_router.onboard_candidate(request, repo, WORKSPACE)  # type: ignore[arg-type]
+    assert exc.value.status_code == 404

--- a/tests/backend/test_teams.py
+++ b/tests/backend/test_teams.py
@@ -8,6 +8,8 @@ from fastapi import HTTPException
 from orcheo.models import WorkflowDraftAccess
 from orcheo_backend.app.repository import (
     InMemoryWorkflowRepository,
+    TeamNotEmptyError,
+    TeamNotFoundError,
     TeamSlugConflictError,
     WorkflowHandleConflictError,
     WorkflowNotFoundError,
@@ -235,3 +237,52 @@ async def test_onboard_into_unknown_team_returns_404(
     with pytest.raises(HTTPException) as exc:
         await candidates_router.onboard_candidate(request, repo, WORKSPACE)  # type: ignore[arg-type]
     assert exc.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# delete_team
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_empty_team_succeeds() -> None:
+    repo = InMemoryWorkflowRepository()
+    team = await repo.create_team(workspace_id=WS, name="Temp", slug="temp")
+    await repo.delete_team(team.id, workspace_id=WS)
+    teams = await repo.list_teams(workspace_id=WS)
+    assert not any(t.id == team.id for t in teams)
+
+
+@pytest.mark.asyncio
+async def test_delete_team_with_colleagues_raises() -> None:
+    repo = InMemoryWorkflowRepository()
+    team = await repo.create_team(workspace_id=WS, name="Temp", slug="temp")
+    await _new_colleague(repo, "bot", str(team.id))
+    with pytest.raises(TeamNotEmptyError):
+        await repo.delete_team(team.id, workspace_id=WS)
+
+
+@pytest.mark.asyncio
+async def test_delete_unknown_team_raises() -> None:
+    repo = InMemoryWorkflowRepository()
+    with pytest.raises(TeamNotFoundError):
+        await repo.delete_team(uuid4(), workspace_id=WS)
+
+
+@pytest.mark.asyncio
+async def test_delete_team_endpoint_returns_409_when_not_empty(
+    _patch_onboarding: None,
+) -> None:
+    repo = InMemoryWorkflowRepository()
+    wf = await candidates_router.onboard_candidate(
+        CandidateOnboardRequest(id="insight-analyst"),
+        repo,
+        WORKSPACE,  # type: ignore[arg-type]
+    )
+    stored = await repo.get_workflow(wf.id, workspace_id=WS)
+    from uuid import UUID
+
+    team_id = UUID(stored.team_id)  # type: ignore[arg-type]
+    with pytest.raises(HTTPException) as exc:
+        await teams_router.delete_team(team_id, repo, WORKSPACE)  # type: ignore[arg-type]
+    assert exc.value.status_code == 409

--- a/tests/backend/test_teams_service.py
+++ b/tests/backend/test_teams_service.py
@@ -1,0 +1,78 @@
+"""Coverage for default-team provisioning service helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from orcheo.models import Team
+from orcheo_backend.app import teams_service
+
+
+class _Repository:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, str]] = []
+
+    async def ensure_default_team(
+        self, *, workspace_id: str, name: str, slug: str
+    ) -> Team:
+        self.calls.append((workspace_id, name, slug))
+        return Team(workspace_id=workspace_id, name=name, slug=slug, is_default=True)
+
+
+class _WorkspaceRepository:
+    def __init__(self, record: object | None = None, error: Exception | None = None):
+        self.record = record
+        self.error = error
+
+    def get_workspace(self, workspace_id):  # noqa: ANN001
+        del workspace_id
+        if self.error is not None:
+            raise self.error
+        return self.record
+
+
+@pytest.mark.asyncio
+async def test_ensure_default_team_uses_workspace_name_when_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid4()
+    repository = _Repository()
+    monkeypatch.setattr(
+        teams_service,
+        "get_workspace_repository",
+        lambda: _WorkspaceRepository(SimpleNamespace(name="Acme Workspace")),
+    )
+
+    team = await teams_service.ensure_default_team(
+        repository,
+        SimpleNamespace(workspace_id=workspace_id, workspace_slug="acme"),
+    )
+
+    assert team.is_default is True
+    assert repository.calls == [(str(workspace_id), "Acme Workspace", "acme")]
+
+
+@pytest.mark.asyncio
+async def test_ensure_default_team_falls_back_to_workspace_slug(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid4()
+    repository = _Repository()
+    monkeypatch.setattr(
+        teams_service,
+        "get_workspace_repository",
+        lambda: _WorkspaceRepository(error=RuntimeError("missing workspace")),
+    )
+
+    team = await teams_service.ensure_default_team(
+        repository,
+        SimpleNamespace(workspace_id=workspace_id, workspace_slug=None),
+    )
+
+    assert team.slug == str(workspace_id)
+    assert repository.calls == [
+        (str(workspace_id), str(workspace_id), str(workspace_id))
+    ]

--- a/tests/backend/test_workflows_router_actor_and_workspace_tags.py
+++ b/tests/backend/test_workflows_router_actor_and_workspace_tags.py
@@ -19,6 +19,7 @@ from orcheo_backend.app.schemas.workflows import (
 
 _MOCK_WORKSPACE = SimpleNamespace(
     workspace_id=uuid4(),
+    workspace_slug="test",
     quotas=WorkspaceQuotas(),
 )
 
@@ -146,7 +147,9 @@ async def test_get_workflow_page_allows_managed_workflow_across_workspaces() -> 
     payload = await workflows.get_workflow_page(
         workflow_ref=MANAGED_VIBE_WORKFLOW_HANDLE,
         repository=repository,
-        workspace=SimpleNamespace(workspace_id=current_workspace),
+        workspace=SimpleNamespace(
+            workspace_id=current_workspace, workspace_slug="test"
+        ),
     )
 
     assert payload.workflow.id == workflow.id
@@ -173,7 +176,9 @@ async def test_update_workflow_allows_managed_workflow_across_workspaces() -> No
         workflow_ref=MANAGED_VIBE_WORKFLOW_HANDLE,
         request=request,
         repository=repository,
-        workspace=SimpleNamespace(workspace_id=current_workspace),
+        workspace=SimpleNamespace(
+            workspace_id=current_workspace, workspace_slug="test"
+        ),
         policy=AuthorizationPolicy(
             RequestContext(
                 subject="studio-app",

--- a/tests/backend/test_workflows_router_actor_and_workspace_tags.py
+++ b/tests/backend/test_workflows_router_actor_and_workspace_tags.py
@@ -98,7 +98,7 @@ class _Repository:
         )
 
     async def resolve_workflow_ref(
-        self, workflow_ref, *, include_archived=True, workspace_id=None
+        self, workflow_ref, *, include_archived=True, workspace_id=None, team_id=None
     ):
         del include_archived
         return UUID(str(workflow_ref))
@@ -116,9 +116,9 @@ class _RepositoryWithExistingWorkflow(_Repository):
         return self._existing_workflow
 
     async def resolve_workflow_ref(
-        self, workflow_ref, *, include_archived=True, workspace_id=None
+        self, workflow_ref, *, include_archived=True, workspace_id=None, team_id=None
     ):
-        del include_archived, workspace_id
+        del include_archived, workspace_id, team_id
         if str(workflow_ref) == MANAGED_VIBE_WORKFLOW_HANDLE:
             return self._existing_workflow.id
         return UUID(str(workflow_ref))

--- a/tests/backend/test_workflows_router_chatkit_session.py
+++ b/tests/backend/test_workflows_router_chatkit_session.py
@@ -33,6 +33,7 @@ class _WorkflowRepo:
         *,
         include_archived: bool = True,
         workspace_id: str | None = None,
+        team_id: str | None = None,
     ) -> UUID:
         del include_archived
         if UUID(str(workflow_ref)) != self._workflow.id:
@@ -58,6 +59,7 @@ class _MissingWorkflowRepo:
         *,
         include_archived: bool = True,
         workspace_id: str | None = None,
+        team_id: str | None = None,
     ) -> UUID:
         del include_archived
         raise WorkflowNotFoundError(str(workflow_ref))
@@ -73,6 +75,7 @@ class _ResolveThenMissingWorkflowRepo:
         *,
         include_archived: bool = True,
         workspace_id: str | None = None,
+        team_id: str | None = None,
     ) -> UUID:
         del include_archived
         return UUID(str(workflow_ref))
@@ -156,6 +159,7 @@ class _ArchivedWorkflowRepo:
         *,
         include_archived: bool = True,
         workspace_id: str | None = None,
+        team_id: str | None = None,
     ) -> UUID:
         del include_archived
         if UUID(str(workflow_ref)) != self._workflow.id:

--- a/tests/backend/test_workflows_router_internal.py
+++ b/tests/backend/test_workflows_router_internal.py
@@ -1,0 +1,353 @@
+"""Coverage for internal workflow router helpers and slug-scoped public access."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from orcheo.models import Workflow
+from orcheo_backend.app.repository import WorkflowNotFoundError
+from orcheo_backend.app.routers import workflows
+from orcheo_backend.app.routers.workflows import (
+    _apply_share_url,
+    _resolve_team_id_from_slug,
+    _resolve_team_slug,
+    _resolve_workspace_id_from_slug,
+)
+
+
+class _WorkspaceService:
+    def __init__(self, workspace_id: UUID | None) -> None:
+        self.repository = self
+        self._workspace_id = workspace_id
+
+    def get_workspace_by_slug(self, slug: str) -> object | None:
+        del slug
+        if self._workspace_id is None:
+            return None
+        return SimpleNamespace(id=self._workspace_id)
+
+
+class _WorkspaceLookupFailure:
+    def get_workspace(self, workspace_id: UUID) -> object:
+        del workspace_id
+        raise RuntimeError("workspace lookup failed")
+
+
+class _WorkspaceLookupError:
+    def get_workspace_by_slug(self, slug: str) -> object:
+        del slug
+        raise RuntimeError("boom")
+
+
+class _PublicWorkflowRepository:
+    def __init__(
+        self,
+        workflow: Workflow,
+        *,
+        team_lookup_id: UUID | None = None,
+        team_slug: str = "sales",
+        team_lookup_error: Exception | None = None,
+        team_by_slug_id: UUID | None = None,
+        team_by_slug_error: Exception | None = None,
+    ) -> None:
+        self.workflow = workflow
+        self.team_lookup_id = team_lookup_id
+        self.team_slug = team_slug
+        self.team_lookup_error = team_lookup_error
+        self.team_by_slug_id = team_by_slug_id
+        self.team_by_slug_error = team_by_slug_error
+
+    async def resolve_workflow_ref(
+        self,
+        workflow_ref: str,
+        *,
+        include_archived: bool = True,
+        workspace_id: str | None = None,
+        team_id: str | None = None,
+    ) -> UUID:
+        del include_archived, workspace_id, team_id
+        if UUID(str(workflow_ref)) != self.workflow.id:
+            raise WorkflowNotFoundError(str(workflow_ref))
+        return self.workflow.id
+
+    async def get_workflow(self, workflow_id: UUID) -> Workflow:
+        if workflow_id != self.workflow.id:
+            raise WorkflowNotFoundError(str(workflow_id))
+        return self.workflow
+
+    async def get_team_by_slug(self, slug: str, *, workspace_id: str) -> object | None:
+        del workspace_id
+        if self.team_by_slug_error is not None:
+            raise self.team_by_slug_error
+        if slug != self.team_slug or self.team_by_slug_id is None:
+            return None
+        return SimpleNamespace(id=self.team_by_slug_id)
+
+    async def get_team(
+        self, team_id: UUID, *, workspace_id: str | None = None
+    ) -> object:
+        del workspace_id
+        if self.team_lookup_error is not None:
+            raise self.team_lookup_error
+        if self.team_lookup_id is not None and team_id != self.team_lookup_id:
+            raise WorkflowNotFoundError(str(team_id))
+        return SimpleNamespace(id=team_id, slug=self.team_slug)
+
+
+def test_apply_share_url_covers_all_variants() -> None:
+    base_url = "https://studio.example"
+
+    both = _apply_share_url(
+        Workflow(name="Published", is_public=True, handle="published"),
+        base_url,
+        workspace_slug="acme",
+        team_slug="sales",
+    )
+    assert both.share_url == "https://studio.example/chat/acme/team/sales/published"
+
+    workspace_only = _apply_share_url(
+        Workflow(name="Published", is_public=True, handle="published-2"),
+        base_url,
+        workspace_slug="acme",
+    )
+    assert workspace_only.share_url == ("https://studio.example/chat/acme/published-2")
+
+    team_only = _apply_share_url(
+        Workflow(name="Published", is_public=True, handle="published-3"),
+        base_url,
+        team_slug="sales",
+    )
+    assert team_only.share_url == "https://studio.example/chat/team/sales/published-3"
+
+    private = _apply_share_url(
+        Workflow(name="Private", is_public=False),
+        base_url,
+        workspace_slug="acme",
+        team_slug="sales",
+    )
+    assert private.share_url is None
+
+
+@pytest.mark.asyncio()
+async def test_resolve_workspace_id_from_slug_handles_success_and_failure() -> None:
+    workspace_id = uuid4()
+    assert _resolve_workspace_id_from_slug(
+        _WorkspaceService(workspace_id), "acme"
+    ) == str(workspace_id)
+    assert _resolve_workspace_id_from_slug(_WorkspaceService(None), "acme") is None
+    assert (
+        _resolve_workspace_id_from_slug(
+            SimpleNamespace(repository=_WorkspaceLookupError()), "acme"
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio()
+async def test_resolve_team_id_from_slug_handles_success_and_failure() -> None:
+    team_id = uuid4()
+
+    class _Repo:
+        async def get_team_by_slug(self, slug: str, *, workspace_id: str) -> object:
+            del slug, workspace_id
+            return SimpleNamespace(id=team_id)
+
+    class _RepoFailure:
+        async def get_team_by_slug(self, slug: str, *, workspace_id: str) -> object:
+            del slug, workspace_id
+            raise RuntimeError("boom")
+
+    assert await _resolve_team_id_from_slug(_Repo(), "sales", "ws-1") == str(team_id)
+    assert await _resolve_team_id_from_slug(_RepoFailure(), "sales", "ws-1") is None
+
+
+@pytest.mark.asyncio()
+async def test_resolve_team_slug_handles_success_and_failure() -> None:
+    team_id = uuid4()
+    workflow = Workflow(name="Published", is_public=True, team_id=str(team_id))
+
+    class _Repo:
+        async def get_team(self, team_id: UUID, *, workspace_id: str | None = None):
+            del workspace_id
+            assert str(team_id) == workflow.team_id
+            return SimpleNamespace(slug="sales")
+
+    class _RepoFailure:
+        async def get_team(self, team_id: UUID, *, workspace_id: str | None = None):
+            del team_id, workspace_id
+            raise RuntimeError("boom")
+
+    assert await _resolve_team_slug(_Repo(), workflow) == "sales"
+    assert await _resolve_team_slug(_RepoFailure(), workflow) is None
+
+
+@pytest.mark.asyncio()
+async def test_get_public_workflow_with_workspace_and_team_slugs_returns_share_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid4()
+    team_id = uuid4()
+    workflow = Workflow(
+        name="Published workflow",
+        handle="published",
+        workspace_id=str(workspace_id),
+        team_id=str(team_id),
+        is_public=True,
+    )
+    repository = _PublicWorkflowRepository(
+        workflow,
+        team_lookup_id=team_id,
+        team_slug="sales",
+        team_by_slug_id=team_id,
+    )
+    monkeypatch.setattr(
+        workflows,
+        "get_workspace_repository",
+        lambda: SimpleNamespace(get_workspace=lambda wid: SimpleNamespace(slug="acme")),
+    )
+    monkeypatch.setattr(
+        workflows,
+        "_resolve_studio_url",
+        lambda: "https://studio.example",
+    )
+
+    response = await workflows.get_public_workflow(
+        str(workflow.id),
+        repository,
+        _WorkspaceService(workspace_id),
+        workspace_slug="acme",
+        team_slug="sales",
+    )
+
+    assert response.share_url == "https://studio.example/chat/acme/team/sales/published"
+
+
+@pytest.mark.asyncio()
+async def test_get_public_workflow_with_workspace_slug_only_returns_share_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid4()
+    workflow = Workflow(
+        name="Published workflow",
+        handle="published",
+        workspace_id=str(workspace_id),
+        is_public=True,
+    )
+    repository = _PublicWorkflowRepository(workflow)
+    monkeypatch.setattr(
+        workflows,
+        "get_workspace_repository",
+        lambda: SimpleNamespace(get_workspace=lambda wid: SimpleNamespace(slug="acme")),
+    )
+    monkeypatch.setattr(
+        workflows,
+        "_resolve_studio_url",
+        lambda: "https://studio.example",
+    )
+
+    response = await workflows.get_public_workflow(
+        str(workflow.id),
+        repository,
+        _WorkspaceService(workspace_id),
+        workspace_slug="acme",
+        team_slug=None,
+    )
+
+    assert response.share_url == "https://studio.example/chat/acme/published"
+
+
+@pytest.mark.asyncio()
+async def test_get_public_workflow_rejects_missing_workspace_slug(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = Workflow(name="Published workflow", is_public=True)
+    repository = _PublicWorkflowRepository(workflow)
+    monkeypatch.setattr(
+        workflows,
+        "_resolve_studio_url",
+        lambda: "https://studio.example",
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        await workflows.get_public_workflow(
+            str(workflow.id),
+            repository,
+            _WorkspaceService(None),
+            workspace_slug="acme",
+        )
+
+    assert excinfo.value.status_code == 404
+
+
+@pytest.mark.asyncio()
+async def test_get_public_workflow_rejects_missing_team_slug(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid4()
+    workflow = Workflow(
+        name="Published workflow",
+        workspace_id=str(workspace_id),
+        is_public=True,
+    )
+    repository = _PublicWorkflowRepository(workflow)
+    monkeypatch.setattr(
+        workflows,
+        "_resolve_studio_url",
+        lambda: "https://studio.example",
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        await workflows.get_public_workflow(
+            str(workflow.id),
+            repository,
+            _WorkspaceService(workspace_id),
+            workspace_slug="acme",
+            team_slug="missing",
+        )
+
+    assert excinfo.value.status_code == 404
+
+
+@pytest.mark.asyncio()
+async def test_get_public_workflow_ignores_workspace_lookup_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid4()
+    team_id = uuid4()
+    workflow = Workflow(
+        name="Published workflow",
+        handle="published",
+        workspace_id=str(workspace_id),
+        team_id=str(team_id),
+        is_public=True,
+    )
+    repository = _PublicWorkflowRepository(
+        workflow,
+        team_lookup_id=team_id,
+        team_slug="sales",
+        team_by_slug_id=team_id,
+    )
+    monkeypatch.setattr(
+        workflows,
+        "get_workspace_repository",
+        lambda: _WorkspaceLookupFailure(),
+    )
+    monkeypatch.setattr(
+        workflows,
+        "_resolve_studio_url",
+        lambda: "https://studio.example",
+    )
+
+    response = await workflows.get_public_workflow(
+        str(workflow.id),
+        repository,
+        _WorkspaceService(workspace_id),
+        workspace_slug=None,
+        team_slug=None,
+    )
+
+    assert response.share_url == "https://studio.example/chat/team/sales/published"

--- a/tests/backend/test_workflows_router_public.py
+++ b/tests/backend/test_workflows_router_public.py
@@ -10,6 +10,16 @@ from orcheo_backend.app.routers import workflows
 from orcheo_backend.app.routers.workflows import _resolve_studio_url
 
 
+class _MockWorkspaceService:
+    def __init__(self) -> None:
+        self.repository = self
+        
+    def get_workspace_by_slug(self, slug: str) -> object:
+        """Mock workspace lookup that always succeeds."""
+        from types import SimpleNamespace
+        return SimpleNamespace(id=uuid4())
+
+
 class _WorkflowRepo:
     def __init__(self, workflow: Workflow) -> None:
         self.workflow = workflow
@@ -20,6 +30,7 @@ class _WorkflowRepo:
         *,
         include_archived: bool = True,
         workspace_id: str | None = None,
+        team_id: str | None = None,
     ) -> UUID:
         del include_archived
         if UUID(str(workflow_ref)) != self.workflow.id:
@@ -30,6 +41,16 @@ class _WorkflowRepo:
         if workflow_id != self.workflow.id:
             raise WorkflowNotFoundError(str(workflow_id))
         return self.workflow
+    
+    async def get_team_by_slug(self, slug: str, *, workspace_id: str) -> object:
+        """Mock team lookup."""
+        from types import SimpleNamespace
+        return SimpleNamespace(id=uuid4())
+        
+    async def get_team(self, team_id: UUID, *, workspace_id: str | None = None) -> object:
+        """Mock team lookup by ID."""
+        from types import SimpleNamespace
+        return SimpleNamespace(id=team_id, slug="mock-team")
 
 
 class _MissingWorkflowRepo:
@@ -39,12 +60,23 @@ class _MissingWorkflowRepo:
         *,
         include_archived: bool = True,
         workspace_id: str | None = None,
+        team_id: str | None = None,
     ) -> UUID:
         del include_archived
         raise WorkflowNotFoundError(str(workflow_ref))
 
     async def get_workflow(self, workflow_id: UUID) -> Workflow:
         raise WorkflowNotFoundError(str(workflow_id))
+        
+    async def get_team_by_slug(self, slug: str, *, workspace_id: str) -> object:
+        """Mock team lookup."""
+        from types import SimpleNamespace
+        return SimpleNamespace(id=uuid4())
+        
+    async def get_team(self, team_id: UUID, *, workspace_id: str | None = None) -> object:
+        """Mock team lookup by ID."""
+        from types import SimpleNamespace
+        return SimpleNamespace(id=team_id, slug="mock-team")
 
 
 @pytest.mark.asyncio()
@@ -56,17 +88,27 @@ async def test_get_public_workflow_not_found_after_resolution() -> None:
             *,
             include_archived: bool = True,
             workspace_id: str | None = None,
+            team_id: str | None = None,
         ) -> UUID:
             del include_archived
             return UUID(str(workflow_ref))
 
         async def get_workflow(self, workflow_id: UUID) -> Workflow:
             raise WorkflowNotFoundError(str(workflow_id))
+            
+        async def get_team_by_slug(self, slug: str, *, workspace_id: str) -> object:
+            from types import SimpleNamespace
+            return SimpleNamespace(id=uuid4())
+            
+        async def get_team(self, team_id: UUID, *, workspace_id: str | None = None) -> object:
+            from types import SimpleNamespace
+            return SimpleNamespace(id=team_id, slug="mock-team")
 
     with pytest.raises(HTTPException) as excinfo:
         await workflows.get_public_workflow(
             str(uuid4()),
             _ResolveThenMissRepo(),
+            _MockWorkspaceService(),
         )
 
     assert excinfo.value.status_code == 404
@@ -78,6 +120,7 @@ async def test_get_public_workflow_not_found() -> None:
         await workflows.get_public_workflow(
             str(uuid4()),
             _MissingWorkflowRepo(),
+            _MockWorkspaceService(),
         )
 
     assert excinfo.value.status_code == 404
@@ -89,7 +132,7 @@ async def test_get_public_workflow_denies_private_workflows() -> None:
     repo = _WorkflowRepo(workflow)
 
     with pytest.raises(HTTPException) as excinfo:
-        await workflows.get_public_workflow(str(workflow.id), repo)
+        await workflows.get_public_workflow(str(workflow.id), repo, _MockWorkspaceService())
 
     assert excinfo.value.status_code == 403
     assert excinfo.value.detail["code"] == "workflow.not_public"
@@ -107,7 +150,7 @@ async def test_get_public_workflow_includes_share_url(
         lambda: "https://studio.example",
     )
 
-    response = await workflows.get_public_workflow(str(workflow.id), repo)
+    response = await workflows.get_public_workflow(str(workflow.id), repo, _MockWorkspaceService())
 
     assert response.share_url == f"https://studio.example/chat/{workflow.id}"
 

--- a/tests/backend/test_workflows_router_public.py
+++ b/tests/backend/test_workflows_router_public.py
@@ -13,10 +13,11 @@ from orcheo_backend.app.routers.workflows import _resolve_studio_url
 class _MockWorkspaceService:
     def __init__(self) -> None:
         self.repository = self
-        
+
     def get_workspace_by_slug(self, slug: str) -> object:
         """Mock workspace lookup that always succeeds."""
         from types import SimpleNamespace
+
         return SimpleNamespace(id=uuid4())
 
 
@@ -41,15 +42,19 @@ class _WorkflowRepo:
         if workflow_id != self.workflow.id:
             raise WorkflowNotFoundError(str(workflow_id))
         return self.workflow
-    
+
     async def get_team_by_slug(self, slug: str, *, workspace_id: str) -> object:
         """Mock team lookup."""
         from types import SimpleNamespace
+
         return SimpleNamespace(id=uuid4())
-        
-    async def get_team(self, team_id: UUID, *, workspace_id: str | None = None) -> object:
+
+    async def get_team(
+        self, team_id: UUID, *, workspace_id: str | None = None
+    ) -> object:
         """Mock team lookup by ID."""
         from types import SimpleNamespace
+
         return SimpleNamespace(id=team_id, slug="mock-team")
 
 
@@ -67,15 +72,19 @@ class _MissingWorkflowRepo:
 
     async def get_workflow(self, workflow_id: UUID) -> Workflow:
         raise WorkflowNotFoundError(str(workflow_id))
-        
+
     async def get_team_by_slug(self, slug: str, *, workspace_id: str) -> object:
         """Mock team lookup."""
         from types import SimpleNamespace
+
         return SimpleNamespace(id=uuid4())
-        
-    async def get_team(self, team_id: UUID, *, workspace_id: str | None = None) -> object:
+
+    async def get_team(
+        self, team_id: UUID, *, workspace_id: str | None = None
+    ) -> object:
         """Mock team lookup by ID."""
         from types import SimpleNamespace
+
         return SimpleNamespace(id=team_id, slug="mock-team")
 
 
@@ -95,13 +104,17 @@ async def test_get_public_workflow_not_found_after_resolution() -> None:
 
         async def get_workflow(self, workflow_id: UUID) -> Workflow:
             raise WorkflowNotFoundError(str(workflow_id))
-            
+
         async def get_team_by_slug(self, slug: str, *, workspace_id: str) -> object:
             from types import SimpleNamespace
+
             return SimpleNamespace(id=uuid4())
-            
-        async def get_team(self, team_id: UUID, *, workspace_id: str | None = None) -> object:
+
+        async def get_team(
+            self, team_id: UUID, *, workspace_id: str | None = None
+        ) -> object:
             from types import SimpleNamespace
+
             return SimpleNamespace(id=team_id, slug="mock-team")
 
     with pytest.raises(HTTPException) as excinfo:
@@ -132,7 +145,9 @@ async def test_get_public_workflow_denies_private_workflows() -> None:
     repo = _WorkflowRepo(workflow)
 
     with pytest.raises(HTTPException) as excinfo:
-        await workflows.get_public_workflow(str(workflow.id), repo, _MockWorkspaceService())
+        await workflows.get_public_workflow(
+            str(workflow.id), repo, _MockWorkspaceService()
+        )
 
     assert excinfo.value.status_code == 403
     assert excinfo.value.detail["code"] == "workflow.not_public"
@@ -150,7 +165,9 @@ async def test_get_public_workflow_includes_share_url(
         lambda: "https://studio.example",
     )
 
-    response = await workflows.get_public_workflow(str(workflow.id), repo, _MockWorkspaceService())
+    response = await workflows.get_public_workflow(
+        str(workflow.id), repo, _MockWorkspaceService()
+    )
 
     assert response.share_url == f"https://studio.example/chat/{workflow.id}"
 

--- a/tests/backend/test_workflows_router_publish.py
+++ b/tests/backend/test_workflows_router_publish.py
@@ -24,6 +24,7 @@ class _MissingPublishRepo:
         *,
         include_archived: bool = True,
         workspace_id: str | None = None,
+        team_id: str | None = None,
     ) -> UUID:
         del include_archived
         raise WorkflowNotFoundError(str(workflow_ref))
@@ -39,6 +40,7 @@ class _InvalidPublishRepo:
         *,
         include_archived: bool = True,
         workspace_id: str | None = None,
+        team_id: str | None = None,
     ) -> UUID:
         del include_archived
         return UUID(str(workflow_ref))
@@ -59,6 +61,7 @@ class _InvalidRevokeRepo:
         *,
         include_archived: bool = True,
         workspace_id: str | None = None,
+        team_id: str | None = None,
     ) -> UUID:
         del include_archived
         return UUID(str(workflow_ref))
@@ -79,6 +82,7 @@ class _MissingRevokeRepo:
         *,
         include_archived: bool = True,
         workspace_id: str | None = None,
+        team_id: str | None = None,
     ) -> UUID:
         del include_archived
         raise WorkflowNotFoundError(str(workflow_ref))
@@ -97,6 +101,7 @@ class _RevokeRepo:
         *,
         include_archived: bool = True,
         workspace_id: str | None = None,
+        team_id: str | None = None,
     ) -> UUID:
         del workflow_ref, include_archived
         return self.workflow.id

--- a/tests/backend/test_workflows_router_publish.py
+++ b/tests/backend/test_workflows_router_publish.py
@@ -111,7 +111,7 @@ class _RevokeRepo:
         return self.workflow
 
 
-_MOCK_WORKSPACE = SimpleNamespace(workspace_id=uuid4())
+_MOCK_WORKSPACE = SimpleNamespace(workspace_id=uuid4(), workspace_slug="test")
 
 
 def test_publish_response_uses_message_helper() -> None:

--- a/tests/backend/test_workflows_router_resolve_branches.py
+++ b/tests/backend/test_workflows_router_resolve_branches.py
@@ -32,7 +32,7 @@ async def test_resolve_workflow_id_get_workflow_not_found_raises_404() -> None:
 
     class Repository:
         async def resolve_workflow_ref(
-            self, ref, *, include_archived=True, workspace_id=None
+            self, ref, *, include_archived=True, workspace_id=None, team_id=None
         ):
             return workflow_id
 

--- a/tests/backend/test_workflows_router_utils.py
+++ b/tests/backend/test_workflows_router_utils.py
@@ -73,6 +73,7 @@ class _MissingWorkflowRepository:
         *,
         include_archived: bool = True,
         workspace_id: str | None = None,
+        team_id: str | None = None,
     ) -> UUID:  # pragma: no cover - stub
         return self._workflow_id
 

--- a/tests/test_app_ingest_workflow_version.py
+++ b/tests/test_app_ingest_workflow_version.py
@@ -217,6 +217,7 @@ async def test_ingest_workflow_version_raises_not_found_error(
             *,
             include_archived: bool = True,
             workspace_id: str | None = None,
+            team_id: str | None = None,
         ) -> UUID:
             del include_archived
             return UUID(str(workflow_ref))


### PR DESCRIPTION
## What changed
- Added a first-class `Team` model and repository support in both in-memory and PostgreSQL backends.
- Added `/api/teams` list/create/delete endpoints, with lazy default-team provisioning so fresh workspaces always have a team to onboard into.
- Made candidate onboarding team-aware: onboarding now defaults to the workspace’s default team, or can target a specific team, and handle resolution is scoped accordingly.
- Updated workflow publishing and public share URLs to carry workspace/team path segments when available.
- Reworked the Studio workflow gallery to group colleagues by team, add create-team and onboard-to-team dialogs, and route workflow views with team-aware paths.
- Expanded the ChatKit widget catalog and updated tests around the new team/workspace flows.

## Why
- Teams are now the grouping unit for onboarded colleagues within a workspace, without changing workspace-level security, credentials, or quotas.
- Fresh workspaces should be usable immediately, without forcing users to create a team before onboarding their first candidate.

## Validation
- `uv run pytest tests/backend/test_teams.py tests/backend/test_workflows_router_publish.py tests/backend/test_routers_candidates.py tests/backend/test_app_workflow_crud.py -q`
- `npm --prefix apps/studio test -- --run src/features/workflow/pages/workflow-gallery/workflow-gallery-tabs.test.tsx src/features/workflow/pages/workflow-gallery/use-workflow-gallery-actions.team.test.tsx src/features/workflow/pages/workflow-gallery/workflow-card.test.tsx src/lib/api.test.ts`