### PR TITLE
Discover chatkit_widgets/ dynamically via GitHub Contents API

### DIFF
--- a/packages/sdk/src/orcheo_sdk/cli/setup.py
+++ b/packages/sdk/src/orcheo_sdk/cli/setup.py
@@ -31,14 +31,26 @@ _STACK_ASSET_BASE_URL_TEMPLATE = (
 )
 _STACK_RELEASE_TAG_PREFIX = "stack-v"
 _GITHUB_TAGS_API_URL = "https://api.github.com/repos/AI-Colleagues/orcheo/tags"
+_GITHUB_CONTENTS_API_URL = (
+    "https://api.github.com/repos/AI-Colleagues/orcheo/contents/deploy/stack"
+)
 _STACK_IMAGE_REPOSITORY = "ghcr.io/ai-colleagues/orcheo-stack"
+_CHATKIT_WIDGETS_DIR = "chatkit_widgets"
+_CHATKIT_WIDGETS_FALLBACK = (
+    "chatkit_widgets/Bounded number input.widget",
+    "chatkit_widgets/Bounded number slider.widget",
+    "chatkit_widgets/Conjoint - 3 concepts.widget",
+    "chatkit_widgets/Conjoint Choice.widget",
+    "chatkit_widgets/Conjoint carousel.widget",
+    "chatkit_widgets/Multi-choice Selector.widget",
+    "chatkit_widgets/Single-choice list.widget",
+    "chatkit_widgets/Todo list.widget",
+)
 _STACK_ASSET_FILES = (
     "docker-compose.yml",
     "Caddyfile",
     "Dockerfile.orcheo",
     ".env.example",
-    "chatkit_widgets/Single-choice list.widget",
-    "chatkit_widgets/Multi-choice Selector.widget",
 )
 _CHATKIT_DOMAIN_KEY_PLACEHOLDER = "domain_pk_replace_me"
 _OS_RELEASE_KEY_PATTERN = re.compile(r"^[A-Z0-9_]+$")
@@ -1130,6 +1142,41 @@ def _discover_latest_stack_version(console: Console) -> str | None:
     return None
 
 
+def _list_chatkit_widget_paths(
+    stack_version: str | None,
+    console: Console,
+) -> tuple[str, ...]:
+    """List files in chatkit_widgets/ via the GitHub Contents API.
+
+    Falls back to _CHATKIT_WIDGETS_FALLBACK when the API is unreachable so that
+    installs still work in air-gapped or offline environments.
+    """
+    ref = f"{_STACK_RELEASE_TAG_PREFIX}{stack_version}" if stack_version else "main"
+    url = f"{_GITHUB_CONTENTS_API_URL}/{_CHATKIT_WIDGETS_DIR}?ref={ref}"
+    try:
+        with urlopen(url, timeout=10) as response:  # noqa: S310
+            entries = json.loads(response.read().decode("utf-8"))
+        if not isinstance(entries, list):
+            raise ValueError("expected a JSON array")
+        return tuple(
+            f"{_CHATKIT_WIDGETS_DIR}/{entry['name']}"
+            for entry in entries
+            if isinstance(entry, dict) and entry.get("type") == "file"
+        )
+    except (
+        OSError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        ValueError,
+        KeyError,
+    ) as exc:
+        console.print(
+            f"[yellow]Could not list {_CHATKIT_WIDGETS_DIR}/ from GitHub; "
+            f"using known widget list: {exc}[/yellow]"
+        )
+        return _CHATKIT_WIDGETS_FALLBACK
+
+
 def _download_stack_asset(
     relative_path: str,
     *,
@@ -1184,6 +1231,13 @@ def _sync_stack_assets_per_file(
     console: Console,
 ) -> None:
     for relative_path in _STACK_ASSET_FILES:
+        _sync_stack_asset(
+            relative_path,
+            stack_dir,
+            stack_version=stack_version,
+            console=console,
+        )
+    for relative_path in _list_chatkit_widget_paths(stack_version, console):
         _sync_stack_asset(
             relative_path,
             stack_dir,

--- a/tests/sdk/test_cli_setup_stack_assets.py
+++ b/tests/sdk/test_cli_setup_stack_assets.py
@@ -2082,3 +2082,45 @@ def test_discover_latest_stack_version_returns_none_when_no_stable_tag(
     )
 
     assert setup_mod._discover_latest_stack_version(Console(record=True)) is None
+
+
+# ---------------------------------------------------------------------------
+# _list_chatkit_widget_paths
+# ---------------------------------------------------------------------------
+
+
+def test_list_chatkit_widget_paths_non_array_response_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the GitHub Contents API returns a JSON object instead of an array,
+    a ValueError is raised internally and the function falls back to the
+    hard-coded widget list."""
+    from orcheo_sdk.cli import setup as setup_mod
+
+    monkeypatch.setattr(
+        setup_mod,
+        "urlopen",
+        lambda url, timeout: _Response(b'{"message": "not an array"}'),
+    )
+    console = Console(record=True)
+    result = setup_mod._list_chatkit_widget_paths(None, console)
+    assert result == setup_mod._CHATKIT_WIDGETS_FALLBACK
+    assert "using known widget list" in console.export_text()
+
+
+def test_list_chatkit_widget_paths_network_error_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When urlopen raises OSError (e.g. network down), the function falls back
+    to the hard-coded widget list."""
+    from orcheo_sdk.cli import setup as setup_mod
+
+    def _raise(url: str, timeout: int) -> _Response:
+        del url, timeout
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(setup_mod, "urlopen", _raise)
+    console = Console(record=True)
+    result = setup_mod._list_chatkit_widget_paths("0.23.0", console)
+    assert result == setup_mod._CHATKIT_WIDGETS_FALLBACK
+    assert "using known widget list" in console.export_text()

--- a/tests/sdk/test_cli_setup_stack_assets.py
+++ b/tests/sdk/test_cli_setup_stack_assets.py
@@ -90,6 +90,17 @@ class _Response:
         return self._buffer.read(size)
 
 
+def _contents_api_response(assets: dict[str, bytes]) -> bytes:
+    """Build a GitHub Contents API JSON payload from the widget entries in *assets*."""
+    prefix = "chatkit_widgets/"
+    entries = [
+        {"name": path.removeprefix(prefix), "type": "file"}
+        for path in assets
+        if path.startswith(prefix)
+    ]
+    return json.dumps(entries).encode()
+
+
 _ENV_EXAMPLE = (
     b"ORCHEO_POSTGRES_PASSWORD=change-me\n"
     b"ORCHEO_VAULT_ENCRYPTION_KEY=replace-with-64-hex-chars\n"
@@ -104,8 +115,14 @@ def _default_assets() -> dict[str, bytes]:
         "Caddyfile": b'localhost { respond "ok" }\n',
         "Dockerfile.orcheo": b"FROM python:3.12-slim\n",
         ".env.example": _ENV_EXAMPLE,
-        "chatkit_widgets/Single-choice list.widget": b"single",
+        "chatkit_widgets/Bounded number input.widget": b"bounded-input",
+        "chatkit_widgets/Bounded number slider.widget": b"bounded-slider",
+        "chatkit_widgets/Conjoint - 3 concepts.widget": b"conjoint-3",
+        "chatkit_widgets/Conjoint Choice.widget": b"conjoint-choice",
+        "chatkit_widgets/Conjoint carousel.widget": b"conjoint-carousel",
         "chatkit_widgets/Multi-choice Selector.widget": b"multi",
+        "chatkit_widgets/Single-choice list.widget": b"single",
+        "chatkit_widgets/Todo list.widget": b"todo",
     }
 
 
@@ -174,6 +191,8 @@ def _patch_common(
 
     def _urlopen(url: str, timeout: int) -> _Response:
         del timeout
+        if "api.github.com" in url and "/contents/" in url:
+            return _Response(_contents_api_response(resolved_assets))
         relative_path = unquote(url.removeprefix(f"{base_url}/"))
         return _Response(resolved_assets[relative_path])
 
@@ -217,8 +236,14 @@ def test_execute_setup_bootstraps_stack_assets(
     assert (stack_dir / "Caddyfile").exists()
     assert (stack_dir / "Dockerfile.orcheo").exists()
     assert (stack_dir / ".env.example").exists()
-    assert (stack_dir / "chatkit_widgets/Single-choice list.widget").exists()
+    assert (stack_dir / "chatkit_widgets/Bounded number input.widget").exists()
+    assert (stack_dir / "chatkit_widgets/Bounded number slider.widget").exists()
+    assert (stack_dir / "chatkit_widgets/Conjoint - 3 concepts.widget").exists()
+    assert (stack_dir / "chatkit_widgets/Conjoint Choice.widget").exists()
+    assert (stack_dir / "chatkit_widgets/Conjoint carousel.widget").exists()
     assert (stack_dir / "chatkit_widgets/Multi-choice Selector.widget").exists()
+    assert (stack_dir / "chatkit_widgets/Single-choice list.widget").exists()
+    assert (stack_dir / "chatkit_widgets/Todo list.widget").exists()
 
     env_content = (stack_dir / ".env").read_text(encoding="utf-8")
     assert "ORCHEO_API_URL=http://localhost:2025" in env_content
@@ -1672,6 +1697,7 @@ def test_setup_misc_uncovered_branches(
         destination.write_text("downloaded", encoding="utf-8")
 
     monkeypatch.setattr(setup_mod, "_sync_stack_asset", _sync)
+    monkeypatch.setattr(setup_mod, "_list_chatkit_widget_paths", lambda sv, c: ())
     monkeypatch.setattr(
         setup_mod.shutil,
         "copyfile",
@@ -1728,8 +1754,6 @@ def test_ensure_stack_assets_syncs_env_example_when_not_in_asset_list(
         (
             "docker-compose.yml",
             "Dockerfile.orcheo",
-            "chatkit_widgets/Single-choice list.widget",
-            "chatkit_widgets/Multi-choice Selector.widget",
         ),
     )
 
@@ -1791,6 +1815,8 @@ def test_ensure_stack_assets_uses_latest_stack_tag_assets(
         del timeout
         if url == f"{setup_mod._GITHUB_TAGS_API_URL}?per_page=100":
             return _Response(tags_payload)
+        if "api.github.com" in url and "/contents/" in url:
+            return _Response(_contents_api_response(assets))
         if url.startswith(f"{tag_base}/"):
             relative_path = unquote(url.removeprefix(f"{tag_base}/"))
             return _Response(assets[relative_path])
@@ -1825,6 +1851,8 @@ def test_ensure_stack_assets_falls_back_to_main_assets_when_tag_lookup_fails(
         del timeout
         if url == f"{setup_mod._GITHUB_TAGS_API_URL}?per_page=100":
             raise OSError("tags unavailable")
+        if "api.github.com" in url and "/contents/" in url:
+            return _Response(_contents_api_response(assets))
         if url.startswith(f"{main_base}/"):
             relative_path = unquote(url.removeprefix(f"{main_base}/"))
             return _Response(assets[relative_path])
@@ -1859,6 +1887,8 @@ def test_ensure_stack_assets_uses_explicit_stack_version(
     def _urlopen(url: str, timeout: int) -> _Response:
         del timeout
         calls.append(url)
+        if "api.github.com" in url and "/contents/" in url:
+            return _Response(_contents_api_response(assets))
         if url.startswith(f"{expected_base}/"):
             relative_path = unquote(url.removeprefix(f"{expected_base}/"))
             return _Response(assets[relative_path])
@@ -1893,6 +1923,8 @@ def test_ensure_stack_assets_uses_env_stack_version(
 
     def _urlopen(url: str, timeout: int) -> _Response:
         del timeout
+        if "api.github.com" in url and "/contents/" in url:
+            return _Response(_contents_api_response(assets))
         if url.startswith(f"{expected_base}/"):
             relative_path = unquote(url.removeprefix(f"{expected_base}/"))
             return _Response(assets[relative_path])
@@ -1930,6 +1962,8 @@ def test_ensure_stack_assets_custom_base_url_forces_per_file_mode(
             raise AssertionError(
                 "Tag lookup should not run when base URL is configured."
             )
+        if "api.github.com" in url and "/contents/" in url:
+            return _Response(_contents_api_response(assets))
         relative_path = unquote(url.removeprefix(f"{base_url}/"))
         return _Response(assets[relative_path])
 


### PR DESCRIPTION
Instead of maintaining a hardcoded list of widget filenames in _STACK_ASSET_FILES, query the GitHub Contents API at install time so new widgets are picked up automatically. Falls back to a known list when the API is unreachable.