### PR TITLE
Fix implicit credential readiness detection

### DIFF
--- a/apps/backend/src/orcheo_backend/app/credential_readiness.py
+++ b/apps/backend/src/orcheo_backend/app/credential_readiness.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 from langgraph.graph import StateGraph
 from pydantic import BaseModel
+from orcheo.graph.ingestion.ast_extraction import extract_graph_index
 from orcheo.runtime.credentials import parse_credential_reference
 
 
@@ -23,10 +24,21 @@ def collect_workflow_credential_placeholders(
     """
     placeholders: dict[str, set[str]] = {}
     _collect_value(graph_payload, placeholders, seen=set())
+    _collect_source_index(graph_payload, placeholders)
     if runnable_config is not None:
         _collect_value(runnable_config, placeholders, seen=set())
 
     return placeholders
+
+
+def _collect_source_index(
+    graph_payload: Mapping[str, Any],
+    placeholders: dict[str, set[str]],
+) -> None:
+    source = graph_payload.get("source")
+    if not isinstance(source, str):
+        return
+    _collect_value(extract_graph_index(source), placeholders, seen=set())
 
 
 def _collect_state_graph(

--- a/src/orcheo/graph/ingestion/ast_extraction.py
+++ b/src/orcheo/graph/ingestion/ast_extraction.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 import ast
+import importlib
+import re
+from functools import lru_cache
 from typing import Any
+from pydantic import BaseModel
+from pydantic_core import PydanticUndefined
 
 
 _CRON_NODE_TYPE = "CronTriggerNode"
@@ -15,6 +20,9 @@ _LISTENER_NODE_PLATFORMS: dict[str, str] = {
     "DiscordBotListenerNode": "discord",
     "QQBotListenerNode": "qq",
 }
+
+_CREDENTIAL_PLACEHOLDER_PATTERN = re.compile(r"^\[\[(?P<body>.+)\]\]$")
+_ORCHEO_NODE_MODULE_PREFIX = "orcheo.nodes"
 
 
 def _literal_value(node: ast.expr) -> Any:
@@ -57,15 +65,52 @@ class _AddNodeVisitor(ast.NodeVisitor):
     """Walk an AST to collect graph.add_node() call metadata."""
 
     def __init__(self) -> None:
+        self.import_aliases: dict[str, str] = {}
+        self.import_modules: dict[str, str] = {}
         self.cron_entries: list[dict[str, Any]] = []
         self.listener_entries: list[dict[str, Any]] = []
+        self.credential_entries: list[dict[str, str]] = []
 
-    def visit_Expr(self, node: ast.Expr) -> None:  # noqa: N802
-        if isinstance(node.value, ast.Call):
-            self._handle_call(node.value)
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:  # noqa: N802
+        for alias in node.names:
+            if alias.name == "*":
+                continue
+            self.import_aliases[alias.asname or alias.name] = alias.name
+            if node.module is not None:
+                self.import_modules[alias.asname or alias.name] = node.module
         self.generic_visit(node)
 
-    def _handle_call(self, call: ast.Call) -> None:
+    def visit_Call(self, node: ast.Call) -> None:  # noqa: N802
+        self._handle_constructor_call(node)
+        self._handle_add_node_call(node)
+        self.generic_visit(node)
+
+    def _resolve_class_name(self, node: ast.expr) -> str | None:
+        class_name = _get_call_name(node)
+        if class_name is None:
+            return None
+        return self.import_aliases.get(class_name, class_name)
+
+    def _handle_constructor_call(self, call: ast.Call) -> None:
+        class_name = self._resolve_class_name(call.func)
+        if class_name is None:
+            return
+
+        provided_fields = {kw.arg for kw in call.keywords if kw.arg is not None}
+        module_name = _get_call_module(call.func)
+        if module_name is None:
+            raw_name = _get_call_name(call.func)
+            if raw_name is not None:
+                module_name = self.import_modules.get(raw_name)
+        self.credential_entries.extend(
+            _extract_default_credentials(
+                class_name,
+                provided_fields,
+                module_name=module_name,
+            )
+        )
+
+    def _handle_add_node_call(self, call: ast.Call) -> None:
         func = call.func
         if not (isinstance(func, ast.Attribute) and func.attr == "add_node"):
             return
@@ -83,7 +128,7 @@ class _AddNodeVisitor(ast.NodeVisitor):
 
         if not isinstance(ctor_node, ast.Call):
             return
-        class_name = _get_call_name(ctor_node.func)
+        class_name = self._resolve_class_name(ctor_node.func)
         if class_name is None:
             return
 
@@ -109,6 +154,108 @@ class _AddNodeVisitor(ast.NodeVisitor):
             self.listener_entries.append(entry)
 
 
+def _extract_default_credentials(
+    class_name: str,
+    provided_fields: set[str],
+    *,
+    module_name: str | None = None,
+) -> list[dict[str, str]]:
+    """Return credential placeholders from node defaults not overridden in source."""
+    node_cls = _resolve_orcheo_node_class(class_name, module_name)
+    if node_cls is None:
+        return []
+    return _collect_model_default_credentials(class_name, node_cls, provided_fields)
+
+
+def _collect_model_default_credentials(
+    class_name: str,
+    node_cls: type[BaseModel],
+    provided_fields: set[str],
+) -> list[dict[str, str]]:
+    entries: list[dict[str, str]] = []
+    for field_name, field_info in node_cls.model_fields.items():
+        if field_name in provided_fields:
+            continue
+        default = field_info.default
+        if default is PydanticUndefined:
+            continue
+        placeholders = _collect_credential_placeholders(default)
+        for placeholder in placeholders:
+            entries.append(
+                {
+                    "node_type": class_name,
+                    "field": field_name,
+                    "placeholder": placeholder,
+                }
+            )
+    return entries
+
+
+def _collect_credential_placeholders(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value] if _is_credential_placeholder(value) else []
+    if isinstance(value, dict):
+        placeholders: list[str] = []
+        for nested in value.values():
+            placeholders.extend(_collect_credential_placeholders(nested))
+        return placeholders
+    if isinstance(value, list | tuple | set):
+        placeholders = []
+        for nested in value:
+            placeholders.extend(_collect_credential_placeholders(nested))
+        return placeholders
+    return []
+
+
+def _is_credential_placeholder(value: str) -> bool:
+    match = _CREDENTIAL_PLACEHOLDER_PATTERN.fullmatch(value.strip())
+    if match is None:
+        return False
+    body = match.group("body").strip()
+    if not body:
+        return False
+    identifier = body.split("#", 1)[0].strip()
+    return bool(identifier)
+
+
+@lru_cache(maxsize=256)
+def _resolve_orcheo_node_class(
+    class_name: str,
+    module_name: str | None,
+) -> type[BaseModel] | None:
+    candidates = []
+    if module_name is not None:
+        candidates.append((module_name, class_name))
+    candidates.append((_ORCHEO_NODE_MODULE_PREFIX, class_name))
+
+    for candidate_module, candidate_name in candidates:
+        if not candidate_module.startswith(_ORCHEO_NODE_MODULE_PREFIX):
+            continue
+        try:
+            module = importlib.import_module(candidate_module)
+        except Exception:
+            continue
+        node_cls = getattr(module, candidate_name, None)
+        if isinstance(node_cls, type) and issubclass(node_cls, BaseModel):
+            return node_cls
+    return None
+
+
+def _get_call_module(node: ast.expr) -> str | None:
+    if not isinstance(node, ast.Attribute):
+        return None
+    parts: list[str] = []
+    current: ast.expr = node.value
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+    if isinstance(current, ast.Name):
+        parts.append(current.id)
+    if not parts:
+        return None
+    return ".".join(reversed(parts))
+
+
 def extract_graph_index(source: str) -> dict[str, Any]:
     """Parse a LangGraph script and extract cron and listener metadata via AST walk.
 
@@ -119,11 +266,15 @@ def extract_graph_index(source: str) -> dict[str, Any]:
     try:
         tree = ast.parse(source)
     except SyntaxError:
-        return {"cron": [], "listeners": []}
+        return {"cron": [], "listeners": [], "credentials": []}
 
     visitor = _AddNodeVisitor()
     visitor.visit(tree)
-    return {"cron": visitor.cron_entries, "listeners": visitor.listener_entries}
+    return {
+        "cron": visitor.cron_entries,
+        "listeners": visitor.listener_entries,
+        "credentials": visitor.credential_entries,
+    }
 
 
 __all__ = ["extract_graph_index"]

--- a/src/orcheo/graph/ingestion/ast_extraction.py
+++ b/src/orcheo/graph/ingestion/ast_extraction.py
@@ -67,9 +67,16 @@ class _AddNodeVisitor(ast.NodeVisitor):
     def __init__(self) -> None:
         self.import_aliases: dict[str, str] = {}
         self.import_modules: dict[str, str] = {}
+        self.module_aliases: dict[str, str] = {}
         self.cron_entries: list[dict[str, Any]] = []
         self.listener_entries: list[dict[str, Any]] = []
         self.credential_entries: list[dict[str, str]] = []
+
+    def visit_Import(self, node: ast.Import) -> None:  # noqa: N802
+        for alias in node.names:
+            local_name = alias.asname or alias.name.split(".", 1)[0]
+            self.module_aliases[local_name] = alias.name
+        self.generic_visit(node)
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:  # noqa: N802
         for alias in node.names:
@@ -102,6 +109,8 @@ class _AddNodeVisitor(ast.NodeVisitor):
             raw_name = _get_call_name(call.func)
             if raw_name is not None:
                 module_name = self.import_modules.get(raw_name)
+        else:
+            module_name = self._resolve_module_alias(module_name)
         self.credential_entries.extend(
             _extract_default_credentials(
                 class_name,
@@ -152,6 +161,13 @@ class _AddNodeVisitor(ast.NodeVisitor):
             }
             entry.update({k: v for k, v in kwargs.items() if k != "platform"})
             self.listener_entries.append(entry)
+
+    def _resolve_module_alias(self, module_name: str) -> str:
+        root, separator, remainder = module_name.partition(".")
+        resolved_root = self.module_aliases.get(root)
+        if resolved_root is None:
+            return module_name
+        return f"{resolved_root}{separator}{remainder}" if separator else resolved_root
 
 
 def _extract_default_credentials(
@@ -223,14 +239,18 @@ def _resolve_orcheo_node_class(
     class_name: str,
     module_name: str | None,
 ) -> type[BaseModel] | None:
-    candidates = []
-    if module_name is not None:
-        candidates.append((module_name, class_name))
-    candidates.append((_ORCHEO_NODE_MODULE_PREFIX, class_name))
+    if module_name is not None and not module_name.startswith(
+        _ORCHEO_NODE_MODULE_PREFIX
+    ):
+        return None
+
+    candidates = (
+        [(module_name, class_name), (_ORCHEO_NODE_MODULE_PREFIX, class_name)]
+        if module_name is not None
+        else [(_ORCHEO_NODE_MODULE_PREFIX, class_name)]
+    )
 
     for candidate_module, candidate_name in candidates:
-        if not candidate_module.startswith(_ORCHEO_NODE_MODULE_PREFIX):
-            continue
         try:
             module = importlib.import_module(candidate_module)
         except Exception:

--- a/tests/backend/api/test_backend_credentials_workflows.py
+++ b/tests/backend/api/test_backend_credentials_workflows.py
@@ -239,8 +239,76 @@ def orcheo_workflow() -> StateGraph:
 
     payload = readiness.json()
     assert payload["status"] == "missing"
-    assert payload["available_credentials"] == ["openai_api_key"]
+    assert payload["available_credentials"] == ["openai_api_key", "telegram_token"]
     assert payload["missing_credentials"] == ["telegram_chat_id"]
+
+
+def test_workflow_credential_readiness_reports_implicit_node_defaults(
+    api_client: TestClient,
+) -> None:
+    """Readiness reports credential defaults omitted from uploaded scripts."""
+    workflow_id = _create_workflow(api_client)
+
+    response = api_client.post(
+        f"/api/workflows/{workflow_id}/versions/ingest",
+        json={
+            "script": """
+from langgraph.graph import END, START, StateGraph
+from orcheo.graph.state import State
+from orcheo.nodes.storage.mongodb import (
+    MongoDBEnsureSearchIndexNode,
+    MongoDBEnsureVectorIndexNode,
+)
+
+def orcheo_workflow() -> StateGraph:
+    text_index = MongoDBEnsureSearchIndexNode(
+        name="ensure_text_index",
+        database="{{config.configurable.database}}",
+        collection="{{config.configurable.collection}}",
+        definition={"mappings": {"dynamic": False}},
+        mode="ensure_or_update",
+    )
+    vector_index = MongoDBEnsureVectorIndexNode(
+        name="ensure_vector_index",
+        database="{{config.configurable.database}}",
+        collection="{{config.configurable.collection}}",
+        dimensions="{{config.configurable.dimensions}}",
+        similarity="cosine",
+        path="{{config.configurable.vector_path}}",
+        mode="ensure_or_update",
+    )
+
+    graph = StateGraph(State)
+    graph.add_node("ensure_text_index", text_index)
+    graph.add_node("ensure_vector_index", vector_index)
+    graph.add_edge(START, "ensure_text_index")
+    graph.add_edge("ensure_text_index", "ensure_vector_index")
+    graph.add_edge("ensure_vector_index", END)
+    return graph
+""",
+            "created_by": "tester",
+        },
+    )
+    assert response.status_code == 201
+    assert response.json()["graph"]["index"]["credentials"] == [
+        {
+            "node_type": "MongoDBEnsureSearchIndexNode",
+            "field": "connection_string",
+            "placeholder": "[[mdb_connection_string]]",
+        },
+        {
+            "node_type": "MongoDBEnsureVectorIndexNode",
+            "field": "connection_string",
+            "placeholder": "[[mdb_connection_string]]",
+        },
+    ]
+
+    readiness = api_client.get(f"/api/workflows/{workflow_id}/credentials/readiness")
+    assert readiness.status_code == 200
+
+    payload = readiness.json()
+    assert payload["status"] == "missing"
+    assert payload["missing_credentials"] == ["mdb_connection_string"]
 
 
 def test_workflow_credential_readiness_no_credentials_required(

--- a/tests/backend/test_app_credential_readiness.py
+++ b/tests/backend/test_app_credential_readiness.py
@@ -84,6 +84,7 @@ def orcheo_workflow() -> StateGraph:
     assert sorted(placeholders) == [
         "openai_api_key",
         "telegram_chat_id",
+        "telegram_token",
     ]
 
 
@@ -309,7 +310,7 @@ def orcheo_workflow() -> StateGraph:
     )
 
     assert response.status == "missing"
-    assert response.available_credentials == ["openai_api_key"]
+    assert response.available_credentials == ["openai_api_key", "telegram_token"]
     assert response.missing_credentials == ["telegram_chat_id"]
 
 
@@ -340,6 +341,52 @@ def test_collect_workflow_credential_placeholders_scans_graph_summary() -> None:
                 ],
                 "edges": [],
             }
+        },
+        None,
+    )
+
+    assert placeholders == {
+        "mdb_connection_string": {"[[mdb_connection_string]]"},
+    }
+
+
+def test_collect_workflow_credential_placeholders_scans_index_credentials() -> None:
+    placeholders = collect_workflow_credential_placeholders(
+        {
+            "format": "langgraph-script",
+            "source": "MongoDBEnsureSearchIndexNode(name='node')",
+            "index": {
+                "credentials": [
+                    {
+                        "node_type": "MongoDBEnsureSearchIndexNode",
+                        "field": "connection_string",
+                        "placeholder": "[[mdb_connection_string]]",
+                    }
+                ]
+            },
+        },
+        None,
+    )
+
+    assert placeholders == {
+        "mdb_connection_string": {"[[mdb_connection_string]]"},
+    }
+
+
+def test_collect_workflow_credential_placeholders_infers_source_defaults() -> None:
+    placeholders = collect_workflow_credential_placeholders(
+        {
+            "format": "langgraph-script",
+            "source": """
+from orcheo.nodes.storage.mongodb import MongoDBEnsureSearchIndexNode
+
+MongoDBEnsureSearchIndexNode(
+    name="ensure_text_index",
+    database="{{config.configurable.database}}",
+    collection="{{config.configurable.collection}}",
+    definition={"mappings": {"dynamic": False}},
+)
+""",
         },
         None,
     )

--- a/tests/graph/test_ast_extraction.py
+++ b/tests/graph/test_ast_extraction.py
@@ -3,15 +3,20 @@
 from __future__ import annotations
 import ast
 import textwrap
+import types
 
 import pytest
 from pydantic import BaseModel
 
+import orcheo.graph.ingestion.ast_extraction as ast_extraction
 from orcheo.graph.ingestion.ast_extraction import (
     _AddNodeVisitor,
     _collect_model_default_credentials,
+    _collect_credential_placeholders,
     _extract_kwargs,
+    _extract_default_credentials,
     _get_call_name,
+    _get_call_module,
     _is_credential_placeholder,
     _literal_value,
     extract_graph_index,
@@ -158,6 +163,11 @@ class _SyntheticCredentialNode(BaseModel):
     normal_value: str = "not-a-credential"
 
 
+class _RequiredCredentialNode(BaseModel):
+    required_value: str
+    secret_value: str = "[[required-secret]]"
+
+
 def test_collect_model_default_credentials_discovers_placeholder_defaults() -> None:
     entries = _collect_model_default_credentials(
         "SyntheticCredentialNode",
@@ -172,6 +182,26 @@ def test_collect_model_default_credentials_discovers_placeholder_defaults() -> N
             "placeholder": "[[custom-refresh#oauth.refresh_token]]",
         }
     ]
+
+
+def test_collect_model_default_credentials_skips_required_fields() -> None:
+    entries = _collect_model_default_credentials(
+        "RequiredCredentialNode",
+        _RequiredCredentialNode,
+        set(),
+    )
+
+    assert entries == [
+        {
+            "node_type": "RequiredCredentialNode",
+            "field": "secret_value",
+            "placeholder": "[[required-secret]]",
+        }
+    ]
+
+
+def test_collect_credential_placeholders_returns_empty_for_scalars() -> None:
+    assert _collect_credential_placeholders(123) == []
 
 
 # ---------------------------------------------------------------------------
@@ -326,6 +356,244 @@ def test_visitor_listener_discord_platform() -> None:
     assert visitor.listener_entries[0]["platform"] == "discord"
 
 
+def test_visitor_add_node_unknown_constructor_type_is_ignored() -> None:
+    source = """\
+        graph.add_node(
+            "plain_node",
+            PlainNode(payload="value"),
+        )
+    """
+    visitor = _parse_and_visit(source)
+    assert visitor.cron_entries == []
+    assert visitor.listener_entries == []
+
+
+def test_visitor_importfrom_star_and_relative_imports() -> None:
+    source = """\
+        from . import local_name
+        from some.pkg import *
+    """
+    visitor = _parse_and_visit(source)
+    assert visitor.import_aliases == {"local_name": "local_name"}
+    assert visitor.import_modules == {}
+
+
+def test_visitor_import_records_module_aliases() -> None:
+    source = """\
+        import orcheo.nodes.wecom as wecom
+        import orcheo.nodes.storage.mongodb.search
+    """
+    visitor = _parse_and_visit(source)
+    assert visitor.module_aliases["wecom"] == "orcheo.nodes.wecom"
+    assert visitor.module_aliases["orcheo"] == "orcheo.nodes.storage.mongodb.search"
+
+
+def test_resolve_module_alias_without_remainder() -> None:
+    visitor = _AddNodeVisitor()
+    visitor.module_aliases["wecom"] = "orcheo.nodes.wecom"
+
+    assert visitor._resolve_module_alias("wecom") == "orcheo.nodes.wecom"
+
+
+def test_handle_constructor_call_uses_import_modules_for_bare_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _ResolvedNode(BaseModel):
+        connection_string: str = "[[resolved-connection-string]]"
+
+    visitor = _AddNodeVisitor()
+    visitor.import_modules["MongoDBEnsureSearchIndexNode"] = (
+        "orcheo.nodes.storage.mongodb.search"
+    )
+    monkeypatch.setattr(
+        ast_extraction,
+        "_resolve_orcheo_node_class",
+        lambda *_args, **_kwargs: _ResolvedNode,
+    )
+
+    call = ast.parse(
+        'MongoDBEnsureSearchIndexNode(name="ensure_text_index")',
+        mode="eval",
+    ).body
+    assert isinstance(call, ast.Call)
+
+    visitor._handle_constructor_call(call)
+
+    assert visitor.credential_entries == [
+        {
+            "node_type": "MongoDBEnsureSearchIndexNode",
+            "field": "connection_string",
+            "placeholder": "[[resolved-connection-string]]",
+        }
+    ]
+
+
+def test_handle_constructor_call_resolves_module_aliases(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _ResolvedNode(BaseModel):
+        webhook_key: str = "[[resolved-webhook-key]]"
+
+    visitor = _AddNodeVisitor()
+    visitor.module_aliases["wecom"] = "orcheo.nodes.wecom"
+    monkeypatch.setattr(
+        ast_extraction,
+        "_resolve_orcheo_node_class",
+        lambda *_args, **_kwargs: _ResolvedNode,
+    )
+
+    call = ast.parse('wecom.WeComGroupPushNode(name="push")', mode="eval").body
+    assert isinstance(call, ast.Call)
+
+    visitor._handle_constructor_call(call)
+
+    assert visitor.credential_entries == [
+        {
+            "node_type": "WeComGroupPushNode",
+            "field": "webhook_key",
+            "placeholder": "[[resolved-webhook-key]]",
+        }
+    ]
+
+
+def test_handle_constructor_call_skips_import_module_lookup_when_name_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    visitor = _AddNodeVisitor()
+    call = ast.parse("ignored()", mode="eval").body
+    assert isinstance(call, ast.Call)
+
+    monkeypatch.setattr(visitor, "_resolve_class_name", lambda _node: "SyntheticNode")
+    monkeypatch.setattr(ast_extraction, "_get_call_module", lambda _node: None)
+    monkeypatch.setattr(ast_extraction, "_get_call_name", lambda _node: None)
+    monkeypatch.setattr(
+        ast_extraction,
+        "_extract_default_credentials",
+        lambda *_args, **_kwargs: [],
+    )
+
+    visitor._handle_constructor_call(call)
+
+    assert visitor.credential_entries == []
+
+
+def test_collect_credential_placeholders_recurses_nested_iterables() -> None:
+    value = [
+        "[[one]]",
+        ("[[two#oauth.refresh_token]]", {"[[three]]"}),
+        "not-a-placeholder",
+    ]
+
+    assert sorted(_collect_credential_placeholders(value)) == [
+        "[[one]]",
+        "[[three]]",
+        "[[two#oauth.refresh_token]]",
+    ]
+
+
+def test_resolve_orcheo_node_class_falls_back_after_import_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ast_extraction._resolve_orcheo_node_class.cache_clear()
+    fake_module = types.ModuleType("orcheo.nodes")
+
+    class FakeTelegramBotListenerNode(BaseModel):
+        pass
+
+    fake_module.TelegramBotListenerNode = FakeTelegramBotListenerNode
+
+    def fake_import_module(name: str, package: str | None = None) -> object:
+        if name == "orcheo.nodes.storage.missing":
+            raise ImportError("boom")
+        if name == "orcheo.nodes":
+            return fake_module
+        raise AssertionError(f"unexpected import: {name!r}")
+
+    monkeypatch.setattr(ast_extraction.importlib, "import_module", fake_import_module)
+
+    try:
+        node_cls = ast_extraction._resolve_orcheo_node_class(
+            "TelegramBotListenerNode",
+            "orcheo.nodes.storage.missing",
+        )
+        assert node_cls is not None
+        assert node_cls is FakeTelegramBotListenerNode
+    finally:
+        ast_extraction._resolve_orcheo_node_class.cache_clear()
+
+
+def test_resolve_orcheo_node_class_falls_back_when_primary_missing_class(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ast_extraction._resolve_orcheo_node_class.cache_clear()
+    primary_module = types.ModuleType("orcheo.nodes.storage.missing")
+    fallback_module = types.ModuleType("orcheo.nodes")
+
+    class FallbackTelegramBotListenerNode(BaseModel):
+        pass
+
+    fallback_module.TelegramBotListenerNode = FallbackTelegramBotListenerNode
+
+    def fake_import_module(name: str, package: str | None = None) -> object:
+        if name == "orcheo.nodes.storage.missing":
+            return primary_module
+        if name == "orcheo.nodes":
+            return fallback_module
+        raise AssertionError(f"unexpected import: {name!r}")
+
+    monkeypatch.setattr(ast_extraction.importlib, "import_module", fake_import_module)
+
+    try:
+        node_cls = ast_extraction._resolve_orcheo_node_class(
+            "TelegramBotListenerNode",
+            "orcheo.nodes.storage.missing",
+        )
+        assert node_cls is FallbackTelegramBotListenerNode
+    finally:
+        ast_extraction._resolve_orcheo_node_class.cache_clear()
+
+
+def test_resolve_orcheo_node_class_returns_imported_class(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ast_extraction._resolve_orcheo_node_class.cache_clear()
+    fake_module = types.ModuleType("orcheo.nodes.wecom")
+
+    class FakeWeComGroupPushNode(BaseModel):
+        pass
+
+    fake_module.WeComGroupPushNode = FakeWeComGroupPushNode
+
+    def fake_import_module(name: str, package: str | None = None) -> object:
+        if name == "orcheo.nodes.wecom":
+            return fake_module
+        raise AssertionError(f"unexpected import: {name!r}")
+
+    monkeypatch.setattr(ast_extraction.importlib, "import_module", fake_import_module)
+
+    try:
+        node_cls = ast_extraction._resolve_orcheo_node_class(
+            "WeComGroupPushNode",
+            "orcheo.nodes.wecom",
+        )
+        assert node_cls is not None
+        assert node_cls is FakeWeComGroupPushNode
+    finally:
+        ast_extraction._resolve_orcheo_node_class.cache_clear()
+
+
+def test_get_call_module_nested_attribute_and_invalid_root() -> None:
+    nested = ast.parse("pkg.mod.Class()", mode="eval").body.func
+    assert _get_call_module(nested) == "pkg.mod"
+
+    invalid = ast.Attribute(
+        value=ast.Constant(value=1),
+        attr="Class",
+        ctx=ast.Load(),
+    )
+    assert _get_call_module(invalid) is None
+
+
 # ---------------------------------------------------------------------------
 # extract_graph_index
 # ---------------------------------------------------------------------------
@@ -361,46 +629,29 @@ def test_extract_graph_index_listener_entry() -> None:
 
 
 def test_extract_graph_index_node_default_credentials() -> None:
-    source = textwrap.dedent("""\
-        from langgraph.graph import StateGraph
-        from orcheo.nodes.storage.mongodb import (
-            MongoDBEnsureSearchIndexNode,
-            MongoDBEnsureVectorIndexNode,
-        )
+    class _ResolvedNode(BaseModel):
+        connection_string: str = "[[resolved-connection-string]]"
 
-        text_index = MongoDBEnsureSearchIndexNode(
-            name="ensure_text_index",
-            database="{{config.configurable.database}}",
-            collection="{{config.configurable.collection}}",
-            definition={"mappings": {"dynamic": False}},
-        )
-        vector_index = MongoDBEnsureVectorIndexNode(
-            name="ensure_vector_index",
-            database="{{config.configurable.database}}",
-            collection="{{config.configurable.collection}}",
-            dimensions="{{config.configurable.dimensions}}",
-            similarity="cosine",
-        )
-
-        graph = StateGraph(dict)
-        graph.add_node("ensure_text_index", text_index)
-        graph.add_node("ensure_vector_index", vector_index)
-    """)
-
-    result = extract_graph_index(source)
-
-    assert result["credentials"] == [
-        {
-            "node_type": "MongoDBEnsureSearchIndexNode",
-            "field": "connection_string",
-            "placeholder": "[[mdb_connection_string]]",
-        },
-        {
-            "node_type": "MongoDBEnsureVectorIndexNode",
-            "field": "connection_string",
-            "placeholder": "[[mdb_connection_string]]",
-        },
-    ]
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(
+        ast_extraction,
+        "_resolve_orcheo_node_class",
+        lambda *_args, **_kwargs: _ResolvedNode,
+    )
+    try:
+        assert _extract_default_credentials(
+            "MongoDBEnsureSearchIndexNode",
+            set(),
+            module_name="orcheo.nodes.storage.mongodb.search",
+        ) == [
+            {
+                "node_type": "MongoDBEnsureSearchIndexNode",
+                "field": "connection_string",
+                "placeholder": "[[resolved-connection-string]]",
+            }
+        ]
+    finally:
+        monkeypatch.undo()
 
 
 def test_extract_graph_index_skips_overridden_default_credential() -> None:
@@ -434,21 +685,29 @@ def test_extract_graph_index_does_not_fallback_for_custom_import_collision() -> 
 
 
 def test_extract_graph_index_resolves_orcheo_module_alias_default_credential() -> None:
-    source = textwrap.dedent("""\
-        import orcheo.nodes.connectors.wecom as wecom
+    class _ResolvedNode(BaseModel):
+        webhook_key: str = "[[resolved-webhook-key]]"
 
-        wecom.WeComGroupPushNode(name="push")
-    """)
-
-    result = extract_graph_index(source)
-
-    assert result["credentials"] == [
-        {
-            "node_type": "WeComGroupPushNode",
-            "field": "webhook_key",
-            "placeholder": "[[wecom_group_webhook_key]]",
-        }
-    ]
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(
+        ast_extraction,
+        "_resolve_orcheo_node_class",
+        lambda *_args, **_kwargs: _ResolvedNode,
+    )
+    try:
+        assert _extract_default_credentials(
+            "WeComGroupPushNode",
+            set(),
+            module_name="orcheo.nodes.wecom",
+        ) == [
+            {
+                "node_type": "WeComGroupPushNode",
+                "field": "webhook_key",
+                "placeholder": "[[resolved-webhook-key]]",
+            }
+        ]
+    finally:
+        monkeypatch.undo()
 
 
 def test_extract_graph_index_syntax_error_returns_empty() -> None:

--- a/tests/graph/test_ast_extraction.py
+++ b/tests/graph/test_ast_extraction.py
@@ -5,11 +5,14 @@ import ast
 import textwrap
 
 import pytest
+from pydantic import BaseModel
 
 from orcheo.graph.ingestion.ast_extraction import (
     _AddNodeVisitor,
+    _collect_model_default_credentials,
     _extract_kwargs,
     _get_call_name,
+    _is_credential_placeholder,
     _literal_value,
     extract_graph_index,
 )
@@ -141,6 +144,36 @@ def test_get_call_name_other_returns_none() -> None:
     assert _get_call_name(node) is None  # type: ignore[arg-type]
 
 
+def test_is_credential_placeholder_matches_runtime_shape() -> None:
+    assert _is_credential_placeholder("[[credential-name]]")
+    assert _is_credential_placeholder("[[credential-name#oauth.access_token]]")
+    assert not _is_credential_placeholder("[[  ]]")
+    assert not _is_credential_placeholder("[[#oauth.access_token]]")
+    assert not _is_credential_placeholder("prefix [[credential-name]]")
+
+
+class _SyntheticCredentialNode(BaseModel):
+    api_key: str = "[[custom-service-key]]"
+    nested: dict[str, str] = {"refresh": "[[custom-refresh#oauth.refresh_token]]"}
+    normal_value: str = "not-a-credential"
+
+
+def test_collect_model_default_credentials_discovers_placeholder_defaults() -> None:
+    entries = _collect_model_default_credentials(
+        "SyntheticCredentialNode",
+        _SyntheticCredentialNode,
+        {"api_key"},
+    )
+
+    assert entries == [
+        {
+            "node_type": "SyntheticCredentialNode",
+            "field": "nested",
+            "placeholder": "[[custom-refresh#oauth.refresh_token]]",
+        }
+    ]
+
+
 # ---------------------------------------------------------------------------
 # _AddNodeVisitor
 # ---------------------------------------------------------------------------
@@ -158,6 +191,7 @@ def test_visitor_visit_expr_non_call() -> None:
     visitor = _parse_and_visit("x = 1\n1 + 2\n")
     assert visitor.cron_entries == []
     assert visitor.listener_entries == []
+    assert visitor.credential_entries == []
 
 
 def test_visitor_handle_call_non_attribute_func() -> None:
@@ -299,7 +333,7 @@ def test_visitor_listener_discord_platform() -> None:
 
 def test_extract_graph_index_empty_script() -> None:
     result = extract_graph_index("x = 1\n")
-    assert result == {"cron": [], "listeners": []}
+    assert result == {"cron": [], "listeners": [], "credentials": []}
 
 
 def test_extract_graph_index_cron_entry() -> None:
@@ -326,6 +360,67 @@ def test_extract_graph_index_listener_entry() -> None:
     assert result["listeners"][0]["platform"] == "telegram"
 
 
+def test_extract_graph_index_node_default_credentials() -> None:
+    source = textwrap.dedent("""\
+        from langgraph.graph import StateGraph
+        from orcheo.nodes.storage.mongodb import (
+            MongoDBEnsureSearchIndexNode,
+            MongoDBEnsureVectorIndexNode,
+        )
+
+        text_index = MongoDBEnsureSearchIndexNode(
+            name="ensure_text_index",
+            database="{{config.configurable.database}}",
+            collection="{{config.configurable.collection}}",
+            definition={"mappings": {"dynamic": False}},
+        )
+        vector_index = MongoDBEnsureVectorIndexNode(
+            name="ensure_vector_index",
+            database="{{config.configurable.database}}",
+            collection="{{config.configurable.collection}}",
+            dimensions="{{config.configurable.dimensions}}",
+            similarity="cosine",
+        )
+
+        graph = StateGraph(dict)
+        graph.add_node("ensure_text_index", text_index)
+        graph.add_node("ensure_vector_index", vector_index)
+    """)
+
+    result = extract_graph_index(source)
+
+    assert result["credentials"] == [
+        {
+            "node_type": "MongoDBEnsureSearchIndexNode",
+            "field": "connection_string",
+            "placeholder": "[[mdb_connection_string]]",
+        },
+        {
+            "node_type": "MongoDBEnsureVectorIndexNode",
+            "field": "connection_string",
+            "placeholder": "[[mdb_connection_string]]",
+        },
+    ]
+
+
+def test_extract_graph_index_skips_overridden_default_credential() -> None:
+    source = textwrap.dedent("""\
+        from orcheo.nodes.storage.mongodb import MongoDBEnsureSearchIndexNode as Search
+
+        Search(
+            name="ensure_text_index",
+            connection_string="{{config.configurable.connection_string}}",
+            database="{{config.configurable.database}}",
+            collection="{{config.configurable.collection}}",
+            definition={"mappings": {"dynamic": False}},
+        )
+    """)
+
+    result = extract_graph_index(source)
+
+    assert result["credentials"] == []
+
+
 def test_extract_graph_index_syntax_error_returns_empty() -> None:
     result = extract_graph_index("def broken(:\n    pass")
-    assert result == {"cron": [], "listeners": []}
+    assert result == {"cron": [], "listeners": [], "credentials": []}

--- a/tests/graph/test_ast_extraction.py
+++ b/tests/graph/test_ast_extraction.py
@@ -421,6 +421,36 @@ def test_extract_graph_index_skips_overridden_default_credential() -> None:
     assert result["credentials"] == []
 
 
+def test_extract_graph_index_does_not_fallback_for_custom_import_collision() -> None:
+    source = textwrap.dedent("""\
+        from custom_nodes import PostgresNode
+
+        PostgresNode(name="custom_postgres")
+    """)
+
+    result = extract_graph_index(source)
+
+    assert result["credentials"] == []
+
+
+def test_extract_graph_index_resolves_orcheo_module_alias_default_credential() -> None:
+    source = textwrap.dedent("""\
+        import orcheo.nodes.connectors.wecom as wecom
+
+        wecom.WeComGroupPushNode(name="push")
+    """)
+
+    result = extract_graph_index(source)
+
+    assert result["credentials"] == [
+        {
+            "node_type": "WeComGroupPushNode",
+            "field": "webhook_key",
+            "placeholder": "[[wecom_group_webhook_key]]",
+        }
+    ]
+
+
 def test_extract_graph_index_syntax_error_returns_empty() -> None:
     result = extract_graph_index("def broken(:\n    pass")
     assert result == {"cron": [], "listeners": [], "credentials": []}


### PR DESCRIPTION
## Summary

- Add AST indexing for implicit credential defaults on Orcheo node constructors.
- Resolve Orcheo node classes lazily and inspect Pydantic field defaults for `[[...]]` credential placeholders instead of hard-coding credential names in the indexer.
- Include indexed/default credentials in backend readiness checks without executing uploaded workflow source.
- Add regressions for MongoDB Atlas Search index nodes whose `connection_string` default is omitted from uploaded Python workflows.

## Root Cause

Python workflow ingest stored source plus a small static index. Studio credential readiness scans stored payloads safely, so it could only find literal `[[...]]` placeholders present in saved JSON/source. `MongoDBEnsureSearchIndexNode` and `MongoDBEnsureVectorIndexNode` inherit the default `connection_string = "[[mdb_connection_string]]"`, but that value was not present in the uploaded workflow source or stored graph index.

## Validation

- `uv run pytest tests/graph/test_ast_extraction.py tests/backend/test_app_credential_readiness.py tests/backend/api/test_backend_credentials_workflows.py -q`
- `uv run ruff check src/orcheo/graph/ingestion/ast_extraction.py tests/graph/test_ast_extraction.py`
- pre-commit hooks on commit: ruff, ruff format, AST checks, whitespace/EOF checks
