### PR TITLE
Group candidates in gallery, fix stale config sheet, refine setup prompts

### DIFF
--- a/apps/studio/src/features/workflow/data/templates/candidate-badges.ts
+++ b/apps/studio/src/features/workflow/data/templates/candidate-badges.ts
@@ -27,6 +27,33 @@ export interface CandidateBadgeDefinition extends CandidateBadgeSpec {
   templateDefinition: WorkflowTemplateDefinition;
 }
 
+/**
+ * Derive a candidate's group slug from its colleague-candidates directory path.
+ *
+ * Candidates are grouped one level under `colleagues/`: a directory that holds a
+ * `workflow.py` directly (no slash in the id) is independent and returns null,
+ * while a nested path such as `news_desk/feed_curator` belongs to the
+ * `news_desk` group.
+ */
+export const candidateGroupSlug = (
+  candidateId: string | null | undefined,
+): string | null => {
+  if (!candidateId) {
+    return null;
+  }
+  const separator = candidateId.indexOf("/");
+  return separator === -1 ? null : candidateId.slice(0, separator);
+};
+
+/**
+ * Turn an underscored group slug into a display label, e.g.
+ * `news_desk` → `News desk`.
+ */
+export const formatCandidateGroupName = (slug: string): string => {
+  const spaced = slug.replace(/_/g, " ");
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+};
+
 const toStringArray = (value: unknown): string[] | undefined => {
   if (!Array.isArray(value)) {
     return undefined;
@@ -70,6 +97,7 @@ const buildCandidateWorkflow = (
     handle: preserveHandle,
     name: spec.name,
     description: spec.description,
+    candidateGroup: candidateGroupSlug(spec.candidateId),
     avatarEmoji: avatarId,
     createdAt: "2026-01-01T00:00:00Z",
     updatedAt: "2026-01-01T00:00:00Z",

--- a/apps/studio/src/features/workflow/data/workflow-types.ts
+++ b/apps/studio/src/features/workflow/data/workflow-types.ts
@@ -34,6 +34,12 @@ export interface Workflow {
   id: string;
   handle?: string;
   teamId?: string | null;
+  /**
+   * Group slug for candidate colleagues, derived from the first path segment
+   * of the colleague-candidates directory (e.g. "news_desk"). Null when the
+   * candidate lives directly under `colleagues/` and is therefore independent.
+   */
+  candidateGroup?: string | null;
   name: string;
   description?: string;
   avatarEmoji?: string | null;

--- a/apps/studio/src/features/workflow/lib/workflow-storage-versioning.ts
+++ b/apps/studio/src/features/workflow/lib/workflow-storage-versioning.ts
@@ -124,4 +124,8 @@ export const persistRunnableConfig = async (
       }),
     },
   );
+  // The cached workflow still holds the previous runnable config; drop it so the
+  // next fetch reflects the value we just persisted.
+  invalidateWorkflowCache(workflowId);
+  return targetVersion;
 };

--- a/apps/studio/src/features/workflow/pages/workflow-gallery/workflow-gallery-tabs.test.tsx
+++ b/apps/studio/src/features/workflow/pages/workflow-gallery/workflow-gallery-tabs.test.tsx
@@ -206,6 +206,11 @@ describe("WorkflowGalleryTabs", () => {
     });
     expect(knowledgeHeader).toBeTruthy();
     expect(screen.getByRole("button", { name: /News desk 1/i })).toBeTruthy();
+    expect(
+      knowledgeHeader.compareDocumentPosition(
+        screen.getByRole("button", { name: /News desk 1/i }),
+      ),
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     // Independent candidates are not wrapped in a section.
     expect(
       screen.queryByRole("button", { name: /Chat interviewer/i }),
@@ -268,7 +273,12 @@ describe("WorkflowGalleryTabs", () => {
         isTemplateView={false}
         teams={[
           { id: "team-default", slug: "acme", name: "Acme", is_default: true },
-          { id: "team-eng", slug: "engineering", name: "Engineering", is_default: false },
+          {
+            id: "team-eng",
+            slug: "engineering",
+            name: "Engineering",
+            is_default: false,
+          },
         ]}
         workspaceLabel="Acme"
         searchQuery=""

--- a/apps/studio/src/features/workflow/pages/workflow-gallery/workflow-gallery-tabs.test.tsx
+++ b/apps/studio/src/features/workflow/pages/workflow-gallery/workflow-gallery-tabs.test.tsx
@@ -152,6 +152,111 @@ describe("WorkflowGalleryTabs", () => {
     expect(screen.getAllByTestId("workflow-card")).toHaveLength(1);
   });
 
+  it("groups candidates into sections mirroring the colleagues layout", async () => {
+    const baseTemplate = {
+      name: "Candidate",
+      description: "",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      owner: { id: "owner-1", name: "Owner", avatar: "" },
+      tags: ["template"],
+      nodes: [],
+      edges: [],
+    };
+    renderTabs(
+      <WorkflowGalleryTabs
+        selectedTab="templates"
+        onSelectedTabChange={vi.fn()}
+        isLoading={false}
+        sortedWorkflows={[
+          { ...baseTemplate, id: "template-chat_interviewer" },
+          { ...baseTemplate, id: "template-general_assistant" },
+          {
+            ...baseTemplate,
+            id: "template-knowledge_desk-knowledge_guide",
+            candidateGroup: "knowledge_desk",
+          },
+          {
+            ...baseTemplate,
+            id: "template-knowledge_desk-web_archivist",
+            candidateGroup: "knowledge_desk",
+          },
+          {
+            ...baseTemplate,
+            id: "template-news_desk-feed_curator",
+            candidateGroup: "news_desk",
+          },
+        ]}
+        tabCounts={{ all: 0, pinned: 0, templates: 5 }}
+        isTemplateView
+        workspaceLabel="AI Company"
+        searchQuery=""
+        onSearchQueryChange={vi.fn()}
+        onImportStarterPack={vi.fn()}
+        onOpenWorkflow={vi.fn()}
+        onUseTemplate={vi.fn()}
+        onExportWorkflow={vi.fn()}
+        onDeleteWorkflow={vi.fn()}
+      />,
+    );
+
+    // Underscored folder names become sentence-case section labels.
+    const knowledgeHeader = screen.getByRole("button", {
+      name: /Knowledge desk 2/i,
+    });
+    expect(knowledgeHeader).toBeTruthy();
+    expect(screen.getByRole("button", { name: /News desk 1/i })).toBeTruthy();
+    // Independent candidates are not wrapped in a section.
+    expect(
+      screen.queryByRole("button", { name: /Chat interviewer/i }),
+    ).toBeNull();
+    // Two independents + three grouped candidates.
+    expect(screen.getAllByTestId("workflow-card")).toHaveLength(5);
+
+    // Collapsing a group hides only that group's cards.
+    const { default: userEvent } = await import("@testing-library/user-event");
+    const user = userEvent.setup();
+    await user.click(knowledgeHeader);
+    expect(screen.getAllByTestId("workflow-card")).toHaveLength(3);
+  });
+
+  it("keeps candidates flat when none belong to a group", () => {
+    const baseTemplate = {
+      name: "Candidate",
+      description: "",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      owner: { id: "owner-1", name: "Owner", avatar: "" },
+      tags: ["template"],
+      nodes: [],
+      edges: [],
+    };
+    renderTabs(
+      <WorkflowGalleryTabs
+        selectedTab="templates"
+        onSelectedTabChange={vi.fn()}
+        isLoading={false}
+        sortedWorkflows={[
+          { ...baseTemplate, id: "template-chat_interviewer" },
+          { ...baseTemplate, id: "template-insight_analyst" },
+        ]}
+        tabCounts={{ all: 0, pinned: 0, templates: 2 }}
+        isTemplateView
+        workspaceLabel="AI Company"
+        searchQuery=""
+        onSearchQueryChange={vi.fn()}
+        onImportStarterPack={vi.fn()}
+        onOpenWorkflow={vi.fn()}
+        onUseTemplate={vi.fn()}
+        onExportWorkflow={vi.fn()}
+        onDeleteWorkflow={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: /desk/i })).toBeNull();
+    expect(screen.getAllByTestId("workflow-card")).toHaveLength(2);
+  });
+
   it("shows empty team sections with no cards inside", () => {
     renderTabs(
       <WorkflowGalleryTabs

--- a/apps/studio/src/features/workflow/pages/workflow-gallery/workflow-gallery-tabs.tsx
+++ b/apps/studio/src/features/workflow/pages/workflow-gallery/workflow-gallery-tabs.tsx
@@ -114,15 +114,17 @@ export const WorkflowGalleryTabs = ({
     return (
       <div className="flex flex-col gap-1 pb-6">
         {independents.length > 0 ? renderGrid(independents) : null}
-        {[...byGroup.entries()].map(([slug, items]) => (
-          <TeamSection
-            key={slug}
-            name={formatCandidateGroupName(slug)}
-            count={items.length}
-          >
-            {renderGrid(items)}
-          </TeamSection>
-        ))}
+        {[...byGroup.entries()]
+          .sort(([left], [right]) => left.localeCompare(right))
+          .map(([slug, items]) => (
+            <TeamSection
+              key={slug}
+              name={formatCandidateGroupName(slug)}
+              count={items.length}
+            >
+              {renderGrid(items)}
+            </TeamSection>
+          ))}
       </div>
     );
   };

--- a/apps/studio/src/features/workflow/pages/workflow-gallery/workflow-gallery-tabs.tsx
+++ b/apps/studio/src/features/workflow/pages/workflow-gallery/workflow-gallery-tabs.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/design-system/ui/tabs";
 import { Loader2, Search, Upload, Zap } from "lucide-react";
 import { type Workflow } from "@features/workflow/data/workflow-data";
+import { formatCandidateGroupName } from "@features/workflow/data/templates/candidate-badges";
 import { type ApiTeam } from "@features/workflow/lib/workflow-storage-api";
 import { UploadWorkflowDialog } from "@features/workflow/components/dialogs/upload-workflow-dialog";
 import { useUploadsAllowed } from "@/hooks/use-uploads-allowed";
@@ -84,11 +85,53 @@ export const WorkflowGalleryTabs = ({
     </div>
   );
 
-  // Group colleagues into vertical, collapsible team sections. Candidate
-  // (template) view stays flat since candidates are not yet assigned a team.
+  // Group candidates into vertical, collapsible sections that mirror the
+  // grouping of the colleague-candidates repository (one level under
+  // `colleagues/`). Independent candidates — those that live directly under
+  // `colleagues/` — stay in a flat grid above the grouped sections.
+  const renderCandidates = () => {
+    const independents: Workflow[] = [];
+    const byGroup = new Map<string, Workflow[]>();
+    for (const workflow of sortedWorkflows) {
+      const group = workflow.candidateGroup;
+      if (!group) {
+        independents.push(workflow);
+        continue;
+      }
+      const bucket = byGroup.get(group);
+      if (bucket) {
+        bucket.push(workflow);
+      } else {
+        byGroup.set(group, [workflow]);
+      }
+    }
+
+    // Nothing is grouped — keep the flat grid.
+    if (byGroup.size === 0) {
+      return renderGrid(sortedWorkflows);
+    }
+
+    return (
+      <div className="flex flex-col gap-1 pb-6">
+        {independents.length > 0 ? renderGrid(independents) : null}
+        {[...byGroup.entries()].map(([slug, items]) => (
+          <TeamSection
+            key={slug}
+            name={formatCandidateGroupName(slug)}
+            count={items.length}
+          >
+            {renderGrid(items)}
+          </TeamSection>
+        ))}
+      </div>
+    );
+  };
+
+  // Group colleagues into vertical, collapsible team sections. Candidates are
+  // grouped to mirror the colleague-candidates repository layout instead.
   const renderColleagues = () => {
     if (isTemplateView) {
-      return renderGrid(sortedWorkflows);
+      return renderCandidates();
     }
 
     // No teams yet — fall back to flat grid (e.g. during first load).

--- a/apps/studio/src/features/workflow/pages/workflow/hooks/use-workflow-saver.ts
+++ b/apps/studio/src/features/workflow/pages/workflow/hooks/use-workflow-saver.ts
@@ -63,8 +63,9 @@ export function useWorkflowSaver(
           "studio",
           runnableConfig,
         );
-        // Keep the in-memory versions in sync so reopening the config sheet
-        // shows the saved values without a page refresh.
+        // Keep the in-memory runnable config in sync so reopening the config
+        // sheet shows the saved values without a page refresh. Other persisted
+        // fields will refresh on the next full workflow fetch.
         setWorkflowVersions((versions) =>
           versions.map((version) =>
             version.versionNumber === targetVersion

--- a/apps/studio/src/features/workflow/pages/workflow/hooks/use-workflow-saver.ts
+++ b/apps/studio/src/features/workflow/pages/workflow/hooks/use-workflow-saver.ts
@@ -58,10 +58,19 @@ export function useWorkflowSaver(
       }
 
       try {
-        await persistRunnableConfig(
+        const targetVersion = await persistRunnableConfig(
           currentWorkflowId,
           "studio",
           runnableConfig,
+        );
+        // Keep the in-memory versions in sync so reopening the config sheet
+        // shows the saved values without a page refresh.
+        setWorkflowVersions((versions) =>
+          versions.map((version) =>
+            version.versionNumber === targetVersion
+              ? { ...version, runnableConfig }
+              : version,
+          ),
         );
         toast({
           title: "Workflow config saved",
@@ -76,7 +85,7 @@ export function useWorkflowSaver(
         });
       }
     },
-    [currentWorkflowId, workflowName],
+    [currentWorkflowId, setWorkflowVersions, workflowName],
   );
 
   const handleSaveWorkflowDetails = useCallback(async () => {

--- a/packages/sdk/src/orcheo_sdk/cli/setup.py
+++ b/packages/sdk/src/orcheo_sdk/cli/setup.py
@@ -1184,8 +1184,8 @@ def _resolve_required_auth_config(
 
     Returns ``(jwt_secret, issuer, audience)``. The HS256 signing secret is
     preserved from the existing .env or generated when absent; the issuer
-    defaults to the HTTPS backend URL and the audience falls back to the
-    first-party IdP default.
+    defaults to the HTTPS backend URL when available and the audience falls
+    back to the first-party IdP default.
     """
     if not auth_mode_required:
         return None, None, None
@@ -1201,9 +1201,14 @@ def _resolve_required_auth_config(
     )
 
     jwt_secret = existing_secret or secrets.token_hex(32)
+    issuer_default = (
+        backend_url
+        if _backend_url_requires_https_auth(backend_url)
+        else _DEFAULT_AUTH_ISSUER
+    )
     issuer = _resolve_defaulted_env_prompt(
         label="Auth issuer",
-        current_value=existing_issuer or backend_url or _DEFAULT_AUTH_ISSUER,
+        current_value=existing_issuer or issuer_default,
         yes=yes,
     )
     audience = _resolve_defaulted_env_prompt(

--- a/packages/sdk/src/orcheo_sdk/cli/setup.py
+++ b/packages/sdk/src/orcheo_sdk/cli/setup.py
@@ -1065,8 +1065,7 @@ def _resolve_smtp_email_config(
         if host is None:
             host = _normalize_optional_value(
                 typer.prompt(
-                    "SMTP host for transactional email (invites and sign-in links) - "
-                    "press Enter to skip (links/codes are logged instead)",
+                    "SMTP host",
                     default="",
                     show_default=False,
                 )
@@ -1176,6 +1175,7 @@ def _resolve_defaulted_env_prompt(
 def _resolve_required_auth_config(
     *,
     auth_mode_required: bool,
+    backend_url: str,
     yes: bool,
     env_file: Path,
     env_exists: bool,
@@ -1183,8 +1183,9 @@ def _resolve_required_auth_config(
     """Resolve first-party auth settings when the backend requires auth.
 
     Returns ``(jwt_secret, issuer, audience)``. The HS256 signing secret is
-    preserved from the existing .env or generated when absent; issuer and
-    audience fall back to the first-party IdP defaults.
+    preserved from the existing .env or generated when absent; the issuer
+    defaults to the HTTPS backend URL and the audience falls back to the
+    first-party IdP default.
     """
     if not auth_mode_required:
         return None, None, None
@@ -1202,7 +1203,7 @@ def _resolve_required_auth_config(
     jwt_secret = existing_secret or secrets.token_hex(32)
     issuer = _resolve_defaulted_env_prompt(
         label="Auth issuer",
-        current_value=existing_issuer or _DEFAULT_AUTH_ISSUER,
+        current_value=existing_issuer or backend_url or _DEFAULT_AUTH_ISSUER,
         yes=yes,
     )
     audience = _resolve_defaulted_env_prompt(
@@ -1223,6 +1224,7 @@ def _resolve_https_auth_config(
     """Backward-compatible wrapper for the required-auth resolver."""
     return _resolve_required_auth_config(
         auth_mode_required=_backend_url_requires_https_auth(backend_url),
+        backend_url=backend_url,
         yes=yes,
         env_file=env_file,
         env_exists=env_exists,
@@ -1856,19 +1858,12 @@ def run_setup(
         resolved_auth_audience,
     ) = _resolve_required_auth_config(
         auth_mode_required=resolved_auth_mode_required,
+        backend_url=auth_backend_url,
         yes=yes,
         env_file=stack_env_file,
         env_exists=has_existing_stack_env,
     )
     resolved_auth_mode = _resolve_auth_mode(auth_mode, yes=yes)
-    (
-        resolved_start_stack,
-        resolved_install_docker,
-    ) = _resolve_setup_toggles(
-        start_stack=start_stack,
-        install_docker=install_docker,
-        yes=yes,
-    )
 
     resolved_api_key = _resolve_api_key(
         resolved_auth_mode,
@@ -1897,6 +1892,14 @@ def run_setup(
     resolved_backend_upstreams, resolved_studio_upstream = _resolve_stack_upstreams(
         stack_env_file,
         env_exists=has_existing_stack_env,
+    )
+    (
+        resolved_start_stack,
+        resolved_install_docker,
+    ) = _resolve_setup_toggles(
+        start_stack=start_stack,
+        install_docker=install_docker,
+        yes=yes,
     )
     resolved_install_agent_skills = _resolve_bool(
         None,

--- a/tests/sdk/test_cli_setup.py
+++ b/tests/sdk/test_cli_setup.py
@@ -1168,6 +1168,39 @@ def test_read_env_value_and_warn(tmp_path):
     assert "ChatKit domain key" in console.file.getvalue()
 
 
+def test_resolve_required_auth_config_ignores_http_backend_url_for_issuer_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text("", encoding="utf-8")
+    monkeypatch.setattr(secrets, "token_hex", lambda _: "generated-secret")
+
+    prompts: list[tuple[str, str]] = []
+
+    def _prompt(prompt: str, *, default: str = "", **_: object) -> str:
+        prompts.append((prompt, default))
+        return default
+
+    monkeypatch.setattr(setup.typer, "prompt", _prompt)
+
+    jwt_secret, issuer, audience = setup._resolve_required_auth_config(
+        auth_mode_required=True,
+        backend_url="http://localhost:8000",
+        yes=False,
+        env_file=env_file,
+        env_exists=False,
+    )
+
+    assert jwt_secret == "generated-secret"
+    assert issuer == setup._DEFAULT_AUTH_ISSUER
+    assert audience == setup._DEFAULT_AUTH_AUDIENCE
+    assert prompts == [
+        ("Auth issuer", setup._DEFAULT_AUTH_ISSUER),
+        ("Auth audience", setup._DEFAULT_AUTH_AUDIENCE),
+    ]
+
+
 def test_mask_chatkit_domain_key_preserves_short_values() -> None:
     assert setup._mask_chatkit_domain_key("abc") == "abc"
     assert setup._mask_chatkit_domain_key("abcd") == "abcd"

--- a/tests/sdk/test_cli_setup.py
+++ b/tests/sdk/test_cli_setup.py
@@ -426,7 +426,7 @@ def test_resolve_https_auth_config_uses_current_values_as_defaults(
     ]
 
 
-def test_resolve_https_auth_config_falls_back_to_first_party_defaults(
+def test_resolve_https_auth_config_defaults_issuer_to_backend_url(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -450,10 +450,10 @@ def test_resolve_https_auth_config_falls_back_to_first_party_defaults(
     )
 
     assert jwt_secret == "generated-secret"
-    assert issuer == setup._DEFAULT_AUTH_ISSUER
+    assert issuer == "https://orcheo.example.com"
     assert audience == setup._DEFAULT_AUTH_AUDIENCE
     assert prompts == [
-        ("Auth issuer", setup._DEFAULT_AUTH_ISSUER),
+        ("Auth issuer", "https://orcheo.example.com"),
         ("Auth audience", setup._DEFAULT_AUTH_AUDIENCE),
     ]
 
@@ -891,12 +891,7 @@ def test_run_setup_https_backend_prompts_auth_and_chatkit_from_current_values(
         ("Auth issuer", "https://issuer.example.com/", True),
         ("Auth audience", "current-audience", True),
         ("ChatKit domain key", "****4989", True),
-        (
-            "SMTP host for transactional email (invites and sign-in links) - "
-            "press Enter to skip (links/codes are logged instead)",
-            "",
-            False,
-        ),
+        ("SMTP host", "", False),
     ]
     assert "confirm:Install Orcheo skill for Claude Code and Codex?" in events
     assert events.index("prompt:Auth issuer") < events.index(
@@ -1192,7 +1187,7 @@ def test_resolve_https_auth_config_generates_secret_and_defaults_when_yes(
         env_exists=False,
     ) == (
         "generated-secret",
-        setup._DEFAULT_AUTH_ISSUER,
+        "https://orcheo.example.com",
         setup._DEFAULT_AUTH_AUDIENCE,
     )
 


### PR DESCRIPTION
## Summary

This branch makes three independent improvements to the Studio gallery, workflow config persistence, and the SDK setup CLI.

### 1. Group candidates in the Studio gallery by colleague-candidates layout
- The template/candidate view now renders candidates in collapsible sections that mirror the colleague-candidates repository layout (one level under `colleagues/`).
- Adds `candidateGroupSlug()` and `formatCandidateGroupName()` helpers to derive a group slug from a candidate's directory path (e.g. `news_desk/feed_curator` → `news_desk` → "News desk"). Candidates that live directly under `colleagues/` are treated as independent.
- Adds an optional `candidateGroup` field to the `Workflow` type, populated when building candidate workflows.
- Independent candidates stay in a flat grid above the grouped sections; the view stays flat when nothing is grouped.

### 2. Fix stale workflow config sheet after save
- `persistRunnableConfig` now invalidates the workflow cache and returns the target version, so the next fetch reflects the just-saved value.
- `useWorkflowSaver` syncs the in-memory workflow versions on save, so reopening the config sheet shows the saved values without a page refresh.

### 3. Refine SDK install prompts
- Shortens the SMTP host prompt label to just "SMTP host".
- Defaults the auth issuer to the HTTPS backend URL (falling back to the first-party IdP default) instead of always using the default.
- Moves the start-stack / install-docker toggle resolution later in the setup flow so it runs after the auth/API-key prompts.

## Testing
- Adds `WorkflowGalleryTabs` tests covering grouped candidate sections, collapse behavior, and the flat-grid fallback.
- Updates SDK setup CLI tests for the new issuer default and SMTP host label.
