### PR TITLE
docs(first-party-auth): add initiative requirements, design, and plan

### DIFF
--- a/project/initiatives/first_party_auth/1_requirements.md
+++ b/project/initiatives/first_party_auth/1_requirements.md
@@ -50,6 +50,7 @@ The approach is to own the simple self-serve IdP and delegate to external IdPs o
 - First-party, passwordless (magic link + OTP) email sign up and log in.
 - A first-party Studio login/signup UI replacing the Auth0 redirect flow.
 - An internal `users` identity keyed by verified email; memberships re-keyed off the Auth0 `sub`.
+- Clean cutover with **no backward compatibility**: the backend is switched to first-party tokens in a single change — there is no dual-run window, no dual-issuer acceptance of Auth0 and first-party tokens, and no rollback that re-enables Auth0 (rollback is by database restore).
 - Complete removal of Auth0-specific env vars, configuration, frontend OIDC client, and the invitation flow's Auth0-claim/Action dependency.
 - Switch transactional email (auth challenges and invitations) to **SMTP**, replacing the Resend HTTP integration with a provider-agnostic SMTP sender behind the existing port.
 - No regression to the just-shipped workspace invitation flow; `email_verified` now comes from the first-party IdP.
@@ -75,7 +76,7 @@ The approach is to own the simple self-serve IdP and delegate to external IdPs o
 - Replace the Auth0 OIDC redirect/callback/auto-login flow; retain route-guard and session-storage behavior backed by the new endpoints.
 
 **P0 — Migration & invitation continuity**
-- Backfill `users` from existing membership emails (populated by member-identity capture) and re-key memberships from Auth0 `sub` → internal user id using the existing `list_memberships_for_email` / `reassign_membership` primitives.
+- Backfill `users` from existing membership emails (populated by member-identity capture) and re-key memberships from Auth0 `sub` → internal user id. This requires two **new** repository primitives — an email-indexed membership lookup (`list_memberships_for_email`) and a re-key operation (`reassign_membership`) — added alongside the existing `list_memberships_for_user` / `update_membership_identity` methods, neither of which re-keys the `user_id`.
 - Invitation accept continues to work, sourcing `email_verified` from first-party tokens; remove the Auth0 custom-claim/Action requirement and the `/userinfo` fallback added for Auth0.
 
 **P0 — Auth0 decommission**
@@ -103,7 +104,7 @@ A new identity service (backend module) owns users, email challenges, and token 
 ### Technical Requirements
 - Reuse `AUTH_JWT_SECRET` and existing JWT validation; no new verification path on the hot route.
 - Provide an SMTP-backed transactional email sender (replacing the Resend HTTP integration) behind the existing sender port; reuse `authentication/rate_limit.py`.
-- Migration must be idempotent and reversible during a rollback window; existing service-token auth is unaffected.
+- Migration is a one-time, idempotent batch backfill run at cutover (create `users` from membership emails, then re-key memberships); because there is no backward compatibility, rollback is by database restore, not by re-enabling Auth0. Existing service-token auth is unaffected.
 - Email deliverability becomes a hard dependency for *every* login (consequence of passwordless) — see Risks.
 
 ### AI/ML Considerations (if applicable)
@@ -124,21 +125,21 @@ N/A — platform infrastructure, no market-launch gating.
 | [Secondary] Abuse blocked | Rate-limit/anti-enumeration effective; no enumeration oracle |
 
 ### Rollout Strategy
-Feature-flagged first-party auth alongside Auth0; dual-run with lazy per-user migration on first first-party login; flip default once migration coverage is high; then remove Auth0. See `./3_plan.md`.
+Clean cutover with no backward compatibility: stand up the first-party IdP and Studio UI, run the one-time membership backfill, switch the backend to first-party tokens, and remove Auth0 in the same change. There is no dual-run or dual-issuer window. Staff verify end-to-end on a staging deployment before the production cutover. See `./3_plan.md`.
 
 ### Estimated Launch Phases (if applicable)
 | Phase | Target | Description |
 |-------|--------|-------------|
-| **Phase 1** | Internal/flagged | First-party IdP + Studio UI behind a flag; staff dogfood |
-| **Phase 2** | Opt-in cohort | Lazy migration on login; monitor delivery and migration coverage |
-| **Phase 3** | Default + decommission | First-party default; backfill remaining users; remove Auth0 |
+| **Phase 1** | Staging | First-party IdP + Studio UI on staging; staff dogfood signup, login, refresh, logout, invites end-to-end |
+| **Phase 2** | Cutover dry-run | Run the membership backfill against a staging copy of production data; verify 100% coverage, no orphaned users |
+| **Phase 3** | Production cutover | Single change: backfill memberships, switch backend to first-party tokens, remove Auth0 |
 
 ## HYPOTHESIS & RISKS
 **Hypothesis:** Email-centric users will complete passwordless login at parity-or-better vs. Auth0, and owning the IdP removes vendor cost/lock-in with no loss of capability for the self-serve tier.
 
 **Risks & mitigations**
 - *Email deliverability is now on the login critical path.* Mitigate with a reputable transactional provider, monitoring, OTP fallback, and a documented self-host SMTP requirement.
-- *Migration lockout (sub → user re-keying).* Mitigate with member-identity-captured emails, idempotent lazy + batch migration, a dual-run window, and a rollback path that re-enables Auth0.
+- *Migration lockout (sub → user re-keying).* Mitigate with member-identity-captured emails, an idempotent batch backfill verified to 100% coverage on a staging copy before cutover, and a database-restore rollback. (No backward compatibility, so there is no dual-run fallback to Auth0 — coverage must be proven before the cutover.)
 - *Account-takeover via email compromise* (inherent to passwordless). Mitigate with short-TTL single-use tokens, rate limits, attempt lockout, and session revocation; MFA deferred but noted.
 - *Loss of social login* may frustrate Google/GitHub users. Mitigate by migrating them by verified email and signposting the future SSO initiative.
 
@@ -146,3 +147,5 @@ Feature-flagged first-party auth alongside Auth0; dual-run with lazy per-user mi
 - Decision: passwordless (magic link + OTP); passwords explicitly out of scope.
 - Decision: retain generic OIDC RP layer (not Auth0-specific) for a future enterprise SSO initiative; remove only Auth0-specific configuration/code.
 - Decision: transactional email is delivered via SMTP; the Resend HTTP integration is replaced by an SMTP sender behind the existing port, and the Resend dependency/config is removed.
+- Decision: clean cutover with **no backward compatibility** — no dual-run, no dual-issuer acceptance of Auth0 + first-party tokens, and no Auth0 rollback; rollback is by database restore. Existing Auth0 sessions are invalidated at cutover and users re-authenticate via the first-party flow.
+- Note: the membership-migration primitives `list_memberships_for_email` / `reassign_membership` are **new** (to be added); the repository today exposes `list_memberships_for_user` / `update_membership_identity`, which do not re-key `user_id`.

--- a/project/initiatives/first_party_auth/1_requirements.md
+++ b/project/initiatives/first_party_auth/1_requirements.md
@@ -1,0 +1,148 @@
+# Requirements Document
+
+## METADATA
+- **Authors:** Claude (Opus 4.8)
+- **Project/Feature Name:** First-party authentication (passwordless email IdP)
+- **Type:** Feature
+- **Summary:** Replace the Auth0-backed login with a first-party identity provider that issues Orcheo's existing JWT contract, delivering passwordless email (magic link + OTP) sign up and log in, removing all Auth0-specific configuration and code, and switching transactional email from the Resend HTTP integration to SMTP.
+- **Owner (if different than authors):** ShaojieJiang
+- **Date Started:** 2026-06-21
+
+## RELEVANT LINKS & STAKEHOLDERS
+
+| Documents | Link | Owner | Name |
+|-----------|------|-------|------|
+| Design Doc | `./2_design.md` | ShaojieJiang | First-party Auth Design |
+| Project Plan | `./3_plan.md` | ShaojieJiang | First-party Auth Plan |
+| Repository Guidelines | `../../../AGENTS.md` | ShaojieJiang | Agents Guidelines |
+| Multi-workspace Initiative | `../multi_workspace/1_requirements.md` | ShaojieJiang | Workspace model & membership |
+| Backend Auth Package | `apps/backend/src/orcheo_backend/app/authentication/` | ShaojieJiang | JWT/JWKS verification, settings |
+| Workspace Repository | `src/orcheo/workspace/repository.py` | ShaojieJiang | Membership + migration primitives |
+| Workspace Invitations | `src/orcheo/workspace/service.py` | ShaojieJiang | Invitation accept (email_verified) |
+| Studio Auth Feature | `apps/studio/src/features/auth/` | ShaojieJiang | Login UI, OIDC client, session |
+
+## PROBLEM DEFINITION
+
+### Objectives
+Stand up a first-party identity provider so Orcheo can authenticate users by email alone, with no dependency on Auth0 (or any external IdP) for the self-serve tier. Deliver passwordless email sign up and log in, and retire all Auth0-specific configuration and code.
+
+### Target users
+Self-serve individuals and enterprise end-users on the hosted deployment who sign in with any email domain; self-hosters who need working authentication without standing up or paying for an external IdP. (Enterprise customers wanting central SSO are explicitly served by a *later* initiative — see Non-goals.)
+
+### User Stories
+| As a... | I want to... | So that... | Priority | Acceptance Criteria |
+|---------|--------------|------------|----------|---------------------|
+| New user | sign up with just my email and a link | I can start using Orcheo without creating or managing a password | P0 | `POST /api/auth/email/start` with a new email sends a verification link/OTP; clicking/entering it creates a verified account and an authenticated session |
+| Returning user | log in by clicking an emailed link or entering a code | I can get back in without a password | P0 | Same email entry point; a known email yields a session on verification; sessions persist and refresh |
+| Invited user | accept a workspace invite after logging in with my email | I join the workspace the invite targeted | P0 | First-party login produces `email_verified=true`; the existing invitation accept flow binds the membership with no Auth0 claim/Action required |
+| Any user | stay logged in across reloads and log out everywhere | my session is convenient but revocable | P0 | Refresh issues new access tokens; logout revokes the session server-side; tokens validate against the existing backend auth layer |
+| Operator | run Orcheo with no Auth0 account or env vars | the deployment has no external-IdP dependency or cost | P0 | A fresh deployment authenticates end-to-end with only first-party settings; no `VITE_ORCHEO_AUTH_*` Auth0 values or Auth0 tenant are required |
+| Existing user (migration) | keep my workspace access after the cutover | I am not locked out when Auth0 is removed | P0 | Memberships are re-keyed from the Auth0 `sub` to an internal user id by verified email; first first-party login resolves my existing memberships |
+| Operator | rate-limit and resist abuse of the email entry point | the IdP is not an open email/abuse relay | P1 | Per-IP and per-identity rate limits; constant-time anti-enumeration responses; single-use, short-TTL tokens with attempt lockout |
+
+### Context, Problems, Opportunities
+Orcheo currently authenticates via Auth0 over OIDC. The backend is already IdP-agnostic — it validates JWTs against a configurable issuer/JWKS (`apps/backend/src/orcheo_backend/app/authentication/settings.py`) — so Auth0 is only the *issuer* we happen to point at. The dependency is concentrated in (a) the Studio Auth0 OIDC redirect flow and its `VITE_ORCHEO_AUTH_*` configuration, and (b) the operational cost and lock-in of an external IdP for what is, today, email-centric self-serve usage. Because every membership is keyed on the Auth0 `sub`, the lock-in is also a *data* coupling.
+
+The approach is to own the simple self-serve IdP and delegate to external IdPs only for enterprise SSO: a small passwordless email IdP that issues the JWT shape the backend already validates, deferring federation to a later initiative that reuses the retained generic OIDC relying-party (RP) layer.
+
+### Product goals and Non-goals
+**Goals**
+- First-party, passwordless (magic link + OTP) email sign up and log in.
+- A first-party Studio login/signup UI replacing the Auth0 redirect flow.
+- An internal `users` identity keyed by verified email; memberships re-keyed off the Auth0 `sub`.
+- Complete removal of Auth0-specific env vars, configuration, frontend OIDC client, and the invitation flow's Auth0-claim/Action dependency.
+- Switch transactional email (auth challenges and invitations) to **SMTP**, replacing the Resend HTTP integration with a provider-agnostic SMTP sender behind the existing port.
+- No regression to the just-shipped workspace invitation flow; `email_verified` now comes from the first-party IdP.
+
+**Non-goals (deferred to later initiatives)**
+- Social login (Google/GitHub) — removed here, reintroduced via the SSO initiative.
+- Enterprise SSO (OIDC/SAML federation) and SCIM provisioning — the generic OIDC RP layer is *retained* for this future work but is dormant after cutover.
+- Passwords (explicitly chosen against — passwordless only).
+- MFA/TOTP, account deregistration/deletion, profile management beyond name/email, and per-org auth policy.
+
+## PRODUCT DEFINITION
+
+### Requirements
+**P0 — Identity provider core**
+- `users` table keyed by a unique, normalized (case-insensitive) email, with `email_verified`, optional display name, status, and timestamps.
+- Passwordless email challenge: issue a single-use **magic link** and an equivalent **OTP code** for the same challenge; both verify the same pending record. Short TTL (default 15 min), hashed at rest, attempt-limited.
+- A single email entry point that serves both sign up and log in (no separate flows; account is created on first verification).
+- Session/token issuance matching the existing JWT contract: signed with `AUTH_JWT_SECRET` (HS256), `sub` = internal user id, plus `email` / `email_verified` / `name` claims; access token + rotating refresh/session.
+- Logout (server-side session revocation) and token refresh.
+
+**P0 — Studio login experience**
+- First-party login/signup screen: email entry → "check your email" → link click or OTP entry → authenticated session.
+- Replace the Auth0 OIDC redirect/callback/auto-login flow; retain route-guard and session-storage behavior backed by the new endpoints.
+
+**P0 — Migration & invitation continuity**
+- Backfill `users` from existing membership emails (populated by member-identity capture) and re-key memberships from Auth0 `sub` → internal user id using the existing `list_memberships_for_email` / `reassign_membership` primitives.
+- Invitation accept continues to work, sourcing `email_verified` from first-party tokens; remove the Auth0 custom-claim/Action requirement and the `/userinfo` fallback added for Auth0.
+
+**P0 — Auth0 decommission**
+- Remove Auth0-specific env vars and config from all manifests/docs (frontend `VITE_ORCHEO_AUTH_*` client values; backend Auth0 issuer/JWKS/audience *values*) and delete the Studio Auth0 OIDC client code.
+- Retain the generic OIDC RP verification code (`jwks.py`, external-issuer JWT validation) for the future SSO initiative, clearly marked dormant.
+
+**P1 — Abuse resistance & operability**
+- Per-IP and per-identity rate limiting (reuse `authentication/rate_limit.py`); constant-time anti-enumeration responses; OTP attempt lockout.
+- Email delivery via the shared transactional sender abstraction over **SMTP** (replacing the Resend HTTP sender), with the logging sender retained as the dev default. Shared by auth challenges and invitations.
+- Telemetry: signups, logins, verification success/expiry, and delivery failures.
+
+### Designs (if applicable)
+See `./2_design.md`. Key screens: email-entry, "check your email" interstitial, OTP-entry fallback, and the post-login redirect (including invitation acceptance).
+
+### [Optional] Other Teams Impacted
+- **Workspace/membership:** identity key changes from Auth0 `sub` to internal user id; requires migration and a brief read-path update.
+- **Invitations:** `email_verified` source changes; Auth0 Action requirement removed.
+- **Self-host / stack templates:** Auth0 env vars removed; new first-party auth + SMTP email settings documented (Resend config retired).
+
+## TECHNICAL CONSIDERATIONS
+
+### Architecture Overview
+A new identity service (backend module) owns users, email challenges, and token issuance, signing the same JWT the backend already verifies. The backend `authentication/` package keeps validating tokens — now issued by us via `AUTH_JWT_SECRET` (HS256) instead of fetched from Auth0's JWKS. Studio replaces the Auth0 OIDC client with calls to the new auth endpoints. Membership resolution moves from `sub`-keyed to internal-user-id-keyed via a one-time migration.
+
+### Technical Requirements
+- Reuse `AUTH_JWT_SECRET` and existing JWT validation; no new verification path on the hot route.
+- Provide an SMTP-backed transactional email sender (replacing the Resend HTTP integration) behind the existing sender port; reuse `authentication/rate_limit.py`.
+- Migration must be idempotent and reversible during a rollback window; existing service-token auth is unaffected.
+- Email deliverability becomes a hard dependency for *every* login (consequence of passwordless) — see Risks.
+
+### AI/ML Considerations (if applicable)
+N/A.
+
+## MARKET DEFINITION (for products or large features)
+N/A — platform infrastructure, no market-launch gating.
+
+## LAUNCH/ROLLOUT PLAN
+
+### Success metrics
+| KPIs | Target & Rationale |
+|------|--------------------|
+| [Primary] Login success rate (email-start → session) | ≥ 95% of attempts that open the email; validates passwordless UX |
+| [Primary] Auth0 dependencies removed | 100% of Auth0 env vars/code removed; deployment boots with none present |
+| [Guardrail] Migration completeness | 100% of email-bearing memberships re-keyed; 0 users locked out post-cutover |
+| [Guardrail] Median email delivery time | < 30s; deliverability is the passwordless critical path |
+| [Secondary] Abuse blocked | Rate-limit/anti-enumeration effective; no enumeration oracle |
+
+### Rollout Strategy
+Feature-flagged first-party auth alongside Auth0; dual-run with lazy per-user migration on first first-party login; flip default once migration coverage is high; then remove Auth0. See `./3_plan.md`.
+
+### Estimated Launch Phases (if applicable)
+| Phase | Target | Description |
+|-------|--------|-------------|
+| **Phase 1** | Internal/flagged | First-party IdP + Studio UI behind a flag; staff dogfood |
+| **Phase 2** | Opt-in cohort | Lazy migration on login; monitor delivery and migration coverage |
+| **Phase 3** | Default + decommission | First-party default; backfill remaining users; remove Auth0 |
+
+## HYPOTHESIS & RISKS
+**Hypothesis:** Email-centric users will complete passwordless login at parity-or-better vs. Auth0, and owning the IdP removes vendor cost/lock-in with no loss of capability for the self-serve tier.
+
+**Risks & mitigations**
+- *Email deliverability is now on the login critical path.* Mitigate with a reputable transactional provider, monitoring, OTP fallback, and a documented self-host SMTP requirement.
+- *Migration lockout (sub → user re-keying).* Mitigate with member-identity-captured emails, idempotent lazy + batch migration, a dual-run window, and a rollback path that re-enables Auth0.
+- *Account-takeover via email compromise* (inherent to passwordless). Mitigate with short-TTL single-use tokens, rate limits, attempt lockout, and session revocation; MFA deferred but noted.
+- *Loss of social login* may frustrate Google/GitHub users. Mitigate by migrating them by verified email and signposting the future SSO initiative.
+
+## APPENDIX
+- Decision: passwordless (magic link + OTP); passwords explicitly out of scope.
+- Decision: retain generic OIDC RP layer (not Auth0-specific) for a future enterprise SSO initiative; remove only Auth0-specific configuration/code.
+- Decision: transactional email is delivered via SMTP; the Resend HTTP integration is replaced by an SMTP sender behind the existing port, and the Resend dependency/config is removed.

--- a/project/initiatives/first_party_auth/2_design.md
+++ b/project/initiatives/first_party_auth/2_design.md
@@ -1,0 +1,176 @@
+# Design Document
+
+## For First-party Authentication (passwordless email IdP)
+
+- **Version:** 0.1
+- **Author:** Claude (Opus 4.8)
+- **Date:** 2026-06-21
+- **Status:** Draft
+
+---
+
+## Overview
+
+This feature replaces Auth0 with a first-party identity provider (IdP) for Orcheo's self-serve tier. The IdP authenticates users by email alone — issuing a single-use magic link and an equivalent OTP code — and mints the **same JWT** the backend already validates, so the hot-path verification logic is unchanged. Auth0 becomes unnecessary: its configuration, env vars, frontend OIDC client, and the invitation flow's Auth0 custom-claim dependency are all removed.
+
+The design is deliberately minimal: own the simple email IdP for self-serve, and keep the generic OIDC relying-party (RP) layer dormant for a later enterprise-SSO initiative. A new internal `users` record keyed by **verified email** becomes the stable identity; workspace memberships are re-keyed from the Auth0 `sub` to this internal id, decoupling Orcheo from any single IdP's subject format for good.
+
+Scope is passwordless email login + signup only. Passwords, social login, enterprise SSO/SAML, MFA, and account deregistration are out of scope (see Requirements doc).
+
+## Components
+
+- **Identity Service (FastAPI, new module — `apps/backend/src/orcheo_backend/app/identity/`)**
+  - Owns the `users` store, email-challenge issuance/verification, session/refresh tokens, and JWT minting.
+  - Mints access tokens signed with `AUTH_JWT_SECRET` (HS256), claims: `sub` = internal user id, `email`, `email_verified`, `name`, `iat`, `exp`, `iss` (first-party issuer).
+  - Depends on: the transactional email sender, `authentication/rate_limit.py`, the workspace repository (for membership migration on first login).
+
+- **Backend Auth Verification (existing — `apps/backend/src/orcheo_backend/app/authentication/`)**
+  - Unchanged hot path: validates bearer JWTs. Now configured to accept first-party HS256 tokens via `AUTH_JWT_SECRET` and the first-party `iss`/`aud`.
+  - `jwt_helpers.extract_identity` keeps reading `email`/`name`; these now originate from first-party tokens. The generic JWKS/external-issuer code (`jwks.py`) is retained but dormant.
+
+- **Transactional Email Sender (existing — `src/orcheo/workspace/email.py`)**
+  - The `InvitationEmailSender` abstraction (logging default) is generalized/shared to send auth challenge emails (magic link + OTP).
+  - The production implementation is an **SMTP** sender, replacing the Resend HTTP integration. SMTP becomes the sole production transport for both auth challenges and invitations.
+
+- **Workspace Membership & Migration (existing — `src/orcheo/workspace/repository.py`)**
+  - Reuses `list_memberships_for_email`, `reassign_membership`, and member-identity-captured `membership.email` to migrate memberships from `sub` → internal user id.
+
+- **Studio Auth UI (React — `apps/studio/src/features/auth/`)**
+  - Replaces the Auth0 OIDC client (`lib/oidc-client.ts`, `pages/oauth-callback.tsx`, `components/auto-login.tsx`) with a first-party email login/signup flow.
+  - Retains `components/require-auth.tsx` (route guard) and `lib/auth-session.ts` (token storage/refresh), repointed at first-party endpoints.
+
+## Request Flows
+
+### Flow 1: Sign up / Log in (magic link)
+1. User enters email on the Studio login screen → `POST /api/auth/email/start { email, intent }`.
+2. Identity Service normalizes the email, finds-or-stages a user, creates a challenge (random token + 6–8 digit OTP), stores **hashes** with a 15-min TTL, and emails the magic link (`/auth/verify?token=…`) plus the OTP. Response is constant-time regardless of whether the email exists (anti-enumeration).
+3. User clicks the link → Studio calls `POST /api/auth/email/verify { token }`.
+4. Identity Service validates the token (unconsumed, unexpired, attempt-OK), marks the user `email_verified=true`, consumes the challenge, creates a session, and returns access + refresh tokens and the profile.
+5. On first first-party login, the service runs membership migration (Flow 4) before returning.
+6. Studio stores tokens and routes the user in.
+
+### Flow 2: OTP fallback
+1. Same `email/start` as above.
+2. User enters the OTP in Studio → `POST /api/auth/email/verify { email, code }`.
+3. Same verification, lockout after N failed attempts; success path identical to Flow 1 step 4+.
+
+### Flow 3: Session refresh & logout
+1. Access token nears expiry → `POST /api/auth/refresh` with the refresh token → new access token; refresh token rotated.
+2. `POST /api/auth/logout` revokes the server-side session/refresh token; Studio clears local tokens.
+
+### Flow 4: Membership migration (first first-party login)
+1. After a user verifies, the service looks up the user's verified email via `list_memberships_for_email(email)`.
+2. For each membership still keyed by an Auth0 `sub`, `reassign_membership(workspace_id, from=sub, to=user_id)` moves it to the internal user id (idempotent; preserves role and row).
+3. The resolver cache is invalidated so the new identity immediately resolves its workspaces.
+
+### Flow 5: Invitation acceptance (continuity)
+1. Invitee logs in via Flow 1/2 → holds a first-party token with `email_verified=true`.
+2. Studio `/invitations/accept` calls the existing accept endpoint; `_verified_email` reads the first-party claims directly (no Auth0 `/userinfo` fallback, no custom-claim Action).
+3. Membership is created/bound to the internal user id as today.
+
+## API Contracts
+
+```
+POST /api/auth/email/start
+Body: { email: string, intent: "login" | "signup" }   # intent advisory only
+Response:
+  200 OK -> { status: "sent" }      # constant-time; never reveals account existence
+  429    -> rate limited
+
+POST /api/auth/email/verify
+Body: { token: string } | { email: string, code: string }
+Response:
+  200 OK -> { access_token, refresh_token, expires_in, user: { id, email, email_verified, name } }
+  400/410 -> invalid/expired/consumed challenge
+  423    -> too many attempts (locked)
+
+POST /api/auth/refresh
+Body: { refresh_token: string }
+Response:
+  200 OK -> { access_token, refresh_token, expires_in }
+  401    -> invalid/revoked refresh token
+
+POST /api/auth/logout
+Headers: Authorization: Bearer <access_token>
+Response: 204 No Content    # revokes the session/refresh token
+
+GET /api/auth/me
+Headers: Authorization: Bearer <access_token>
+Response: 200 OK -> { id, email, email_verified, name }
+
+# Access tokens carry the existing contract validated by authentication/:
+# { sub: <user uuid>, email, email_verified, name, iss: <first-party>, aud, iat, exp }
+```
+
+## Data Models / Schemas
+
+**`users`**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| id | UUID (PK) | Internal stable identity; becomes membership key |
+| email | TEXT (unique, normalized lower-case) | Verified email; the human identity |
+| email_verified | BOOL | True once any challenge is completed |
+| name | TEXT (nullable) | Optional display name |
+| status | TEXT | `active` \| `disabled` |
+| created_at / last_login_at | TIMESTAMPTZ | Lifecycle timestamps |
+
+**`auth_email_challenges`**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| id | UUID (PK) | Challenge id |
+| email | TEXT | Target email (user may not exist yet) |
+| token_hash | TEXT | SHA-256 of the magic-link token (raw never stored) |
+| code_hash | TEXT | Hash of the OTP code |
+| purpose | TEXT | `login_or_signup` |
+| attempts | INT | OTP attempt counter for lockout |
+| expires_at | TIMESTAMPTZ | Short TTL (default 15 min) |
+| consumed_at | TIMESTAMPTZ (nullable) | Single-use marker |
+
+**`auth_sessions`** (refresh tokens)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| id | UUID (PK) | Session id |
+| user_id | UUID (FK users) | Owner |
+| refresh_token_hash | TEXT | Hashed, rotating |
+| expires_at / revoked_at | TIMESTAMPTZ | Lifecycle / logout |
+| user_agent / ip | TEXT (nullable) | Audit context |
+
+**Membership change:** `workspace_memberships.user_id` transitions from the Auth0 `sub` string to the internal `users.id` (UUID as text). Migration is data-only; the column and uniqueness constraint are unchanged.
+
+## Security Considerations
+
+- **Token handling:** magic-link tokens and OTPs are random, single-use, short-TTL, and stored only as hashes. Verification is constant-time where it matters.
+- **Anti-enumeration:** `email/start` returns an identical response and timing whether or not the account exists.
+- **Rate limiting & lockout:** per-IP and per-identity limits via `authentication/rate_limit.py`; OTP attempts capped with lockout.
+- **Session security:** rotating refresh tokens, server-side revocation, secure/httpOnly storage; access-token TTL kept short.
+- **Signing key:** `AUTH_JWT_SECRET` is the IdP signing key — document rotation; consider moving to RS256/JWKS later if external verifiers need it (not required now).
+- **email_verified semantics:** only set true via a completed challenge; this is the control the invitation flow relies on.
+- **Unaffected:** service-token (machine) auth is independent and untouched.
+
+## Performance Considerations
+- Hot path (request authorization) is unchanged — local HS256 verification, no network call (removes the Auth0 JWKS fetch/cache entirely).
+- Email send is async to the user's perception via the "check your email" interstitial; sender failures surfaced and retried.
+- Challenge/session tables are small and indexed by `email` and `token_hash`.
+
+## Testing Strategy
+- **Unit tests:** email normalization; challenge issuance/verification (expiry, single-use, OTP lockout); JWT minting/claims; refresh rotation/revocation; anti-enumeration response invariance.
+- **Integration tests:** full start→verify→session; refresh; logout; invitation accept end-to-end on first-party tokens; membership migration (`sub` → user id) idempotency.
+- **Manual QA:** Studio signup, login (link + OTP), reload/refresh, logout, invite acceptance, and a fresh deployment with zero Auth0 env vars.
+
+## Rollout Plan
+1. **Phase 1 — flagged:** ship Identity Service + Studio UI behind a flag alongside Auth0; staff dogfood.
+2. **Phase 2 — dual-run:** lazy per-user migration on first first-party login; monitor delivery and migration coverage.
+3. **Phase 3 — default + decommission:** make first-party default; batch-migrate stragglers; remove Auth0 env vars/code, the Studio OIDC client, the invitation Auth0-claim path, and the Resend integration/config (SMTP becomes the sole transport). Keep the generic OIDC RP code dormant for the SSO initiative.
+
+Backwards compatibility: during dual-run the backend accepts both Auth0 and first-party tokens (two configured issuers); after decommission only the first-party issuer remains.
+
+---
+
+## Revision History
+
+| Date | Author | Changes |
+|------|--------|---------|
+| 2026-06-21 | Claude (Opus 4.8) | Initial draft |

--- a/project/initiatives/first_party_auth/2_design.md
+++ b/project/initiatives/first_party_auth/2_design.md
@@ -17,6 +17,8 @@ The design is deliberately minimal: own the simple email IdP for self-serve, and
 
 Scope is passwordless email login + signup only. Passwords, social login, enterprise SSO/SAML, MFA, and account deregistration are out of scope (see Requirements doc).
 
+This ships as a **clean cutover with no backward compatibility**: after cutover the backend validates only first-party HS256 tokens, there is no dual-run or dual-issuer window in which Auth0 and first-party tokens are both accepted, existing Auth0 sessions are invalidated, and rollback is by database restore rather than re-enabling Auth0.
+
 ## Components
 
 - **Identity Service (FastAPI, new module — `apps/backend/src/orcheo_backend/app/identity/`)**
@@ -32,8 +34,8 @@ Scope is passwordless email login + signup only. Passwords, social login, enterp
   - The `InvitationEmailSender` abstraction (logging default) is generalized/shared to send auth challenge emails (magic link + OTP).
   - The production implementation is an **SMTP** sender, replacing the Resend HTTP integration. SMTP becomes the sole production transport for both auth challenges and invitations.
 
-- **Workspace Membership & Migration (existing — `src/orcheo/workspace/repository.py`)**
-  - Reuses `list_memberships_for_email`, `reassign_membership`, and member-identity-captured `membership.email` to migrate memberships from `sub` → internal user id.
+- **Workspace Membership & Migration (`src/orcheo/workspace/repository.py`)**
+  - Adds two **new** repository primitives — `list_memberships_for_email(email)` and `reassign_membership(workspace_id, from_user_id, to_user_id)` — built on the existing store, which already captures `membership.email` and exposes `list_memberships_for_user` / `update_membership_identity` (neither of which re-keys `user_id`). These drive the `sub` → internal user id backfill.
 
 - **Studio Auth UI (React — `apps/studio/src/features/auth/`)**
   - Replaces the Auth0 OIDC client (`lib/oidc-client.ts`, `pages/oauth-callback.tsx`, `components/auto-login.tsx`) with a first-party email login/signup flow.
@@ -46,7 +48,7 @@ Scope is passwordless email login + signup only. Passwords, social login, enterp
 2. Identity Service normalizes the email, finds-or-stages a user, creates a challenge (random token + 6–8 digit OTP), stores **hashes** with a 15-min TTL, and emails the magic link (`/auth/verify?token=…`) plus the OTP. Response is constant-time regardless of whether the email exists (anti-enumeration).
 3. User clicks the link → Studio calls `POST /api/auth/email/verify { token }`.
 4. Identity Service validates the token (unconsumed, unexpired, attempt-OK), marks the user `email_verified=true`, consumes the challenge, creates a session, and returns access + refresh tokens and the profile.
-5. On first first-party login, the service runs membership migration (Flow 4) before returning.
+5. On login the service resolves the user's memberships by verified email — they were re-keyed to the internal user id by the one-time backfill (Flow 4) — before returning.
 6. Studio stores tokens and routes the user in.
 
 ### Flow 2: OTP fallback
@@ -58,10 +60,10 @@ Scope is passwordless email login + signup only. Passwords, social login, enterp
 1. Access token nears expiry → `POST /api/auth/refresh` with the refresh token → new access token; refresh token rotated.
 2. `POST /api/auth/logout` revokes the server-side session/refresh token; Studio clears local tokens.
 
-### Flow 4: Membership migration (first first-party login)
-1. After a user verifies, the service looks up the user's verified email via `list_memberships_for_email(email)`.
-2. For each membership still keyed by an Auth0 `sub`, `reassign_membership(workspace_id, from=sub, to=user_id)` moves it to the internal user id (idempotent; preserves role and row).
-3. The resolver cache is invalidated so the new identity immediately resolves its workspaces.
+### Flow 4: Membership migration (one-time backfill at cutover)
+1. A one-time, idempotent backfill creates a `users` row (new UUID) for each distinct `membership.email`, then for every membership still keyed by an Auth0 `sub` calls `reassign_membership(workspace_id, from_user_id=sub, to_user_id=user_id)` to move it to that internal user id via `list_memberships_for_email(email)` (preserves role and row; skips rows already on an internal id).
+2. After cutover, first-party login resolves the pre-created `users` row by verified email, so its memberships already point at the matching internal id. The resolver cache is invalidated so identities resolve their workspaces immediately.
+3. Because there is no backward compatibility (no dual-run), no new Auth0-keyed rows are created after cutover; any stragglers are caught by re-running the idempotent backfill.
 
 ### Flow 5: Invitation acceptance (continuity)
 1. Invitee logs in via Flow 1/2 → holds a first-party token with `email_verified=true`.
@@ -138,7 +140,7 @@ Response: 200 OK -> { id, email, email_verified, name }
 | expires_at / revoked_at | TIMESTAMPTZ | Lifecycle / logout |
 | user_agent / ip | TEXT (nullable) | Audit context |
 
-**Membership change:** `workspace_memberships.user_id` transitions from the Auth0 `sub` string to the internal `users.id` (UUID as text). Migration is data-only; the column and uniqueness constraint are unchanged.
+**Membership change:** `workspace_memberships.user_id` transitions from the Auth0 `sub` string to the internal `users.id` (UUID as text). Migration is data-only; the column and the `(workspace_id, user_id)` uniqueness constraint are unchanged. The one-time backfill assigns each email exactly one internal id, so a workspace cannot end up with two rows for the same person; if a target `(workspace_id, internal_id)` row already exists, the backfill keeps it and drops the duplicate `sub`-keyed row (highest role wins).
 
 ## Security Considerations
 
@@ -161,11 +163,12 @@ Response: 200 OK -> { id, email, email_verified, name }
 - **Manual QA:** Studio signup, login (link + OTP), reload/refresh, logout, invite acceptance, and a fresh deployment with zero Auth0 env vars.
 
 ## Rollout Plan
-1. **Phase 1 — flagged:** ship Identity Service + Studio UI behind a flag alongside Auth0; staff dogfood.
-2. **Phase 2 — dual-run:** lazy per-user migration on first first-party login; monitor delivery and migration coverage.
-3. **Phase 3 — default + decommission:** make first-party default; batch-migrate stragglers; remove Auth0 env vars/code, the Studio OIDC client, the invitation Auth0-claim path, and the Resend integration/config (SMTP becomes the sole transport). Keep the generic OIDC RP code dormant for the SSO initiative.
+This initiative ships as a **clean cutover with no backward compatibility** — there is no dual-run, no dual-issuer window, and no rollback that re-enables Auth0.
+1. **Phase 1 — staging:** ship Identity Service + Studio UI to staging; staff dogfood signup, login (link + OTP), refresh, logout, and invitation acceptance end-to-end.
+2. **Phase 2 — cutover dry-run:** run the one-time membership backfill against a staging copy of production data; verify 100% of email-bearing memberships re-key and no user is orphaned.
+3. **Phase 3 — production cutover (single change):** run the backfill, switch the backend from the Auth0 issuer/JWKS to first-party HS256 tokens, and remove Auth0 env vars/code, the Studio OIDC client, the invitation Auth0-claim path, and the Resend integration/config (SMTP becomes the sole transport). Keep the generic OIDC RP code dormant for the SSO initiative.
 
-Backwards compatibility: during dual-run the backend accepts both Auth0 and first-party tokens (two configured issuers); after decommission only the first-party issuer remains.
+**No backward compatibility:** after cutover the backend validates only first-party HS256 tokens — it never accepts Auth0 and first-party tokens concurrently. Any Auth0 session is invalidated at cutover and users re-authenticate via the first-party flow. Rollback is by database restore, not by re-enabling Auth0.
 
 ---
 
@@ -174,3 +177,4 @@ Backwards compatibility: during dual-run the backend accepts both Auth0 and firs
 | Date | Author | Changes |
 |------|--------|---------|
 | 2026-06-21 | Claude (Opus 4.8) | Initial draft |
+| 2026-06-21 | Claude (Opus 4.8) | Clean cutover, no backward compatibility (removed dual-run/dual-issuer); corrected membership-migration primitives as new (`list_memberships_for_email` / `reassign_membership`); added re-key conflict handling |

--- a/project/initiatives/first_party_auth/3_plan.md
+++ b/project/initiatives/first_party_auth/3_plan.md
@@ -1,0 +1,121 @@
+# Project Plan
+
+## For First-party Authentication (passwordless email IdP)
+
+- **Version:** 0.1
+- **Author:** Claude (Opus 4.8)
+- **Date:** 2026-06-21
+- **Status:** Draft
+
+---
+
+## Overview
+
+Build a first-party, passwordless email identity provider that mints Orcheo's existing JWT contract, replace the Studio Auth0 login with a first-party UI, migrate workspace memberships from the Auth0 `sub` to an internal verified-email identity, switch transactional email to SMTP, and decommission all Auth0-specific configuration and code (and the Resend integration). Scope is email magic-link + OTP login/signup only; social login, enterprise SSO, MFA, and deregistration are out of scope.
+
+**Related Documents:**
+- Requirements: `./1_requirements.md`
+- Design: `./2_design.md`
+
+---
+
+## Milestones
+
+### Milestone 1: Identity Service core
+
+**Description:** A backend identity service that issues and verifies passwordless email challenges and mints first-party JWTs validated by the existing auth layer. Success: an automated test can drive start → verify → authenticated session and refresh/logout, with tokens accepted by `authentication/`.
+
+#### Task Checklist
+
+- [ ] Task 1.1: Add `users`, `auth_email_challenges`, and `auth_sessions` schemas + repository (in-memory + Postgres), mirroring the workspace store pattern.
+  - Dependencies: None
+- [ ] Task 1.2: Implement email-challenge issuance (magic-link token + OTP, hashed, TTL, single-use) and verification with attempt lockout.
+  - Dependencies: Task 1.1
+- [ ] Task 1.3: Implement JWT minting (HS256 via `AUTH_JWT_SECRET`, first-party `iss`/`aud`, `sub`=user id, `email`/`email_verified`/`name`) + refresh-token rotation and session revocation.
+  - Dependencies: Task 1.1
+- [ ] Task 1.4: Generalize the transactional email sender (`src/orcheo/workspace/email.py`) to send auth challenge emails, and add an **SMTP**-backed sender as the production implementation (replacing Resend) behind the existing port; keep the logging sender as the dev default.
+  - Dependencies: None
+- [ ] Task 1.5: Expose endpoints `POST /api/auth/email/start`, `/email/verify`, `/refresh`, `/logout`, `GET /api/auth/me` with rate limiting and anti-enumeration.
+  - Dependencies: Tasks 1.2, 1.3
+- [ ] Task 1.6: Configure `authentication/` to accept first-party HS256 tokens (issuer/audience/secret); keep generic JWKS path intact.
+  - Dependencies: Task 1.3
+
+---
+
+### Milestone 2: Studio first-party login experience
+
+**Description:** Replace the Auth0 OIDC redirect flow with a first-party email login/signup UI, preserving route-guarding, session storage, and refresh. Success: a user can sign up, log in (link + OTP), persist across reload, and log out entirely against the new endpoints.
+
+#### Task Checklist
+
+- [ ] Task 2.1: Build the email-entry → "check your email" → OTP-entry screens and the `/auth/verify` link handler.
+  - Dependencies: Milestone 1
+- [ ] Task 2.2: Repoint `lib/auth-session.ts` (token storage/refresh) and `components/require-auth.tsx` (guard) at first-party endpoints.
+  - Dependencies: Task 2.1
+- [ ] Task 2.3: Remove the Auth0 OIDC client flow (`lib/oidc-client.ts`, `pages/oauth-callback.tsx`, `components/auto-login.tsx`) and rewrite `pages/login.tsx`.
+  - Dependencies: Task 2.2
+- [ ] Task 2.4: Verify the invitation `/invitations/accept` route works on first-party tokens end-to-end.
+  - Dependencies: Task 2.2
+
+---
+
+### Milestone 3: Identity migration & invitation continuity
+
+**Description:** Re-key workspace memberships from the Auth0 `sub` to the internal user id by verified email, and source `email_verified` for invitations from first-party tokens. Success: 100% of email-bearing memberships migrate idempotently; no user is locked out; invitations no longer require any Auth0 claim/Action.
+
+#### Task Checklist
+
+- [ ] Task 3.1: Implement lazy migration on first first-party login using `list_memberships_for_email` + `reassign_membership`; invalidate the resolver cache.
+  - Dependencies: Milestone 1
+- [ ] Task 3.2: Add an idempotent batch backfill (CLI/management task) to migrate users who have not yet logged in, from captured `membership.email`.
+  - Dependencies: Task 3.1
+- [ ] Task 3.3: Simplify the invitation accept path — read `email_verified` from first-party claims; remove the Auth0 `/userinfo` fallback and custom-claim handling in `routers/workspaces.py::_verified_email`.
+  - Dependencies: Milestone 2
+- [ ] Task 3.4: Report on migration coverage (memberships migrated vs. remaining) for cutover readiness.
+  - Dependencies: Task 3.2
+
+---
+
+### Milestone 4: Auth0 & Resend decommission
+
+**Description:** Remove every Auth0-specific dependency, and retire the Resend integration in favour of SMTP, once migration coverage is sufficient. Success: a fresh deployment authenticates end-to-end and sends email over SMTP with no Auth0 env vars/tenant/code and no Resend config present; the generic OIDC RP layer remains, clearly marked dormant.
+
+#### Task Checklist
+
+- [ ] Task 4.1: Remove Auth0 frontend env/config (`VITE_ORCHEO_AUTH_ISSUER/CLIENT_ID/AUDIENCE/ORGANIZATION/PROVIDER_*/REDIRECT_URI/SCOPES/STATE_BYTES/VERIFIER_BYTES`) from manifests, `.env` examples, and stack templates.
+  - Dependencies: Milestone 2
+- [ ] Task 4.2: Remove Auth0 backend issuer/JWKS/audience *values* and dual-issuer config; retain generic JWKS code marked dormant for the SSO initiative.
+  - Dependencies: Milestone 3
+- [ ] Task 4.3: Delete the Auth0 Action / custom-claim documentation and references introduced for the invitation flow.
+  - Dependencies: Task 3.3
+- [ ] Task 4.4: Update `AGENTS.md`, self-host docs, and stack templates to document first-party auth + SMTP email settings.
+  - Dependencies: Tasks 4.1, 4.2
+- [ ] Task 4.5: Remove the Resend integration and its config/env (e.g. `ORCHEO_RESEND_API_KEY`, `ORCHEO_INVITE_FROM_EMAIL`) and the `httpx`-based Resend sender; SMTP becomes the sole production transport.
+  - Dependencies: Task 1.4
+- [ ] Task 4.6: Update stack templates and `.env` examples to replace Resend settings with SMTP settings (host, port, credentials, from-address, TLS).
+  - Dependencies: Task 4.5
+
+---
+
+### Milestone 5: Hardening & rollout
+
+**Description:** Production-readiness for the passwordless critical path and a safe phased rollout. Success: rate limits and anti-enumeration verified, email delivery monitored, and first-party auth defaulted with a rollback path.
+
+#### Task Checklist
+
+- [ ] Task 5.1: Finalize per-IP/per-identity rate limits, OTP lockout, and anti-enumeration timing; add abuse tests.
+  - Dependencies: Milestone 1
+- [ ] Task 5.2: Add telemetry/alerts for signups, logins, verification expiry, and email-delivery failures.
+  - Dependencies: Milestone 1
+- [ ] Task 5.3: Phased rollout — flag on for staff (Phase 1) → dual-run cohort (Phase 2) → default (Phase 3); document rollback (re-enable Auth0 during the dual-run window).
+  - Dependencies: Milestones 2, 3
+- [ ] Task 5.4: Document `AUTH_JWT_SECRET` rotation and the optional future move to RS256/JWKS.
+  - Dependencies: Task 1.3
+
+---
+
+## Revision History
+
+| Date | Author | Changes |
+|------|--------|---------|
+| 2026-06-21 | Claude (Opus 4.8) | Initial draft |

--- a/project/initiatives/first_party_auth/3_plan.md
+++ b/project/initiatives/first_party_auth/3_plan.md
@@ -11,7 +11,7 @@
 
 ## Overview
 
-Build a first-party, passwordless email identity provider that mints Orcheo's existing JWT contract, replace the Studio Auth0 login with a first-party UI, migrate workspace memberships from the Auth0 `sub` to an internal verified-email identity, switch transactional email to SMTP, and decommission all Auth0-specific configuration and code (and the Resend integration). Scope is email magic-link + OTP login/signup only; social login, enterprise SSO, MFA, and deregistration are out of scope.
+Build a first-party, passwordless email identity provider that mints Orcheo's existing JWT contract, replace the Studio Auth0 login with a first-party UI, migrate workspace memberships from the Auth0 `sub` to an internal verified-email identity, switch transactional email to SMTP, and decommission all Auth0-specific configuration and code (and the Resend integration). This is a **clean cutover with no backward compatibility** — no dual-run, no dual-issuer window, and no rollback that re-enables Auth0 (rollback is by database restore). Scope is email magic-link + OTP login/signup only; social login, enterprise SSO, MFA, and deregistration are out of scope.
 
 **Related Documents:**
 - Requirements: `./1_requirements.md`
@@ -37,7 +37,7 @@ Build a first-party, passwordless email identity provider that mints Orcheo's ex
   - Dependencies: None
 - [ ] Task 1.5: Expose endpoints `POST /api/auth/email/start`, `/email/verify`, `/refresh`, `/logout`, `GET /api/auth/me` with rate limiting and anti-enumeration.
   - Dependencies: Tasks 1.2, 1.3
-- [ ] Task 1.6: Configure `authentication/` to accept first-party HS256 tokens (issuer/audience/secret); keep generic JWKS path intact.
+- [ ] Task 1.6: Configure `authentication/` to validate first-party HS256 tokens (issuer/audience/secret) as the sole accepted issuer — no dual-issuer/Auth0 acceptance; keep the generic JWKS code present but dormant for the future SSO initiative.
   - Dependencies: Task 1.3
 
 ---
@@ -65,9 +65,9 @@ Build a first-party, passwordless email identity provider that mints Orcheo's ex
 
 #### Task Checklist
 
-- [ ] Task 3.1: Implement lazy migration on first first-party login using `list_memberships_for_email` + `reassign_membership`; invalidate the resolver cache.
+- [ ] Task 3.1: Add the two **new** repository primitives — `list_memberships_for_email(email)` and `reassign_membership(workspace_id, from_user_id, to_user_id)` (the existing `list_memberships_for_user` / `update_membership_identity` do not re-key `user_id`); invalidate the resolver cache on re-key.
   - Dependencies: Milestone 1
-- [ ] Task 3.2: Add an idempotent batch backfill (CLI/management task) to migrate users who have not yet logged in, from captured `membership.email`.
+- [ ] Task 3.2: Implement the one-time idempotent batch backfill (CLI/management task) run at cutover: create a `users` row per distinct captured `membership.email`, then re-key every `sub`-keyed membership to the internal id via `reassign_membership` (resolving any `(workspace_id, internal_id)` collision by keeping the existing row, highest role wins). Because there is no dual-run, this is the primary migration path, not a straggler cleanup.
   - Dependencies: Task 3.1
 - [ ] Task 3.3: Simplify the invitation accept path — read `email_verified` from first-party claims; remove the Auth0 `/userinfo` fallback and custom-claim handling in `routers/workspaces.py::_verified_email`.
   - Dependencies: Milestone 2
@@ -84,7 +84,7 @@ Build a first-party, passwordless email identity provider that mints Orcheo's ex
 
 - [ ] Task 4.1: Remove Auth0 frontend env/config (`VITE_ORCHEO_AUTH_ISSUER/CLIENT_ID/AUDIENCE/ORGANIZATION/PROVIDER_*/REDIRECT_URI/SCOPES/STATE_BYTES/VERIFIER_BYTES`) from manifests, `.env` examples, and stack templates.
   - Dependencies: Milestone 2
-- [ ] Task 4.2: Remove Auth0 backend issuer/JWKS/audience *values* and dual-issuer config; retain generic JWKS code marked dormant for the SSO initiative.
+- [ ] Task 4.2: Remove the Auth0 backend issuer/JWKS/audience *values* (there is no dual-issuer config — the backend accepts only the first-party issuer); retain the generic JWKS code marked dormant for the SSO initiative.
   - Dependencies: Milestone 3
 - [ ] Task 4.3: Delete the Auth0 Action / custom-claim documentation and references introduced for the invitation flow.
   - Dependencies: Task 3.3
@@ -99,7 +99,7 @@ Build a first-party, passwordless email identity provider that mints Orcheo's ex
 
 ### Milestone 5: Hardening & rollout
 
-**Description:** Production-readiness for the passwordless critical path and a safe phased rollout. Success: rate limits and anti-enumeration verified, email delivery monitored, and first-party auth defaulted with a rollback path.
+**Description:** Production-readiness for the passwordless critical path and a safe clean cutover (no backward compatibility). Success: rate limits and anti-enumeration verified, email delivery monitored, and the production cutover completed with a database-restore rollback path.
 
 #### Task Checklist
 
@@ -107,7 +107,7 @@ Build a first-party, passwordless email identity provider that mints Orcheo's ex
   - Dependencies: Milestone 1
 - [ ] Task 5.2: Add telemetry/alerts for signups, logins, verification expiry, and email-delivery failures.
   - Dependencies: Milestone 1
-- [ ] Task 5.3: Phased rollout — flag on for staff (Phase 1) → dual-run cohort (Phase 2) → default (Phase 3); document rollback (re-enable Auth0 during the dual-run window).
+- [ ] Task 5.3: Clean-cutover rollout — staging dogfood (Phase 1) → cutover dry-run against a staging copy verifying 100% backfill coverage (Phase 2) → single-change production cutover (Phase 3). No dual-run; document database-restore rollback (not re-enabling Auth0).
   - Dependencies: Milestones 2, 3
 - [ ] Task 5.4: Document `AUTH_JWT_SECRET` rotation and the optional future move to RS256/JWKS.
   - Dependencies: Task 1.3
@@ -119,3 +119,4 @@ Build a first-party, passwordless email identity provider that mints Orcheo's ex
 | Date | Author | Changes |
 |------|--------|---------|
 | 2026-06-21 | Claude (Opus 4.8) | Initial draft |
+| 2026-06-21 | Claude (Opus 4.8) | Clean cutover, no backward compatibility (removed dual-run/dual-issuer/Auth0 rollback); corrected migration tasks to add new `list_memberships_for_email` / `reassign_membership` primitives |


### PR DESCRIPTION
Draft the first-party authentication initiative: a passwordless email (magic link + OTP) identity provider that issues Orcheo's existing JWT contract, replacing Auth0. Covers the local IdP, a first-party Studio login/signup UI, an internal verified-email users table with membership migration off the Auth0 sub, switching transactional email to SMTP, and decommissioning all Auth0-specific config/code (and the Resend integration). The generic OIDC relying-party layer is retained, dormant, for a future enterprise-SSO initiative.