### PR TITLE
Add candidate workflow version updates

### DIFF
--- a/apps/backend/src/orcheo_backend/app/candidates_service.py
+++ b/apps/backend/src/orcheo_backend/app/candidates_service.py
@@ -20,7 +20,7 @@ from typing import Any
 import httpx
 from orcheo.graph.ingestion import ScriptIngestionError, ingest_langgraph_script
 from orcheo.workflow.mermaid import render_mermaid_from_graph_payload
-from orcheo_backend.app.schemas.candidates import CandidateItem
+from orcheo_backend.app.schemas.candidates import CandidateItem, CandidateUpdateNote
 from orcheo_sdk.cli.errors import CLIError
 from orcheo_sdk.cli.workflow.frontmatter import parse_workflow_frontmatter
 
@@ -139,6 +139,15 @@ def _build_candidate(
         entrypoint=frontmatter.entrypoint,
         notes=frontmatter.notes,
         metadata=frontmatter.metadata,
+        version=frontmatter.version,
+        updates=[
+            CandidateUpdateNote(
+                version=note.version,
+                summary=note.summary,
+                migration=note.migration,
+            )
+            for note in (frontmatter.updates or [])
+        ],
         # Populated later by catalog preview enrichment; parsing the archive
         # itself must not execute remotely sourced Python.
         mermaid=None,

--- a/apps/backend/src/orcheo_backend/app/routers/candidates.py
+++ b/apps/backend/src/orcheo_backend/app/routers/candidates.py
@@ -14,7 +14,11 @@ from orcheo.runtime.configurable_schema import (
 )
 from orcheo.runtime.runnable_config import RunnableConfigModel
 from orcheo.workflow.mermaid import render_mermaid_from_graph_payload_full_env
-from orcheo_backend.app.candidates_service import CandidateFetchError, get_candidates
+from orcheo_backend.app.candidates_service import (
+    CandidateFetchError,
+    _repo_settings,
+    get_candidates,
+)
 from orcheo_backend.app.dependencies import RepositoryDep
 from orcheo_backend.app.errors import WorkspaceQuotaExceededError
 from orcheo_backend.app.plugin_inventory import (
@@ -24,12 +28,14 @@ from orcheo_backend.app.plugin_inventory import (
 from orcheo_backend.app.repository import (
     WorkflowHandleConflictError,
     WorkflowNotFoundError,
+    WorkflowVersionNotFoundError,
 )
 from orcheo_backend.app.repository.errors import TeamNotFoundError
 from orcheo_backend.app.schemas.candidates import CandidateItem, CandidatePublicItem
 from orcheo_backend.app.teams_service import ensure_default_team
 from orcheo_backend.app.workspace import WorkspaceContextDep
 from orcheo_backend.app.workspace_governance import ensure_workspace_workflow_quota
+from orcheo_sdk.cli.workflow.frontmatter import compare_strict_semver, is_strict_semver
 
 
 logger = logging.getLogger(__name__)
@@ -41,6 +47,13 @@ class CandidateOnboardRequest(BaseModel):
 
     id: str
     team_id: str | None = None
+
+
+class CandidateUpdateRequest(BaseModel):
+    """Request body for updating an onboarded workflow from a candidate."""
+
+    workflow_id: UUID
+    candidate_id: str
 
 
 def _candidates_502(exc: Exception) -> HTTPException:
@@ -68,15 +81,25 @@ async def _fetch_candidate_by_id(candidate_id: str) -> CandidateItem:
 
 def _build_version_metadata(candidate: CandidateItem) -> dict[str, Any]:
     metadata: dict[str, Any] = {
+        **(candidate.metadata or {}),
         "source": "candidate-onboard",
         "candidate_id": candidate.id,
-        **(candidate.metadata or {}),
+        "candidate_handle": candidate.handle,
+        "candidate_source_ref": _candidate_source_ref(),
     }
+    if candidate.version:
+        metadata["candidate_version"] = candidate.version
     if candidate.avatar:
         metadata.setdefault("avatar", candidate.avatar)
     if candidate.subtitle:
         metadata.setdefault("subtitle", candidate.subtitle)
     return metadata
+
+
+def _candidate_source_ref() -> str:
+    """Return the configured repository ref used as a candidate source hint."""
+    _, ref, _ = _repo_settings()
+    return ref
 
 
 def _merge_configurable_schema(
@@ -187,6 +210,121 @@ def _raise_for_missing_required_plugins(metadata: dict[str, Any]) -> None:
     )
 
 
+def _ingest_candidate_graph(candidate: CandidateItem) -> dict[str, Any]:
+    """Ingest the candidate script and attach pre-rendered Mermaid when possible."""
+    try:
+        graph_payload = ingest_langgraph_script(
+            candidate.script,
+            entrypoint=candidate.entrypoint,
+        )
+    except ScriptIngestionError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "message": f"Candidate script ingestion failed: {exc}",
+                "code": "candidate.script_ingestion_failed",
+            },
+        ) from exc
+
+    mermaid = render_mermaid_from_graph_payload_full_env(graph_payload)
+    if mermaid and isinstance(graph_payload.get("index"), dict):
+        graph_payload["index"]["mermaid"] = mermaid
+    return graph_payload
+
+
+def _prepare_candidate_version(
+    candidate: CandidateItem,
+) -> tuple[dict[str, Any], dict[str, Any] | None, dict[str, Any]]:
+    """Validate and normalize candidate payload before mutating storage."""
+    metadata = _build_version_metadata(candidate)
+    _raise_for_missing_required_plugins(metadata)
+    runnable_config, metadata = _resolve_candidate_runnable_config(candidate, metadata)
+    graph_payload = _ingest_candidate_graph(candidate)
+    return graph_payload, runnable_config, metadata
+
+
+async def _append_candidate_version(
+    repository: RepositoryDep,
+    workflow_id: UUID,
+    candidate: CandidateItem,
+    *,
+    created_by: str,
+) -> None:
+    """Create a workflow version from the latest server-side candidate payload."""
+    graph_payload, runnable_config, metadata = _prepare_candidate_version(candidate)
+
+    await repository.create_version(
+        workflow_id,
+        graph=graph_payload,
+        metadata=metadata,
+        notes=candidate.notes,
+        created_by=created_by,
+        runnable_config=runnable_config,
+    )
+
+
+def _raise_candidate_conflict(message: str, code: str) -> None:
+    """Raise a 409 conflict with a machine-readable candidate update code."""
+    raise HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail={"message": message, "code": code},
+    )
+
+
+def _validate_candidate_update_source(
+    latest_metadata: dict[str, Any],
+    candidate: CandidateItem,
+) -> str:
+    """Return the installed candidate version after source validation."""
+    if latest_metadata.get("source") != "candidate-onboard":
+        _raise_candidate_conflict(
+            "Workflow is not sourced from a candidate.",
+            "candidate.source_mismatch",
+        )
+
+    installed_candidate_id = latest_metadata.get("candidate_id")
+    installed_candidate_handle = latest_metadata.get("candidate_handle")
+    if installed_candidate_id != candidate.id and installed_candidate_handle != (
+        candidate.handle
+    ):
+        _raise_candidate_conflict(
+            "Workflow is not sourced from this candidate.",
+            "candidate.source_mismatch",
+        )
+
+    installed_version = latest_metadata.get("candidate_version")
+    if not isinstance(installed_version, str) or not is_strict_semver(
+        installed_version
+    ):
+        _raise_candidate_conflict(
+            "Workflow does not have a valid installed candidate version.",
+            "candidate.installed_version_unknown",
+        )
+
+    return installed_version
+
+
+def _validate_candidate_update_version(
+    candidate: CandidateItem,
+    installed_version: str,
+) -> None:
+    """Reject unversioned, invalid, or non-newer candidate updates."""
+    if not candidate.version or not is_strict_semver(candidate.version):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "message": "Candidate does not declare a valid version.",
+                "code": "candidate.unversioned",
+            },
+        )
+
+    if compare_strict_semver(candidate.version, installed_version) <= 0:
+        _raise_candidate_conflict(
+            "Candidate is not newer than the installed version.",
+            "candidate.no_update_available",
+        )
+
+
 @router.get("/candidates", response_model=list[CandidatePublicItem])
 async def list_candidates() -> list[CandidateItem]:
     """Return candidate AI colleagues sourced from the candidates repository.
@@ -234,28 +372,7 @@ async def onboard_candidate(
         },
     )
 
-    metadata = _build_version_metadata(candidate)
-    _raise_for_missing_required_plugins(metadata)
-    runnable_config, metadata = _resolve_candidate_runnable_config(candidate, metadata)
-
-    try:
-        graph_payload = ingest_langgraph_script(
-            candidate.script,
-            entrypoint=candidate.entrypoint,
-        )
-    except ScriptIngestionError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail={
-                "message": f"Candidate script ingestion failed: {exc}",
-                "code": "candidate.script_ingestion_failed",
-            },
-        ) from exc
-
-    mermaid = render_mermaid_from_graph_payload_full_env(graph_payload)
-    if mermaid and isinstance(graph_payload.get("index"), dict):
-        graph_payload["index"]["mermaid"] = mermaid
-
+    graph_payload, runnable_config, metadata = _prepare_candidate_version(candidate)
     workspace_id = str(workspace.workspace_id)
 
     # Resolve the target team. When unspecified, onboard into the default team.
@@ -322,6 +439,70 @@ async def onboard_candidate(
             "candidate_id": request.id,
             "candidate_handle": candidate.handle,
             "workflow_id": workflow.id,
+            "workspace_id": str(workspace.workspace_id),
+        },
+    )
+
+    return workflow
+
+
+@router.post(
+    "/candidates/update",
+    response_model=Workflow,
+    status_code=status.HTTP_200_OK,
+)
+async def update_candidate_workflow(
+    request: CandidateUpdateRequest,
+    repository: RepositoryDep,
+    workspace: WorkspaceContextDep,
+) -> Workflow:
+    """Append a new workflow version from the latest candidate release."""
+    candidate = await _fetch_candidate_by_id(request.candidate_id)
+    workspace_id = str(workspace.workspace_id)
+
+    try:
+        workflow = await repository.get_workflow(
+            request.workflow_id,
+            workspace_id=workspace_id,
+        )
+    except WorkflowNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "message": f"Workflow '{request.workflow_id}' not found.",
+                "code": "workflow.not_found",
+            },
+        ) from exc
+
+    try:
+        latest_version = await repository.get_latest_version(workflow.id)
+    except WorkflowVersionNotFoundError as exc:
+        _raise_candidate_conflict(
+            "Workflow does not have an installed candidate version.",
+            "candidate.installed_version_unknown",
+        )
+        raise AssertionError("unreachable") from exc
+
+    installed_version = _validate_candidate_update_source(
+        latest_version.metadata,
+        candidate,
+    )
+    _validate_candidate_update_version(candidate, installed_version)
+
+    await _append_candidate_version(
+        repository,
+        workflow.id,
+        candidate,
+        created_by="candidate-update",
+    )
+
+    logger.info(
+        "Candidate workflow update completed successfully",
+        extra={
+            "candidate_id": request.candidate_id,
+            "candidate_handle": candidate.handle,
+            "candidate_version": candidate.version,
+            "workflow_id": str(workflow.id),
             "workspace_id": str(workspace.workspace_id),
         },
     )

--- a/apps/backend/src/orcheo_backend/app/schemas/candidates.py
+++ b/apps/backend/src/orcheo_backend/app/schemas/candidates.py
@@ -2,7 +2,15 @@
 
 from __future__ import annotations
 from typing import Any
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+
+class CandidateUpdateNote(BaseModel):
+    """A versioned update note for a candidate colleague."""
+
+    version: str
+    summary: str
+    migration: str | None = None
 
 
 class CandidateItem(BaseModel):
@@ -24,6 +32,8 @@ class CandidateItem(BaseModel):
     notes: str | None = None
     metadata: dict[str, Any] | None = None
     mermaid: str | None = None
+    version: str | None = None
+    updates: list[CandidateUpdateNote] = Field(default_factory=list)
 
 
 class CandidatePublicItem(BaseModel):
@@ -43,3 +53,5 @@ class CandidatePublicItem(BaseModel):
     notes: str | None = None
     metadata: dict[str, Any] | None = None
     mermaid: str | None = None
+    version: str | None = None
+    updates: list[CandidateUpdateNote] = Field(default_factory=list)

--- a/apps/studio/src/features/workflow/data/templates/candidate-badges.ts
+++ b/apps/studio/src/features/workflow/data/templates/candidate-badges.ts
@@ -5,6 +5,7 @@ import type {
   WorkflowTemplateDefinition,
   WorkflowTemplateMetadata,
 } from "./template-definition";
+import type { CandidateUpdateNote } from "../../lib/candidate-version-updates";
 
 export interface CandidateBadgeSpec {
   id: string;
@@ -20,6 +21,8 @@ export interface CandidateBadgeSpec {
   mermaid?: string | null;
   /** Raw snake_case metadata dict from the colleague-candidates frontmatter. */
   rawMetadata?: Record<string, unknown> | null;
+  version?: string | null;
+  updates?: CandidateUpdateNote[];
 }
 
 export interface CandidateBadgeDefinition extends CandidateBadgeSpec {
@@ -164,6 +167,11 @@ export const getCandidateBadgeByHandle = (
   handle: string,
 ): CandidateBadgeDefinition | undefined =>
   candidateBadges.find((badge) => badge.handle === handle);
+
+export const getCandidateBadgeByCandidateId = (
+  candidateId: string,
+): CandidateBadgeDefinition | undefined =>
+  candidateBadges.find((badge) => badge.candidateId === candidateId);
 
 export const getCandidateTemplateDefinition = (
   templateId: string,

--- a/apps/studio/src/features/workflow/data/workflow-types.ts
+++ b/apps/studio/src/features/workflow/data/workflow-types.ts
@@ -28,6 +28,12 @@ export interface WorkflowMermaidPreviewVersion {
   id: string;
   mermaid?: string | null;
   templateId?: string;
+  candidateSource?: {
+    candidateId?: string;
+    candidateHandle?: string;
+    candidateVersion?: string;
+    candidateSourceRef?: string;
+  };
 }
 
 export interface Workflow {

--- a/apps/studio/src/features/workflow/lib/candidate-version-updates.test.ts
+++ b/apps/studio/src/features/workflow/lib/candidate-version-updates.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  compareStrictSemver,
+  resolveCandidateUpdateAvailability,
+} from "./candidate-version-updates";
+
+describe("candidate version updates", () => {
+  it("compares strict semantic versions by segment", () => {
+    expect(compareStrictSemver("1.10.0", "1.2.9")).toBe(1);
+    expect(compareStrictSemver("1.2.0", "1.2.0")).toBe(0);
+    expect(compareStrictSemver("1.2.0", "2.0.0")).toBe(-1);
+    expect(Number.isNaN(compareStrictSemver("v1.2.0", "1.2.0"))).toBe(true);
+  });
+
+  it("resolves crossed update notes and major-update state", () => {
+    const availability = resolveCandidateUpdateAvailability(
+      {
+        candidateId: "insight-analyst",
+        candidateHandle: "insight-analyst",
+        candidateVersion: "1.2.0",
+      },
+      {
+        candidateId: "insight-analyst",
+        handle: "insight-analyst",
+        version: "2.0.0",
+        updates: [
+          {
+            version: "2.0.0",
+            summary: "Changes prompt contracts.",
+            migration: "Review custom prompts.",
+          },
+          { version: "1.3.0", summary: "Adds source checks." },
+          { version: "1.1.0", summary: "Old note." },
+        ],
+      },
+    );
+
+    expect(availability).toMatchObject({
+      candidateId: "insight-analyst",
+      currentVersion: "1.2.0",
+      latestVersion: "2.0.0",
+      latestSummary: "Changes prompt contracts.",
+      firstMigration: "Review custom prompts.",
+      isMajorUpdate: true,
+    });
+    expect(availability?.crossedUpdates.map((note) => note.version)).toEqual([
+      "2.0.0",
+      "1.3.0",
+    ]);
+  });
+
+  it("returns undefined when versions are missing, invalid, or not newer", () => {
+    expect(
+      resolveCandidateUpdateAvailability(
+        { candidateId: "x", candidateVersion: "1.0.0" },
+        { candidateId: "x", handle: "x", version: "1.0.0" },
+      ),
+    ).toBeUndefined();
+    expect(
+      resolveCandidateUpdateAvailability(
+        { candidateId: "x", candidateVersion: "1.0" },
+        { candidateId: "x", handle: "x", version: "1.1.0" },
+      ),
+    ).toBeUndefined();
+    expect(
+      resolveCandidateUpdateAvailability(
+        { candidateId: "x", candidateVersion: "1.0.0" },
+        { candidateId: "y", handle: "y", version: "1.1.0" },
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/apps/studio/src/features/workflow/lib/candidate-version-updates.ts
+++ b/apps/studio/src/features/workflow/lib/candidate-version-updates.ts
@@ -1,0 +1,110 @@
+export interface CandidateUpdateNote {
+  version: string;
+  summary: string;
+  migration?: string | null;
+}
+
+export interface CandidateReleaseInfo {
+  candidateId: string;
+  handle: string;
+  version?: string | null;
+  updates?: CandidateUpdateNote[];
+}
+
+export interface InstalledCandidateSource {
+  candidateId?: string;
+  candidateHandle?: string;
+  candidateVersion?: string;
+}
+
+export interface CandidateUpdateAvailability {
+  candidateId: string;
+  currentVersion: string;
+  latestVersion: string;
+  latestSummary?: string;
+  firstMigration?: string;
+  crossedUpdates: CandidateUpdateNote[];
+  isMajorUpdate: boolean;
+}
+
+const STRICT_SEMVER_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
+const parseStrictSemver = (value: string): [number, number, number] | null => {
+  const match = STRICT_SEMVER_PATTERN.exec(value.trim());
+  if (!match) {
+    return null;
+  }
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+};
+
+export const isStrictSemver = (value: string): boolean =>
+  parseStrictSemver(value) !== null;
+
+export const compareStrictSemver = (left: string, right: string): number => {
+  const leftParts = parseStrictSemver(left);
+  const rightParts = parseStrictSemver(right);
+  if (!leftParts || !rightParts) {
+    return Number.NaN;
+  }
+
+  for (let index = 0; index < leftParts.length; index += 1) {
+    const delta = leftParts[index] - rightParts[index];
+    if (delta !== 0) {
+      return delta > 0 ? 1 : -1;
+    }
+  }
+  return 0;
+};
+
+const sortUpdatesDescending = (
+  updates: CandidateUpdateNote[],
+): CandidateUpdateNote[] =>
+  [...updates].sort((left, right) =>
+    compareStrictSemver(right.version, left.version),
+  );
+
+export const resolveCandidateUpdateAvailability = (
+  source: InstalledCandidateSource | undefined,
+  candidate: CandidateReleaseInfo | undefined,
+): CandidateUpdateAvailability | undefined => {
+  if (!source || !candidate?.version) {
+    return undefined;
+  }
+
+  const sourceMatches =
+    source.candidateId === candidate.candidateId ||
+    source.candidateHandle === candidate.handle;
+  if (!sourceMatches || !source.candidateVersion) {
+    return undefined;
+  }
+
+  if (
+    !isStrictSemver(source.candidateVersion) ||
+    !isStrictSemver(candidate.version) ||
+    compareStrictSemver(candidate.version, source.candidateVersion) <= 0
+  ) {
+    return undefined;
+  }
+
+  const crossedUpdates = sortUpdatesDescending(candidate.updates ?? []).filter(
+    (note) =>
+      isStrictSemver(note.version) &&
+      compareStrictSemver(note.version, source.candidateVersion ?? "") > 0 &&
+      compareStrictSemver(note.version, candidate.version ?? "") <= 0,
+  );
+  const latestNote = crossedUpdates.find(
+    (note) => note.version === candidate.version,
+  );
+  const currentMajor = parseStrictSemver(source.candidateVersion)?.[0] ?? 0;
+  const latestMajor = parseStrictSemver(candidate.version)?.[0] ?? 0;
+
+  return {
+    candidateId: candidate.candidateId,
+    currentVersion: source.candidateVersion,
+    latestVersion: candidate.version,
+    latestSummary: latestNote?.summary ?? crossedUpdates[0]?.summary,
+    firstMigration: crossedUpdates.find((note) => note.migration)?.migration,
+    crossedUpdates,
+    isMajorUpdate: latestMajor > currentMajor,
+  };
+};

--- a/apps/studio/src/features/workflow/lib/workflow-storage-api.ts
+++ b/apps/studio/src/features/workflow/lib/workflow-storage-api.ts
@@ -1,6 +1,7 @@
 import { authFetch } from "@/lib/auth-fetch";
 import { buildBackendHttpUrl, getBackendBaseUrl } from "@/lib/config";
 import type {
+  CandidateUpdateNote,
   ApiTeam,
   ApiWorkflow,
   ApiWorkflowPagePayload,
@@ -179,6 +180,8 @@ export interface ApiCandidate {
   notes: string | null;
   metadata: Record<string, unknown> | null;
   mermaid: string | null;
+  version: string | null;
+  updates: CandidateUpdateNote[];
 }
 
 export const fetchCandidates = async (): Promise<ApiCandidate[]> =>
@@ -211,6 +214,18 @@ export const onboardCandidate = async (
     body: JSON.stringify({
       id: candidateId,
       ...(teamId ? { team_id: teamId } : {}),
+    }),
+  });
+
+export const updateCandidateWorkflow = async (
+  workflowId: string,
+  candidateId: string,
+): Promise<ApiWorkflow> =>
+  request<ApiWorkflow>("/api/candidates/update", {
+    method: "POST",
+    body: JSON.stringify({
+      workflow_id: workflowId,
+      candidate_id: candidateId,
     }),
   });
 

--- a/apps/studio/src/features/workflow/lib/workflow-storage-helpers.ts
+++ b/apps/studio/src/features/workflow/lib/workflow-storage-helpers.ts
@@ -97,6 +97,33 @@ const extractAvatarEmoji = (metadata: unknown): string | undefined => {
   return undefined;
 };
 
+const extractCandidateSource = (
+  metadata: unknown,
+): WorkflowVersionMetadata["candidateSource"] => {
+  if (!isRecord(metadata) || metadata.source !== "candidate-onboard") {
+    return undefined;
+  }
+
+  return {
+    candidateId:
+      typeof metadata.candidate_id === "string"
+        ? metadata.candidate_id
+        : undefined,
+    candidateHandle:
+      typeof metadata.candidate_handle === "string"
+        ? metadata.candidate_handle
+        : undefined,
+    candidateVersion:
+      typeof metadata.candidate_version === "string"
+        ? metadata.candidate_version
+        : undefined,
+    candidateSourceRef:
+      typeof metadata.candidate_source_ref === "string"
+        ? metadata.candidate_source_ref
+        : undefined,
+  };
+};
+
 const toAuthor = (id: string | undefined): Workflow["owner"] => {
   if (!id) {
     return { ...DEFAULT_OWNER };
@@ -178,6 +205,7 @@ const parseWorkflowMetadata = (
     isRecord(metadata) ? metadata.configurable_schema : undefined,
   );
   const avatarEmoji = extractAvatarEmoji(metadata);
+  const candidateSource = extractCandidateSource(metadata);
   const resolveTemplateFallback = (): WorkflowVersionMetadata | undefined => {
     if (!metadata || typeof metadata !== "object") {
       return undefined;
@@ -204,6 +232,7 @@ const parseWorkflowMetadata = (
       templateId,
       configurableSchemas,
       avatarEmoji,
+      candidateSource,
     };
   };
 
@@ -214,6 +243,7 @@ const parseWorkflowMetadata = (
       templateId: undefined,
       configurableSchemas: undefined,
       avatarEmoji: undefined,
+      candidateSource: undefined,
     };
   }
 
@@ -226,6 +256,7 @@ const parseWorkflowMetadata = (
         summary: { ...DEFAULT_SUMMARY },
         configurableSchemas,
         avatarEmoji,
+        candidateSource,
       }
     );
   }
@@ -280,6 +311,7 @@ const parseWorkflowMetadata = (
     templateId,
     configurableSchemas,
     avatarEmoji,
+    candidateSource,
   };
 };
 
@@ -337,6 +369,7 @@ const toVersionRecord = (
     graphToWorkflow: metadata.graphToWorkflow,
     templateId: metadata.templateId,
     avatarEmoji: metadata.avatarEmoji,
+    candidateSource: metadata.candidateSource,
   };
 };
 

--- a/apps/studio/src/features/workflow/lib/workflow-storage.ts
+++ b/apps/studio/src/features/workflow/lib/workflow-storage.ts
@@ -16,6 +16,7 @@ import {
   fetchWorkflowVersions,
   onboardCandidate,
   request,
+  updateCandidateWorkflow,
   upsertWorkflow,
 } from "./workflow-storage-api";
 import {
@@ -467,6 +468,22 @@ export const onboardCandidateAsWorkflow = async (
     throw new Error("Failed to load onboarded workflow");
   }
   invalidateWorkflowListCache();
+  primeWorkflowCache(stored);
+  emitUpdate();
+  return stored;
+};
+
+export const updateCandidateWorkflowAsLatest = async (
+  workflowId: string,
+  candidateId: string,
+): Promise<StoredWorkflow> => {
+  const apiWorkflow = await updateCandidateWorkflow(workflowId, candidateId);
+  invalidateWorkflowCache(apiWorkflow.id);
+  invalidateWorkflowListCache();
+  const stored = await ensureWorkflow(apiWorkflow.id);
+  if (!stored) {
+    throw new Error("Failed to load updated workflow");
+  }
   primeWorkflowCache(stored);
   emitUpdate();
   return stored;

--- a/apps/studio/src/features/workflow/lib/workflow-storage.types.ts
+++ b/apps/studio/src/features/workflow/lib/workflow-storage.types.ts
@@ -5,6 +5,7 @@ import type {
 } from "@features/workflow/data/workflow-data";
 import type { WorkflowDiffResult, WorkflowSnapshot } from "./workflow-diff";
 import type { RJSFSchema } from "@rjsf/utils";
+import type { CandidateUpdateNote } from "./candidate-version-updates";
 
 export interface ApiTeam {
   id: string;
@@ -219,6 +220,12 @@ export interface WorkflowVersionMetadata {
   templateId?: string;
   configurableSchemas?: Record<string, RJSFSchema>;
   avatarEmoji?: string;
+  candidateSource?: {
+    candidateId?: string;
+    candidateHandle?: string;
+    candidateVersion?: string;
+    candidateSourceRef?: string;
+  };
 }
 
 export interface RequestOptions extends RequestInit {
@@ -241,7 +248,10 @@ export interface WorkflowVersionRecord {
   configurableSchemas?: Record<string, RJSFSchema>;
   graphToWorkflow?: Record<string, string>;
   templateId?: string;
+  candidateSource?: WorkflowVersionMetadata["candidateSource"];
 }
+
+export type { CandidateUpdateNote };
 
 export interface StoredWorkflow extends Workflow {
   versions: WorkflowVersionRecord[];

--- a/apps/studio/src/features/workflow/pages/workflow-gallery.tsx
+++ b/apps/studio/src/features/workflow/pages/workflow-gallery.tsx
@@ -62,6 +62,7 @@ export default function WorkflowGallery() {
     handleImportStarterPack,
     handleExportWorkflow,
     handleDeleteWorkflow,
+    handleUpdateCandidateWorkflow,
     handleOpenWorkflow,
     onboardTarget,
     confirmOnboardTeam,
@@ -102,6 +103,7 @@ export default function WorkflowGallery() {
             onUseTemplate={handleUseTemplate}
             onExportWorkflow={handleExportWorkflow}
             onDeleteWorkflow={handleDeleteWorkflow}
+            onUpdateCandidateWorkflow={handleUpdateCandidateWorkflow}
             onDeleteTeam={handleDeleteTeam}
           />
         </div>

--- a/apps/studio/src/features/workflow/pages/workflow-gallery/use-workflow-gallery-actions.ts
+++ b/apps/studio/src/features/workflow/pages/workflow-gallery/use-workflow-gallery-actions.ts
@@ -9,6 +9,7 @@ import { getCandidateBadgeDefinition } from "@features/workflow/data/templates/c
 import {
   deleteWorkflow,
   onboardCandidateAsWorkflow,
+  updateCandidateWorkflowAsLatest,
 } from "@features/workflow/lib/workflow-storage";
 import {
   type ApiTeam,
@@ -302,6 +303,30 @@ export const useWorkflowGalleryActions = (
     [],
   );
 
+  const handleUpdateCandidateWorkflow = useCallback(
+    async (workflowId: string, candidateId: string) => {
+      try {
+        const workflow = await updateCandidateWorkflowAsLatest(
+          workflowId,
+          candidateId,
+        );
+        toast({
+          title: "Candidate updated",
+          description: `"${workflow.name}" is now on the latest candidate version.`,
+        });
+      } catch (error) {
+        toast({
+          title: "Failed to update candidate",
+          description:
+            error instanceof Error ? error.message : "Unknown error occurred",
+          variant: "destructive",
+        });
+        throw error;
+      }
+    },
+    [],
+  );
+
   const openCreateTeamDialog = useCallback(() => setIsCreateTeamOpen(true), []);
   const closeCreateTeamDialog = useCallback(
     () => setIsCreateTeamOpen(false),
@@ -314,6 +339,7 @@ export const useWorkflowGalleryActions = (
     handleImportStarterPack,
     handleExportWorkflow,
     handleDeleteWorkflow,
+    handleUpdateCandidateWorkflow,
     onboardTarget,
     confirmOnboardTeam,
     cancelOnboardTeam,

--- a/apps/studio/src/features/workflow/pages/workflow-gallery/use-workflow-gallery-state.ts
+++ b/apps/studio/src/features/workflow/pages/workflow-gallery/use-workflow-gallery-state.ts
@@ -50,6 +50,8 @@ const toCandidateSpec = (candidate: ApiCandidate): CandidateBadgeSpec => ({
   notes: candidate.notes,
   mermaid: candidate.mermaid,
   rawMetadata: candidate.metadata,
+  version: candidate.version,
+  updates: candidate.updates,
 });
 
 const matchesWorkflowSearch = (

--- a/apps/studio/src/features/workflow/pages/workflow-gallery/workflow-card.test.tsx
+++ b/apps/studio/src/features/workflow/pages/workflow-gallery/workflow-card.test.tsx
@@ -79,6 +79,7 @@ const createHandlers = () => ({
   onUseTemplate: vi.fn(),
   onExportWorkflow: vi.fn(),
   onDeleteWorkflow: vi.fn(),
+  onUpdateCandidateWorkflow: vi.fn(),
 });
 
 afterEach(() => {
@@ -89,12 +90,25 @@ beforeEach(() => {
   setCandidateBadges([
     {
       id: "template-insight-analyst",
+      candidateId: "insight-analyst",
       name: "Insight Analyst",
       handle: "insight-analyst",
       subtitle: "AI Insights & Analytics",
       description:
         "Detects themes from text data using advanced thematic coding frameworks.",
       avatar: "avatar-03",
+      version: "1.3.0",
+      updates: [
+        {
+          version: "1.3.0",
+          summary: "Adds source-quality checks.",
+          migration: "Review custom prompt overrides.",
+        },
+        {
+          version: "1.2.0",
+          summary: "Improves citation formatting.",
+        },
+      ],
     },
   ]);
 });
@@ -247,6 +261,124 @@ describe("WorkflowCard", () => {
     );
 
     expect(screen.getByRole("img", { hidden: true })).toBeInTheDocument();
+  });
+
+  it("shows and confirms candidate update actions for older onboarded versions", async () => {
+    const user = userEvent.setup();
+    const handlers = createHandlers();
+
+    render(
+      <WorkflowCard
+        workflow={{
+          ...onboardedCandidateWorkflow,
+          versions: [
+            {
+              id: "version-1",
+              candidateSource: {
+                candidateId: "insight-analyst",
+                candidateHandle: "insight-analyst",
+                candidateVersion: "1.1.0",
+              },
+            },
+          ],
+        }}
+        isTemplate={false}
+        workspaceLabel="AI Company"
+        {...handlers}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /update candidate from 1\.1\.0 to 1\.3\.0/i,
+      }),
+    );
+
+    expect(screen.getByText("Update candidate version")).toBeInTheDocument();
+    expect(screen.getByText("Adds source-quality checks.")).toBeInTheDocument();
+    expect(screen.getByText("Improves citation formatting.")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /^update$/i }));
+
+    expect(handlers.onUpdateCandidateWorkflow).toHaveBeenCalledWith(
+      "workflow-onboarded-insight",
+      "insight-analyst",
+    );
+  });
+
+  it("shows compact candidate update context on hover", async () => {
+    const user = userEvent.setup();
+    const handlers = createHandlers();
+
+    render(
+      <WorkflowCard
+        workflow={{
+          ...onboardedCandidateWorkflow,
+          versions: [
+            {
+              id: "version-1",
+              candidateSource: {
+                candidateId: "insight-analyst",
+                candidateHandle: "insight-analyst",
+                candidateVersion: "1.1.0",
+              },
+            },
+          ],
+        }}
+        isTemplate={false}
+        workspaceLabel="AI Company"
+        {...handlers}
+      />,
+    );
+
+    await user.hover(
+      screen.getByRole("button", {
+        name: /update candidate from 1\.1\.0 to 1\.3\.0/i,
+      }),
+    );
+
+    expect(await screen.findAllByText("Candidate update")).not.toHaveLength(0);
+    expect(screen.getAllByText("1.1.0 to 1.3.0")).not.toHaveLength(0);
+    expect(screen.getAllByText("Adds source-quality checks.")).not.toHaveLength(0);
+    expect(screen.getAllByText("Review custom prompt overrides.")).not.toHaveLength(
+      0,
+    );
+  });
+
+  it("cancels candidate updates without calling the update handler", async () => {
+    const user = userEvent.setup();
+    const handlers = createHandlers();
+
+    render(
+      <WorkflowCard
+        workflow={{
+          ...onboardedCandidateWorkflow,
+          versions: [
+            {
+              id: "version-1",
+              candidateSource: {
+                candidateId: "insight-analyst",
+                candidateHandle: "insight-analyst",
+                candidateVersion: "1.1.0",
+              },
+            },
+          ],
+        }}
+        isTemplate={false}
+        workspaceLabel="AI Company"
+        {...handlers}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /update candidate from 1\.1\.0 to 1\.3\.0/i,
+      }),
+    );
+    await user.click(screen.getByRole("button", { name: /^cancel$/i }));
+
+    expect(handlers.onUpdateCandidateWorkflow).not.toHaveBeenCalled();
+    expect(screen.queryByText("Update candidate version")).toBeNull();
   });
 
   it("keeps dropdown transfer actions from triggering navigation", async () => {

--- a/apps/studio/src/features/workflow/pages/workflow-gallery/workflow-card.tsx
+++ b/apps/studio/src/features/workflow/pages/workflow-gallery/workflow-card.tsx
@@ -1,6 +1,14 @@
 import { useRef, useState } from "react";
 import type { KeyboardEvent, MouseEvent, SyntheticEvent } from "react";
-import { MoreHorizontal, Send, Star, UserMinus, UserPlus } from "lucide-react";
+import {
+  AlertTriangle,
+  MoreHorizontal,
+  RefreshCw,
+  Send,
+  Star,
+  UserMinus,
+  UserPlus,
+} from "lucide-react";
 import { toast } from "@/hooks/use-toast";
 import { Button } from "@/design-system/ui/button";
 import {
@@ -10,20 +18,37 @@ import {
   CardHeader,
 } from "@/design-system/ui/card";
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/design-system/ui/dialog";
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/design-system/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/design-system/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { resolveAvatarUrl } from "@/assets/avatars";
 import { ConfirmDeleteWorkflowDialog } from "@features/workflow/components/dialogs/confirm-delete-workflow-dialog";
 import {
   getCandidateBadgeByHandle,
+  getCandidateBadgeByCandidateId,
   getCandidateBadgeDefinition,
 } from "@features/workflow/data/templates/candidate-badges";
 import { type Workflow } from "@features/workflow/data/workflow-data";
+import type { CandidateUpdateAvailability } from "@features/workflow/lib/candidate-version-updates";
+import { resolveCandidateUpdateAvailability } from "@features/workflow/lib/candidate-version-updates";
 import { getWorkflowRouteRef } from "@features/workflow/lib/workflow-storage-helpers";
 import { WORKFLOW_GALLERY_CARD_ASPECT_CLASSNAME } from "./workflow-card-size";
 
@@ -49,6 +74,10 @@ interface WorkflowCardProps {
     workflowId: string,
     workflowName: string,
   ) => Promise<void> | void;
+  onUpdateCandidateWorkflow: (
+    workflowId: string,
+    candidateId: string,
+  ) => Promise<void> | void;
 }
 
 export const WorkflowCard = ({
@@ -60,6 +89,7 @@ export const WorkflowCard = ({
   onUseTemplate,
   onExportWorkflow,
   onDeleteWorkflow,
+  onUpdateCandidateWorkflow,
 }: WorkflowCardProps) => {
   const workflowRouteRef = getWorkflowRouteRef(workflow);
   const isClickable = !isTemplate;
@@ -78,6 +108,27 @@ export const WorkflowCard = ({
           : undefined)
     : undefined;
   const displayBadge = candidateBadge ?? templateBadge;
+  const latestWorkflowVersion = workflow.versions?.at(-1);
+  const candidateSource = latestWorkflowVersion?.candidateSource;
+  const sourceBadge =
+    candidateSource?.candidateId !== undefined
+      ? getCandidateBadgeByCandidateId(candidateSource.candidateId)
+      : candidateSource?.candidateHandle !== undefined
+        ? getCandidateBadgeByHandle(candidateSource.candidateHandle)
+        : undefined;
+  const updateAvailability = !isTemplate
+    ? resolveCandidateUpdateAvailability(
+        candidateSource,
+        sourceBadge
+          ? {
+              candidateId: sourceBadge.candidateId,
+              handle: sourceBadge.handle,
+              version: sourceBadge.version,
+              updates: sourceBadge.updates,
+            }
+          : undefined,
+      )
+    : undefined;
   const headerLabel = isTemplate ? "Candidate" : workspaceLabel;
   const rawHandle = workflow.handle ?? workflow.id;
   const workflowSlug = isTemplate
@@ -93,7 +144,9 @@ export const WorkflowCard = ({
   const suppressCardOpenRef = useRef(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [isUpdateDialogOpen, setIsUpdateDialogOpen] = useState(false);
   const [isDeletePending, setIsDeletePending] = useState(false);
+  const [isUpdatePending, setIsUpdatePending] = useState(false);
 
   const suppressCardOpen = () => {
     suppressCardOpenRef.current = true;
@@ -146,6 +199,22 @@ export const WorkflowCard = ({
       setIsDeleteDialogOpen(false);
     } finally {
       setIsDeletePending(false);
+    }
+  };
+
+  const handleConfirmUpdate = async () => {
+    if (!updateAvailability) {
+      return;
+    }
+    setIsUpdatePending(true);
+    try {
+      await onUpdateCandidateWorkflow(
+        workflow.id,
+        updateAvailability.candidateId,
+      );
+      setIsUpdateDialogOpen(false);
+    } finally {
+      setIsUpdatePending(false);
     }
   };
 
@@ -267,23 +336,35 @@ export const WorkflowCard = ({
             </div>
 
             {!isTemplate ? (
-              <Button
-                variant="ghost"
-                size="icon"
-                className="absolute right-0 top-0 h-8 w-8"
-                aria-label="Star workflow"
-                data-card-action="true"
-                onClick={(event) => {
-                  stopPropagation(event);
-                  toast({
-                    title: "Starred workflows coming soon",
-                    description: `We'll remember ${workflow.name} as a starred workflow soon.`,
-                  });
-                }}
-                onPointerDown={stopPropagation}
-              >
-                <Star className="h-3 w-3" />
-              </Button>
+              <div className="absolute right-0 top-0 flex gap-1">
+                {updateAvailability ? (
+                  <CandidateUpdateButton
+                    update={updateAvailability}
+                    onOpen={(event) => {
+                      stopPropagation(event);
+                      setIsUpdateDialogOpen(true);
+                    }}
+                    onPointerDown={stopPropagation}
+                  />
+                ) : null}
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  aria-label="Star workflow"
+                  data-card-action="true"
+                  onClick={(event) => {
+                    stopPropagation(event);
+                    toast({
+                      title: "Starred workflows coming soon",
+                      description: `We'll remember ${workflow.name} as a starred workflow soon.`,
+                    });
+                  }}
+                  onPointerDown={stopPropagation}
+                >
+                  <Star className="h-3 w-3" />
+                </Button>
+              </div>
             ) : null}
           </div>
 
@@ -343,6 +424,149 @@ export const WorkflowCard = ({
           onConfirm={handleConfirmDelete}
         />
       ) : null}
+      {updateAvailability ? (
+        <CandidateUpdateDialog
+          open={isUpdateDialogOpen}
+          workflowName={workflow.name}
+          update={updateAvailability}
+          isPending={isUpdatePending}
+          onOpenChange={setIsUpdateDialogOpen}
+          onConfirm={handleConfirmUpdate}
+        />
+      ) : null}
     </>
   );
 };
+
+const CandidateUpdateButton = ({
+  update,
+  onOpen,
+  onPointerDown,
+}: {
+  update: CandidateUpdateAvailability;
+  onOpen: (event: MouseEvent<HTMLButtonElement>) => void;
+  onPointerDown: (event: SyntheticEvent) => void;
+}) => (
+  <TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="outline"
+          size="icon"
+          className="h-8 w-8 border-emerald-500/50 bg-emerald-50 text-emerald-700 hover:bg-emerald-100 dark:bg-emerald-950/40 dark:text-emerald-300"
+          aria-label={`Update candidate from ${update.currentVersion} to ${update.latestVersion}`}
+          data-card-action="true"
+          onClick={onOpen}
+          onPointerDown={onPointerDown}
+        >
+          <RefreshCw className="h-3.5 w-3.5" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent
+        side="left"
+        className="max-w-[280px] bg-popover p-3 text-popover-foreground shadow-lg"
+      >
+        <div className="space-y-2 text-left">
+          <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+            Candidate update
+          </div>
+          <div className="text-xs">
+            {update.currentVersion} to {update.latestVersion}
+          </div>
+          {update.latestSummary ? (
+            <p className="text-xs leading-5 text-muted-foreground">
+              {update.latestSummary}
+            </p>
+          ) : null}
+          {update.firstMigration ? (
+            <p className="text-xs leading-5 text-amber-700 dark:text-amber-300">
+              {update.firstMigration}
+            </p>
+          ) : null}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+);
+
+const CandidateUpdateDialog = ({
+  open,
+  workflowName,
+  update,
+  isPending,
+  onOpenChange,
+  onConfirm,
+}: {
+  open: boolean;
+  workflowName: string;
+  update: CandidateUpdateAvailability;
+  isPending: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => Promise<void> | void;
+}) => (
+  <Dialog open={open} onOpenChange={onOpenChange}>
+    <DialogContent
+      className="max-h-[85vh] overflow-y-auto sm:max-w-xl"
+      data-card-action="true"
+    >
+      <DialogHeader>
+        <DialogTitle>Update candidate version</DialogTitle>
+        <DialogDescription>
+          {workflowName} will move from candidate version{" "}
+          {update.currentVersion} to {update.latestVersion}.
+        </DialogDescription>
+      </DialogHeader>
+
+      {update.isMajorUpdate ? (
+        <div className="flex gap-3 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+          <p>
+            This is a major update. Review migration notes before applying it.
+          </p>
+        </div>
+      ) : null}
+
+      <div className="space-y-3">
+        {update.crossedUpdates.length > 0 ? (
+          update.crossedUpdates.map((note) => (
+            <div
+              key={`${note.version}-${note.summary}`}
+              className="rounded-md border border-border/70 p-3"
+            >
+              <div className="font-mono text-xs font-semibold">
+                {note.version}
+              </div>
+              <p className="mt-1 text-sm leading-6 text-foreground">
+                {note.summary}
+              </p>
+              {note.migration ? (
+                <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                  {note.migration}
+                </p>
+              ) : null}
+            </div>
+          ))
+        ) : (
+          <p className="rounded-md border border-border/70 p-3 text-sm text-muted-foreground">
+            No release notes were provided for this version range.
+          </p>
+        )}
+      </div>
+
+      <DialogFooter>
+        <Button
+          type="button"
+          variant="outline"
+          disabled={isPending}
+          onClick={() => onOpenChange(false)}
+        >
+          Cancel
+        </Button>
+        <Button type="button" disabled={isPending} onClick={onConfirm}>
+          <RefreshCw className="mr-2 h-4 w-4" />
+          {isPending ? "Updating" : "Update"}
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+);

--- a/apps/studio/src/features/workflow/pages/workflow-gallery/workflow-gallery-tabs.test.tsx
+++ b/apps/studio/src/features/workflow/pages/workflow-gallery/workflow-gallery-tabs.test.tsx
@@ -34,6 +34,7 @@ describe("WorkflowGalleryTabs", () => {
         onUseTemplate={vi.fn()}
         onExportWorkflow={vi.fn()}
         onDeleteWorkflow={vi.fn()}
+        onUpdateCandidateWorkflow={vi.fn()}
       />,
     );
 
@@ -69,6 +70,7 @@ describe("WorkflowGalleryTabs", () => {
         onUseTemplate={vi.fn()}
         onExportWorkflow={vi.fn()}
         onDeleteWorkflow={vi.fn()}
+        onUpdateCandidateWorkflow={vi.fn()}
       />,
     );
 
@@ -93,6 +95,7 @@ describe("WorkflowGalleryTabs", () => {
         onUseTemplate={vi.fn()}
         onExportWorkflow={vi.fn()}
         onDeleteWorkflow={vi.fn()}
+        onUpdateCandidateWorkflow={vi.fn()}
       />,
     );
 
@@ -136,6 +139,7 @@ describe("WorkflowGalleryTabs", () => {
         onUseTemplate={vi.fn()}
         onExportWorkflow={vi.fn()}
         onDeleteWorkflow={vi.fn()}
+        onUpdateCandidateWorkflow={vi.fn()}
       />,
     );
 
@@ -197,6 +201,7 @@ describe("WorkflowGalleryTabs", () => {
         onUseTemplate={vi.fn()}
         onExportWorkflow={vi.fn()}
         onDeleteWorkflow={vi.fn()}
+        onUpdateCandidateWorkflow={vi.fn()}
       />,
     );
 
@@ -255,6 +260,7 @@ describe("WorkflowGalleryTabs", () => {
         onUseTemplate={vi.fn()}
         onExportWorkflow={vi.fn()}
         onDeleteWorkflow={vi.fn()}
+        onUpdateCandidateWorkflow={vi.fn()}
       />,
     );
 
@@ -288,6 +294,7 @@ describe("WorkflowGalleryTabs", () => {
         onUseTemplate={vi.fn()}
         onExportWorkflow={vi.fn()}
         onDeleteWorkflow={vi.fn()}
+        onUpdateCandidateWorkflow={vi.fn()}
       />,
     );
 

--- a/apps/studio/src/features/workflow/pages/workflow-gallery/workflow-gallery-tabs.tsx
+++ b/apps/studio/src/features/workflow/pages/workflow-gallery/workflow-gallery-tabs.tsx
@@ -39,6 +39,10 @@ interface WorkflowGalleryTabsProps {
     workflowId: string,
     workflowName: string,
   ) => Promise<void> | void;
+  onUpdateCandidateWorkflow: (
+    workflowId: string,
+    candidateId: string,
+  ) => Promise<void> | void;
   onDeleteTeam?: (teamId: string) => void;
 }
 
@@ -58,6 +62,7 @@ export const WorkflowGalleryTabs = ({
   onUseTemplate,
   onExportWorkflow,
   onDeleteWorkflow,
+  onUpdateCandidateWorkflow,
   onDeleteTeam,
 }: WorkflowGalleryTabsProps) => {
   const [isUploadOpen, setIsUploadOpen] = useState(false);
@@ -80,6 +85,7 @@ export const WorkflowGalleryTabs = ({
           onUseTemplate={onUseTemplate}
           onExportWorkflow={onExportWorkflow}
           onDeleteWorkflow={onDeleteWorkflow}
+          onUpdateCandidateWorkflow={onUpdateCandidateWorkflow}
         />
       ))}
     </div>

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -264,8 +264,9 @@ Workflow `.py` files may include an optional PEP 723-style metadata block. When 
 # id = "wf-abc123"
 # config = "./my-workflow.config.json"
 # entrypoint = "build_graph"
-# emoji = "🤖"
+# avatar = "avatar-07"
 # subtitle = "AI Assistant"
+# version = "1.3.0"
 # ///
 
 from langgraph.graph import StateGraph
@@ -280,12 +281,42 @@ Supported fields (all optional):
 - `id` (or `handle`) – workflow reference; when set, the upload updates this existing workflow instead of creating a new one.
 - `config` – path to a companion JSON runnable config file. Relative paths resolve against the workflow file's directory.
 - `entrypoint` – LangGraph entrypoint function/variable name.
-- `emoji` – emoji shown on the colleague's Candidates badge in Studio.
+- `avatar` – avatar id shown on the colleague's Candidates badge in Studio.
 - `subtitle` – short role line shown on the Candidates badge.
 - `notes` – free-form notes describing the workflow template.
 - `metadata` – a `[metadata]` table of template compatibility info (e.g. `required_plugins`, `validated_provider_api`).
+- `version` – candidate release version in strict `MAJOR.MINOR.PATCH` format. Versions with a leading `v`, prerelease suffix, build metadata, missing segments, or leading zero segments are rejected.
+- `updates` – a `[[updates]]` table array for candidate release notes. Each entry requires `version` and `summary`; `migration` is optional.
 
 The block is parsed as TOML; only the fields above are accepted. CLI flags (`--name`, `--id`, `--config-file`, `--entrypoint`) always win over the frontmatter values.
+
+Candidate workflows can use versioned update notes so Studio can show update
+availability for onboarded colleagues:
+
+```python
+# /// orcheo
+# name = "Insight Analyst"
+# handle = "insight-analyst"
+# version = "1.3.0"
+# notes = "Best used with uploaded research documents."
+#
+# [[updates]]
+# version = "1.3.0"
+# summary = "Adds source-quality checks before insight synthesis."
+# migration = "Review custom prompt overrides if they assume every source is accepted."
+#
+# [[updates]]
+# version = "1.2.0"
+# summary = "Improves citation formatting and report structure."
+# ///
+```
+
+Use patch bumps for bug fixes and low-risk prompt or formatting improvements,
+minor bumps for backwards-compatible capability changes, and major bumps when
+the workflow changes required inputs, credential expectations, output contracts,
+or operator behavior. Add `migration` whenever users may need to review custom
+prompts, runnable config overrides, credential bindings, schedules, or dependent
+automation before updating.
 
 ## Offline Mode
 

--- a/packages/sdk/src/orcheo_sdk/cli/workflow/frontmatter.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflow/frontmatter.py
@@ -11,6 +11,7 @@ The frontmatter follows the PEP 723-inspired comment block convention:
     # entrypoint = "build_graph"
     # avatar = "avatar-07"
     # subtitle = "AI Assistant"
+    # version = "1.3.0"
     # ///
 
 The block content is parsed as TOML. All fields are optional; CLI flags
@@ -44,9 +45,61 @@ _ALLOWED_FIELDS = frozenset(
         "subtitle",
         "notes",
         "metadata",
+        "version",
+        "updates",
     }
 )
 _ENCODING_RE = re.compile(r"coding[=:]\s*([-\w.]+)")
+_STRICT_SEMVER_RE = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+
+
+@dataclass(frozen=True, order=True)
+class StrictSemVer:
+    """Strict ``MAJOR.MINOR.PATCH`` semantic version."""
+
+    major: int
+    minor: int
+    patch: int
+
+    @classmethod
+    def parse(cls, value: str) -> StrictSemVer:
+        """Parse a strict SemVer string or raise ``CLIError``."""
+        match = _STRICT_SEMVER_RE.fullmatch(value.strip())
+        if match is None:
+            raise CLIError(
+                "Version must use strict SemVer 'MAJOR.MINOR.PATCH' with "
+                "non-negative integer segments and no suffix."
+            )
+        return cls(*(int(part) for part in match.groups()))
+
+
+def is_strict_semver(value: str) -> bool:
+    """Return whether *value* is a strict ``MAJOR.MINOR.PATCH`` version."""
+    return _STRICT_SEMVER_RE.fullmatch(value.strip()) is not None
+
+
+def compare_strict_semver(left: str, right: str) -> int:
+    """Compare two strict SemVer strings.
+
+    Returns ``-1`` when ``left < right``, ``0`` when equal, and ``1`` when
+    ``left > right``.
+    """
+    left_version = StrictSemVer.parse(left)
+    right_version = StrictSemVer.parse(right)
+    if left_version < right_version:
+        return -1
+    if left_version > right_version:
+        return 1
+    return 0
+
+
+@dataclass(frozen=True)
+class WorkflowUpdateNote:
+    """Versioned update note declared in workflow frontmatter."""
+
+    version: str
+    summary: str
+    migration: str | None = None
 
 
 def _encoding_from_cookie(line: bytes) -> str | None:
@@ -122,6 +175,8 @@ class WorkflowFrontmatter:
     subtitle: str | None = None
     notes: str | None = None
     metadata: dict[str, Any] | None = None
+    version: str | None = None
+    updates: list[WorkflowUpdateNote] | None = None
 
     @property
     def is_empty(self) -> bool:
@@ -138,6 +193,8 @@ class WorkflowFrontmatter:
                 self.subtitle,
                 self.notes,
                 self.metadata,
+                self.version,
+                self.updates,
             )
         )
 
@@ -179,6 +236,8 @@ def parse_workflow_frontmatter(source: str) -> WorkflowFrontmatter:
         subtitle=_string_field(data, "subtitle"),
         notes=_string_field(data, "notes"),
         metadata=_table_field(data, "metadata"),
+        version=_semver_field(data, "version"),
+        updates=_updates_field(data),
     )
 
 
@@ -250,6 +309,59 @@ def _table_field(data: dict[str, Any], key: str) -> dict[str, Any] | None:
     if not isinstance(value, dict):
         raise CLIError(f"'orcheo' frontmatter field '{key}' must be a table.")
     return value
+
+
+def _semver_field(data: dict[str, Any], key: str) -> str | None:
+    """Return a validated strict SemVer field, or None when absent."""
+    value = _string_field(data, key)
+    if value is None:
+        return None
+    StrictSemVer.parse(value)
+    return value
+
+
+def _updates_field(data: dict[str, Any]) -> list[WorkflowUpdateNote] | None:
+    """Return validated versioned update notes, newest first."""
+    if "updates" not in data:
+        return None
+    value = data["updates"]
+    if not isinstance(value, list):
+        raise CLIError("'orcheo' frontmatter field 'updates' must be a table array.")
+
+    notes: list[WorkflowUpdateNote] = []
+    for index, entry in enumerate(value, start=1):
+        if not isinstance(entry, dict):
+            raise CLIError(
+                f"'orcheo' frontmatter updates entry {index} must be a table."
+            )
+        version = _semver_field(entry, "version")
+        if version is None:
+            raise CLIError(
+                f"'orcheo' frontmatter updates entry {index} requires 'version'."
+            )
+        summary = _string_field(entry, "summary")
+        if summary is None:
+            raise CLIError(
+                f"'orcheo' frontmatter updates entry {index} requires 'summary'."
+            )
+        migration = _string_field(entry, "migration")
+        unknown = set(entry) - {"version", "summary", "migration"}
+        if unknown:
+            keys = ", ".join(sorted(unknown))
+            raise CLIError(
+                f"Unknown 'orcheo' frontmatter updates entry {index} field(s): {keys}."
+            )
+        notes.append(
+            WorkflowUpdateNote(
+                version=version,
+                summary=summary,
+                migration=migration,
+            )
+        )
+
+    return sorted(
+        notes, key=lambda note: StrictSemVer.parse(note.version), reverse=True
+    )
 
 
 def load_workflow_frontmatter(path: Path) -> WorkflowFrontmatter:
@@ -357,7 +469,11 @@ def _normalize_schema_definition_map(
 
 
 __all__ = [
+    "StrictSemVer",
+    "WorkflowUpdateNote",
     "WorkflowFrontmatter",
+    "compare_strict_semver",
+    "is_strict_semver",
     "parse_workflow_frontmatter",
     "load_workflow_frontmatter",
     "resolve_frontmatter_config",

--- a/project/initiatives/candidate_workflow_version_updates/1_requirements.md
+++ b/project/initiatives/candidate_workflow_version_updates/1_requirements.md
@@ -1,0 +1,206 @@
+# Requirements Document
+
+## METADATA
+- **Authors:** Codex
+- **Project/Feature Name:** Candidate Workflow Version Updates
+- **Type:** Enhancement
+- **Summary:** Add semantic versioning and versioned update notes to candidate workflow frontmatter, surface update availability for onboarded colleagues, and let users explicitly update selected colleagues to the latest candidate version.
+- **Owner (if different than authors):** ShaojieJiang
+- **Date Started:** 2026-06-23
+
+## RELEVANT LINKS & STAKEHOLDERS
+
+| Documents | Link | Owner | Name |
+|-----------|------|-------|------|
+| Prior Artifact | `project/initiatives/python_only_workflow_composition/1_requirements.md` | ShaojieJiang | Python-only workflow composition requirements |
+| Prior Artifact | `project/initiatives/workflow_upload_config/1_requirements.md` | ShaojieJiang | Workflow upload runnable config requirements |
+| Design Review | `./2_design.md` | ShaojieJiang | Candidate workflow version updates design |
+| Project Plan | `./3_plan.md` | ShaojieJiang | Candidate workflow version updates plan |
+| Candidate API | `apps/backend/src/orcheo_backend/app/routers/candidates.py` | ShaojieJiang | Candidate onboarding endpoint |
+| Candidate Service | `apps/backend/src/orcheo_backend/app/candidates_service.py` | ShaojieJiang | Candidate repository parser and cache |
+| Workflow Frontmatter Parser | `packages/sdk/src/orcheo_sdk/cli/workflow/frontmatter.py` | ShaojieJiang | Orcheo workflow frontmatter parsing |
+| Studio Gallery | `apps/studio/src/features/workflow/pages/workflow-gallery/` | ShaojieJiang | Candidate and colleague gallery UI |
+
+## PROBLEM DEFINITION
+### Objectives
+Make candidate colleague updates visible, understandable, and user-controlled. Each candidate workflow should declare a semantic release version and versioned update notes, while each onboarded colleague records the candidate version it was created or last updated from.
+
+### Target users
+- Studio users who onboard and operate candidate colleagues in a workspace.
+- Workflow authors maintaining candidate workflows in the `colleague-candidates` repository.
+- Platform engineers maintaining candidate ingestion, onboarding, and workflow version storage.
+
+### User Stories
+| As a... | I want to... | So that... | Priority | Acceptance Criteria |
+|---------|--------------|------------|----------|---------------------|
+| Candidate author | Declare a `version` in workflow frontmatter | Users and Orcheo can tell which candidate release is current | P0 | Candidate frontmatter accepts only SemVer `x.y.z`; invalid versions exclude the candidate with a logged parser warning |
+| Candidate author | Add update notes and migration guidance to frontmatter | Users can understand whether they should update | P0 | Candidate metadata can include versioned update notes with summary and optional migration text |
+| Studio user | See when an onboarded colleague has a newer candidate version | I can choose whether and when to update | P0 | Gallery cards for onboarded candidate colleagues show an update action when latest candidate SemVer is greater than the stored candidate version |
+| Studio user | Hover over the update action | I can quickly understand what changed without opening a dialog | P0 | Hover/focus shows current version, latest version, and concise update summary; long notes are not forced into the hover content |
+| Studio user | Click update and review details before applying | I can avoid accidental breaking changes | P0 | Clicking update opens a confirmation dialog with full notes for all versions being crossed and a clear update action |
+| Studio user | Update one selected colleague | I can upgrade only the colleagues I choose | P0 | Confirming update appends a new workflow version from the latest candidate script/config and updates stored candidate source metadata |
+| Platform engineer | Preserve workspace-specific colleague state during update | Updates do not erase local operational state | P0 | Workflow identity, team placement, credentials, runnable config overrides where appropriate, execution history, and workspace bindings are preserved |
+| Studio user | Recognize high-risk updates | I can treat major version updates more carefully | P1 | Major SemVer updates show stronger warning copy and migration notes prominently in the confirmation dialog |
+
+### Context, Problems, Opportunities
+Candidate colleagues are fetched from the `AI-Colleagues/colleague-candidates` repository, parsed from `# /// orcheo` frontmatter, and onboarded through `POST /api/candidates/onboard`. Re-onboarding an existing candidate handle already appends a new workflow version, but this path is implicit and does not tell users which candidate version they currently have, whether a newer candidate exists, or what changed.
+
+This creates an update lifecycle gap: candidate authors can improve workflows, but onboarded colleagues do not clearly show available updates or migration context. Users need an explicit package-like upgrade model: candidate releases have versions and notes; onboarded colleagues are pinned to a candidate version; updating is a deliberate action with preview and confirmation.
+
+### Product goals and Non-goals
+Goals:
+- Add `version` to workflow frontmatter using strict SemVer `x.y.z`.
+- Add versioned update notes to candidate metadata, including short summaries and optional migration guidance.
+- Persist source candidate metadata on onboarded colleague workflow versions.
+- Show update availability in Studio for onboarded candidate colleagues.
+- Provide compact hover/focus context and a full confirmation dialog before update.
+- Update selected colleagues by appending a new workflow version from the latest candidate release.
+
+Non-goals:
+- Automatic background updates of colleagues.
+- Supporting arbitrary SemVer ranges or prerelease/build metadata in v1.
+- Building a full candidate release registry outside the existing candidates repository.
+- Bulk update flows in the first release.
+- Diff visualization between candidate versions.
+- Rewriting unrelated workflow version history or execution records.
+
+## PRODUCT DEFINITION
+### Requirements
+- **P0: Frontmatter candidate version**
+  - Add a top-level `version` field to `# /// orcheo` workflow frontmatter.
+  - Accept only strict SemVer `MAJOR.MINOR.PATCH` with non-negative integer segments and no prerelease/build suffix in v1.
+  - Candidate repository parsing must expose `version` in internal and public candidate API models.
+  - Candidates without `version` remain visible but are treated as not update-trackable; they do not trigger update buttons.
+
+- **P0: Versioned update notes**
+  - Add an `updates` frontmatter table array where each entry has:
+    - `version`: SemVer string matching a released candidate version.
+    - `summary`: short user-facing summary.
+    - `migration`: optional migration guide or caution.
+  - `updates` entries are sorted by SemVer descending in API responses.
+  - Existing `notes` remains supported as general candidate notes, not as release notes.
+
+- **P0: Onboarded colleague source metadata**
+  - Store source metadata when onboarding/updating from a candidate:
+    - `source`: `candidate-onboard`
+    - `candidate_id`
+    - `candidate_handle`
+    - `candidate_version`
+    - `candidate_source_ref` where available from the fetched repository ref/cache snapshot
+  - Existing onboarded colleagues without `candidate_version` are treated as unknown and do not show update availability until updated or re-onboarded with versioned metadata.
+
+- **P0: Update availability detection**
+  - Backend or Studio compares the latest candidate `version` with the onboarded colleague's latest source `candidate_version`.
+  - Update available only when:
+    - workflow latest version metadata indicates it came from the same `candidate_id` or matching candidate handle.
+    - both versions are valid strict SemVer.
+    - candidate version is greater than installed candidate version.
+  - Missing or invalid versions do not show an update action.
+
+- **P0: Studio update UX**
+  - On onboarded colleague cards, show an update button when an update is available.
+  - Hover and keyboard focus on the update button show compact context:
+    - current installed version
+    - latest candidate version
+    - latest update summary
+    - first migration warning when present
+  - Clicking the update button opens a confirmation dialog with full version notes for the versions being crossed.
+  - Confirmation copy distinguishes patch/minor updates from major updates.
+  - Users can cancel without changing the colleague.
+
+- **P0: Explicit update operation**
+  - Add or refine an API endpoint that updates an existing onboarded colleague from a candidate by candidate id and workflow id.
+  - The update appends a new workflow version using latest candidate script/config.
+  - The update must preserve workflow identity, team assignment, handle, user-visible workflow shell fields unless explicitly replaced by candidate metadata policy, credentials, execution history, and workspace ownership.
+  - On failure, the previous workflow version remains the active latest version.
+
+- **P1: Documentation and author guidance**
+  - Document candidate frontmatter version/update fields with examples.
+  - Provide guidance for major, minor, and patch version bump expectations.
+  - Document migration-note writing expectations for candidate authors.
+
+### Designs (if applicable)
+See `./2_design.md` for schema, API, request-flow, and UI details.
+
+### Other Teams Impacted
+- **Backend/API:** Candidate parser, public schema, onboard/update endpoint, source metadata persistence.
+- **Studio:** Gallery card update action, hover/focus popover, confirmation dialog, update API integration.
+- **Candidate authors:** Must add version and update notes to release-trackable candidates.
+- **SDK/CLI:** Frontmatter parser validation and tests.
+
+## TECHNICAL CONSIDERATIONS
+### Architecture Overview
+Candidate workflows continue to be sourced from the existing candidates repository and ingested server-side. The frontmatter parser gains version/update fields; the candidate service publishes those fields through `/api/candidates`; workflow version metadata records the installed candidate version; Studio compares installed and latest versions and calls an explicit update endpoint that appends a new workflow version.
+
+### Technical Requirements
+- Extend `WorkflowFrontmatter` and `parse_workflow_frontmatter` to support `version` and `updates`.
+- Use a shared strict SemVer parser/comparator in backend and Studio, or compute update availability server-side to avoid duplicate comparison rules.
+- Extend `CandidateItem` and `CandidatePublicItem` with `version` and `updates`.
+- Include source candidate version metadata during onboarding and update.
+- Preserve existing candidate cache stale-while-revalidate behavior; update availability may be stale until the candidate cache refreshes.
+- Use idempotent storage migration only if a dedicated source metadata field is introduced; otherwise persist under existing workflow version metadata.
+- Keep multi-workspace isolation intact using the hard-coded `X-Orcheo-Workspace` workspace context.
+
+## MARKET DEFINITION
+Internal platform and Studio enhancement; no external market analysis required.
+
+## LAUNCH/ROLLOUT PLAN
+
+### Success metrics
+| KPIs | Target & Rationale |
+|------|--------------------|
+| Primary: Versioned candidates parsed | 100% of candidates with valid SemVer expose version data through `/api/candidates` |
+| Primary: Update decision quality | 100% of update buttons show current/latest versions and release-note context before mutation |
+| Secondary: Update success rate | >=99% successful candidate colleague updates in staging and internal workspaces |
+| Guardrail: No accidental overwrite | 0 update flows that remove workflow identity, team assignment, credentials, or history |
+| Guardrail: Existing candidates unaffected | Candidates without version metadata remain onboardable with no update button |
+
+### Rollout Strategy
+Ship parser/schema support first, then backend update operation, then Studio update UI. Enable candidate authors to add versions progressively; unversioned candidates remain usable but do not participate in update detection.
+
+### Experiment Plan (if applicable)
+Not applicable. Validate with internal candidate workflows and automated regression coverage.
+
+### Estimated Launch Phases (if applicable)
+| Phase | Target | Description |
+|-------|--------|-------------|
+| **Phase 1** | Backend/SDK tests | Add frontmatter parsing, candidate API fields, and source metadata persistence |
+| **Phase 2** | Internal Studio | Add update availability, hover/focus summary, confirmation dialog, and update endpoint integration |
+| **Phase 3** | Candidate authors | Document frontmatter versioning and update-note authoring; migrate official candidates gradually |
+
+## HYPOTHESIS & RISKS
+Hypothesis: explicit candidate versions and update notes will make candidate colleague upgrades safer and more understandable, increasing adoption of upstream improvements without surprising workspace users.
+
+Risks:
+- Users may confuse workflow version numbers with candidate semantic versions.
+- Major updates may require manual migration that cannot be fully automated.
+- Cached candidate data can temporarily hide newly released updates.
+- Existing onboarded colleagues without source version metadata cannot reliably show update availability.
+
+Risk mitigation:
+- Label UI copy as "Candidate version" where ambiguity is likely.
+- Show major-update warnings and full migration notes before confirmation.
+- Keep stale-while-revalidate behavior but allow manual refresh as a follow-up if needed.
+- Treat unknown installed versions conservatively and do not show update buttons without valid comparison data.
+
+## APPENDIX
+Example candidate frontmatter:
+
+```python
+# /// orcheo
+# name = "Insight Analyst"
+# handle = "insight-analyst"
+# description = "Analyzes research inputs and produces concise insight summaries."
+# version = "1.3.0"
+# notes = "Best used with uploaded research documents."
+#
+# [[updates]]
+# version = "1.3.0"
+# summary = "Adds source-quality checks before insight synthesis."
+# migration = "Review custom prompt overrides if they assume every source is accepted."
+#
+# [[updates]]
+# version = "1.2.0"
+# summary = "Improves citation formatting and final report structure."
+# ///
+```

--- a/project/initiatives/candidate_workflow_version_updates/2_design.md
+++ b/project/initiatives/candidate_workflow_version_updates/2_design.md
@@ -1,0 +1,271 @@
+# Design Document
+
+## For Candidate Workflow Version Updates
+
+- **Version:** 0.1
+- **Author:** Codex
+- **Date:** 2026-06-23
+- **Status:** Draft
+
+---
+
+## Overview
+
+This initiative gives candidate colleagues an explicit release lifecycle. Candidate workflow files declare a strict SemVer `version` and optional versioned `updates` entries in the existing `# /// orcheo` frontmatter block. The backend candidate service parses and exposes that release metadata through `/api/candidates`.
+
+When a user onboards a candidate, Orcheo records which candidate id/handle/version produced the colleague's workflow version. Studio can then compare that installed candidate version against the latest candidate fetched from the repository and show an update action only when the latest candidate version is greater.
+
+The update operation remains explicit. Hover/focus on the update button gives compact context; clicking opens a confirmation dialog with full update notes for the versions being crossed. Confirming appends a new workflow version from the latest candidate script/config and preserves the colleague's workflow identity, team, credentials, workspace bindings, and history.
+
+## Components
+
+- **Workflow Frontmatter Parser (`packages/sdk`)**
+  - Adds `version` and `updates` to the allowed `orcheo` frontmatter fields.
+  - Validates strict SemVer strings and update-note structure.
+
+- **Candidate Service (`apps/backend`)**
+  - Parses candidate version/update notes from the candidates repository.
+  - Exposes release metadata through internal and public candidate schemas.
+  - Preserves stale-while-revalidate cache semantics.
+
+- **Candidate Router (`apps/backend`)**
+  - Records source candidate metadata when onboarding.
+  - Adds an explicit update endpoint for existing onboarded colleagues.
+  - Reuses script ingestion, runnable config normalization, plugin checks, and Mermaid rendering from onboarding.
+
+- **Workflow Repository (`apps/backend`)**
+  - Persists source candidate metadata on workflow version metadata, or in a dedicated nullable source metadata field if introduced.
+  - Lists workflow versions with enough metadata for update detection.
+
+- **Studio API Client (`apps/studio`)**
+  - Extends candidate and workflow version types with candidate version/update metadata.
+  - Calls the update endpoint and refreshes workflow/gallery state after success.
+
+- **Studio Gallery UI (`apps/studio`)**
+  - Shows an update button on onboarded colleague cards when an update is available.
+  - Shows compact update notes on hover/focus.
+  - Opens a review/confirmation dialog before applying the update.
+
+## Request Flows
+
+### Flow 1: Candidate Release Metadata Parsing
+
+1. Candidate author updates `colleagues/<id>/workflow.py` frontmatter with `version` and `updates`.
+2. Backend candidate service downloads the candidate repository tarball.
+3. Candidate parser reads `workflow.py`, validates frontmatter, and builds `CandidateItem`.
+4. `/api/candidates` returns public candidate metadata including version and update notes, but still omits script/config.
+
+### Flow 2: Onboard Candidate with Source Version
+
+1. User clicks Onboard on a candidate card.
+2. Studio posts candidate id and optional team id to `POST /api/candidates/onboard`.
+3. Backend fetches the candidate from the server-side cache.
+4. Backend ingests the script and creates a workflow/version as today.
+5. Workflow version metadata includes `candidate_id`, `candidate_handle`, and `candidate_version`.
+6. Studio refreshes the gallery and the new colleague is pinned to the installed candidate version.
+
+### Flow 3: Detect Update Availability
+
+1. Studio loads workspace workflows and candidates.
+2. For each onboarded colleague, Studio reads latest workflow version metadata.
+3. If metadata identifies a candidate source and both versions are valid SemVer, Studio compares installed and latest candidate versions.
+4. If latest is greater, the card shows an update action with hover/focus details.
+
+Server-side detection is acceptable if implemented as an enriched workflow/gallery response; the comparison rules must remain the same.
+
+### Flow 4: Review and Apply Update
+
+1. User hovers or focuses the update button and sees a short summary.
+2. User clicks the update button.
+3. Studio opens a confirmation dialog showing:
+   - current installed candidate version
+   - latest candidate version
+   - update notes for versions greater than installed and less than or equal to latest
+   - migration guidance and major-update warning when applicable
+4. User confirms.
+5. Studio calls update endpoint with workflow id and candidate id.
+6. Backend validates that the workflow is an onboarded colleague from the requested candidate.
+7. Backend ingests latest candidate script/config and appends a new workflow version.
+8. Backend returns the updated workflow; Studio refreshes gallery/workflow state.
+
+## API Contracts
+
+Existing candidate list response expands with release metadata:
+
+```text
+GET /api/candidates
+
+Response:
+  200 OK -> [
+    {
+      id: string,
+      handle: string,
+      name: string,
+      description: string | null,
+      avatar: string | null,
+      subtitle: string | null,
+      notes: string | null,
+      metadata: object | null,
+      mermaid: string | null,
+      version: string | null,
+      updates: CandidateUpdateNote[]
+    }
+  ]
+```
+
+Candidate update endpoint:
+
+```text
+POST /api/candidates/update
+Headers:
+  X-Orcheo-Workspace: <workspace>
+Body:
+  workflow_id: string
+  candidate_id: string
+
+Response:
+  200 OK -> Workflow
+  400 -> candidate is unversioned, script ingestion failed, or plugins/config invalid
+  403 -> user cannot update the workflow in this workspace
+  404 -> workflow or candidate not found
+  409 -> workflow is not sourced from this candidate, or latest version is not newer
+```
+
+An equivalent nested route is also acceptable:
+
+```text
+POST /api/workflows/{workflow_id}/candidate-update
+Body:
+  candidate_id: string
+```
+
+The endpoint should be idempotent for already-current colleagues: if installed version equals latest candidate version, return `409` with code `candidate.no_update_available` or `200` with no mutation and a clear `updated=false` response. Choose one behavior and document it consistently before implementation.
+
+## Data Models / Schemas
+
+### Frontmatter
+
+```toml
+version = "1.3.0"
+
+[[updates]]
+version = "1.3.0"
+summary = "Adds source-quality checks before insight synthesis."
+migration = "Review custom prompt overrides if they assume every source is accepted."
+```
+
+### Candidate Update Note
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `version` | string | Strict SemVer `x.y.z` release version |
+| `summary` | string | Short user-facing change summary |
+| `migration` | string \| null | Optional migration guide, warning, or operator action |
+
+### Candidate API Model Additions
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `version` | string \| null | Latest candidate release version parsed from workflow frontmatter |
+| `updates` | list[CandidateUpdateNote] | Versioned update notes, sorted newest first |
+
+### Workflow Version Source Metadata
+
+Persisted in workflow version metadata:
+
+```json
+{
+  "source": "candidate-onboard",
+  "candidate_id": "insight-analyst",
+  "candidate_handle": "insight-analyst",
+  "candidate_version": "1.3.0",
+  "candidate_source_ref": "main"
+}
+```
+
+If `candidate_source_ref` can be made more precise than the configured ref, prefer the fetched Git commit SHA. If not available from the tarball request in v1, store the configured repo ref and document that it is a cache-source hint, not a content hash.
+
+### SemVer Rules
+
+Strict v1 format:
+
+```text
+MAJOR.MINOR.PATCH
+```
+
+Rules:
+- Each segment is a base-10 non-negative integer.
+- No empty segments.
+- No leading `v`.
+- No prerelease suffix.
+- No build metadata suffix.
+- Numeric comparison is segment-wise: major, then minor, then patch.
+
+## Security Considerations
+
+- Candidate scripts remain server-sourced from the configured candidate repository; clients cannot submit script/config through the update endpoint.
+- Preserve existing workspace authorization and the hard-coded `X-Orcheo-Workspace` scope.
+- Do not trust client-provided current/latest versions. Backend must resolve candidate and workflow metadata server-side before mutating.
+- Continue plugin availability checks before onboarding/updating candidates.
+- Update notes are repository-authored text and must be rendered as plain text or sanitized Markdown in Studio.
+- Candidate configs must continue to validate through `RunnableConfigModel`; secrets should not be embedded in candidate config.
+
+## Performance Considerations
+
+- SemVer comparison and update-note filtering are negligible.
+- Candidate cache behavior remains TTL-based with stale-while-revalidate; no per-card GitHub calls.
+- Studio should memoize update-availability calculations by `{workflow latest version id, candidate id, candidate version}`.
+- Update operation cost is similar to re-onboarding: script ingestion plus version creation.
+
+## Testing Strategy
+
+- **Unit tests**
+  - Frontmatter parser accepts valid `version` and `updates`.
+  - Frontmatter parser rejects invalid SemVer and malformed update notes.
+  - SemVer comparator handles major/minor/patch ordering.
+  - Candidate parser exposes version/update metadata and preserves unversioned candidates.
+
+- **Backend integration tests**
+  - `/api/candidates` returns version/update metadata but still omits script/config.
+  - Onboarding stores candidate source version metadata.
+  - Update endpoint appends a new version when latest candidate is newer.
+  - Update endpoint rejects wrong candidate id, missing candidate, invalid config, missing plugins, and already-current versions.
+  - Failed update leaves prior latest version unchanged.
+
+- **Studio tests**
+  - Onboarded colleague card shows update action only when latest candidate version is greater.
+  - Hover/focus content includes current/latest versions and concise update summary.
+  - Confirmation dialog shows full notes for crossed versions and major-update warning.
+  - Confirming update calls the API and refreshes cached gallery state.
+
+- **Manual QA checklist**
+  - Add a versioned candidate and onboard it.
+  - Increase patch version and verify update button appears.
+  - Hover update button and verify compact notes.
+  - Confirm update and verify a new workflow version is appended.
+  - Verify credentials, team placement, workflow handle, and execution history remain intact.
+  - Try a major update and verify stronger warning copy.
+
+## Rollout Plan
+
+1. Phase 1: Add parser/schema support and tests; deploy with no Studio update UI yet.
+2. Phase 2: Store source candidate version metadata on onboarding/update and expose enough workflow metadata for update detection.
+3. Phase 3: Add Studio update action, hover/focus popover, confirmation dialog, and update API integration.
+4. Phase 4: Document candidate authoring policy and migrate official candidates to versioned frontmatter.
+
+Include backward compatibility for candidates and onboarded colleagues without candidate version metadata.
+
+## Rollback Plan
+
+- Hide the Studio update action if update behavior needs to be paused.
+- Keep frontmatter parser additions if safe; unrecognized older clients can ignore new fields only after parser support is deployed.
+- Existing workflow version metadata can remain in place without being used.
+- Disable the update endpoint at the router level if needed; onboarding remains unchanged.
+
+---
+
+## Revision History
+
+| Date | Author | Changes |
+|------|--------|---------|
+| 2026-06-23 | Codex | Initial draft |

--- a/project/initiatives/candidate_workflow_version_updates/3_plan.md
+++ b/project/initiatives/candidate_workflow_version_updates/3_plan.md
@@ -1,0 +1,134 @@
+# Project Plan
+
+## For Candidate Workflow Version Updates
+
+- **Version:** 0.1
+- **Author:** Codex
+- **Date:** 2026-06-23
+- **Status:** Draft
+
+---
+
+## Overview
+
+Add a package-style update lifecycle for candidate colleagues. Candidate workflows declare SemVer release metadata and update notes; onboarded colleagues store which candidate version they came from; Studio shows update availability and lets users explicitly update selected colleagues after reviewing release notes.
+
+**Related Documents:**
+- Requirements: `./1_requirements.md`
+- Design: `./2_design.md`
+
+**Priority Mapping:** P0 work is covered by Milestones 1 through 4. P1 documentation and authoring guidance are covered by Milestone 5.
+
+---
+
+## Milestones
+
+### Milestone 1: Frontmatter Release Metadata
+
+**Description:** Teach Orcheo workflow frontmatter to parse and validate candidate release metadata.
+
+#### Task Checklist
+
+- [ ] Task 1.1: Add `version` and `updates` to the workflow frontmatter allowed fields and dataclass/model shape
+  - Dependencies: None
+- [ ] Task 1.2: Implement strict SemVer validation and comparison helper for `x.y.z`
+  - Dependencies: Task 1.1
+- [ ] Task 1.3: Validate `updates` entries for `version`, `summary`, and optional `migration`
+  - Dependencies: Task 1.2
+- [ ] Task 1.4: Add SDK parser tests for valid metadata, invalid SemVer, malformed update notes, and unversioned workflows
+  - Dependencies: Task 1.3
+
+---
+
+### Milestone 2: Candidate API and Source Metadata
+
+**Description:** Expose candidate version data and persist installed candidate version metadata during onboarding.
+
+#### Task Checklist
+
+- [ ] Task 2.1: Extend `CandidateItem` and `CandidatePublicItem` with `version` and `updates`
+  - Dependencies: Milestone 1
+- [ ] Task 2.2: Update candidate tarball parsing to populate version/update metadata while preserving unversioned candidates
+  - Dependencies: Task 2.1
+- [ ] Task 2.3: Store `candidate_id`, `candidate_handle`, and `candidate_version` in workflow version metadata on onboarding
+  - Dependencies: Task 2.2
+- [ ] Task 2.4: Add backend tests for `/api/candidates` response shape and onboarding metadata persistence
+  - Dependencies: Task 2.3
+
+---
+
+### Milestone 3: Explicit Candidate Update Endpoint
+
+**Description:** Add a backend operation that updates an existing onboarded colleague from the latest candidate release.
+
+#### Task Checklist
+
+- [ ] Task 3.1: Add request/response schema for updating a workflow from a candidate
+  - Dependencies: Milestone 2
+- [ ] Task 3.2: Validate workflow ownership, workspace scope, candidate source match, and version ordering before mutation
+  - Dependencies: Task 3.1
+- [ ] Task 3.3: Reuse candidate script ingestion, runnable config normalization, plugin checks, and Mermaid rendering to append the new workflow version
+  - Dependencies: Task 3.2
+- [ ] Task 3.4: Preserve workflow shell identity, team assignment, credentials, workspace bindings, and execution history
+  - Dependencies: Task 3.3
+- [ ] Task 3.5: Add integration tests for successful update, wrong candidate id, already-current version, unversioned candidate, invalid config, missing plugins, and failed-ingestion rollback behavior
+  - Dependencies: Task 3.4
+
+---
+
+### Milestone 4: Studio Update UX
+
+**Description:** Surface update availability on onboarded colleague cards and require confirmation before applying updates.
+
+#### Task Checklist
+
+- [ ] Task 4.1: Extend Studio candidate and workflow version types with source candidate version metadata
+  - Dependencies: Milestone 2
+- [ ] Task 4.2: Compute update availability for onboarded colleague cards using strict SemVer comparison
+  - Dependencies: Task 4.1
+- [ ] Task 4.3: Add update button to onboarded colleague cards only when a newer candidate version is available
+  - Dependencies: Task 4.2
+- [ ] Task 4.4: Add hover/focus popover with current version, latest version, concise summary, and first migration warning
+  - Dependencies: Task 4.3
+- [ ] Task 4.5: Add confirmation dialog with full crossed-version update notes and stronger major-update warning
+  - Dependencies: Task 4.4
+- [ ] Task 4.6: Wire confirm action to the update endpoint and refresh gallery/workflow caches on success
+  - Dependencies: Task 4.5
+- [ ] Task 4.7: Add Vitest coverage for update visibility, popover content, dialog content, cancel behavior, and successful update call
+  - Dependencies: Task 4.6
+
+---
+
+### Milestone 5: Candidate Author Guidance and Rollout
+
+**Description:** Document release metadata policy and migrate official candidate workflows gradually.
+
+#### Task Checklist
+
+- [ ] Task 5.1: Document candidate frontmatter fields with examples for `version` and `updates`
+  - Dependencies: Milestone 1
+- [ ] Task 5.2: Define author guidance for patch, minor, and major version bump expectations
+  - Dependencies: Task 5.1
+- [ ] Task 5.3: Add migration-note writing guidance for risky or manual updates
+  - Dependencies: Task 5.2
+- [ ] Task 5.4: Add version/update metadata to a small set of official candidates for staging validation
+  - Dependencies: Milestone 4
+- [ ] Task 5.5: Verify staged candidate updates end-to-end before migrating the rest of the candidate catalog
+  - Dependencies: Task 5.4
+
+---
+
+## Revision History
+
+| Date | Author | Changes |
+|------|--------|---------|
+| 2026-06-23 | Codex | Initial draft |
+
+---
+
+## Rollback / Contingency
+
+- Hide or disable the Studio update button while keeping candidate onboarding unchanged.
+- Disable the update endpoint if update mutations need to pause.
+- Continue accepting unversioned candidates so candidate repository rollout can be incremental.
+- Leave source candidate metadata on workflow versions; it is informational if the update feature is disabled.

--- a/project/initiatives/candidate_workflow_version_updates/3_plan.md
+++ b/project/initiatives/candidate_workflow_version_updates/3_plan.md
@@ -29,13 +29,13 @@ Add a package-style update lifecycle for candidate colleagues. Candidate workflo
 
 #### Task Checklist
 
-- [ ] Task 1.1: Add `version` and `updates` to the workflow frontmatter allowed fields and dataclass/model shape
+- [x] Task 1.1: Add `version` and `updates` to the workflow frontmatter allowed fields and dataclass/model shape
   - Dependencies: None
-- [ ] Task 1.2: Implement strict SemVer validation and comparison helper for `x.y.z`
+- [x] Task 1.2: Implement strict SemVer validation and comparison helper for `x.y.z`
   - Dependencies: Task 1.1
-- [ ] Task 1.3: Validate `updates` entries for `version`, `summary`, and optional `migration`
+- [x] Task 1.3: Validate `updates` entries for `version`, `summary`, and optional `migration`
   - Dependencies: Task 1.2
-- [ ] Task 1.4: Add SDK parser tests for valid metadata, invalid SemVer, malformed update notes, and unversioned workflows
+- [x] Task 1.4: Add SDK parser tests for valid metadata, invalid SemVer, malformed update notes, and unversioned workflows
   - Dependencies: Task 1.3
 
 ---
@@ -46,13 +46,13 @@ Add a package-style update lifecycle for candidate colleagues. Candidate workflo
 
 #### Task Checklist
 
-- [ ] Task 2.1: Extend `CandidateItem` and `CandidatePublicItem` with `version` and `updates`
+- [x] Task 2.1: Extend `CandidateItem` and `CandidatePublicItem` with `version` and `updates`
   - Dependencies: Milestone 1
-- [ ] Task 2.2: Update candidate tarball parsing to populate version/update metadata while preserving unversioned candidates
+- [x] Task 2.2: Update candidate tarball parsing to populate version/update metadata while preserving unversioned candidates
   - Dependencies: Task 2.1
-- [ ] Task 2.3: Store `candidate_id`, `candidate_handle`, and `candidate_version` in workflow version metadata on onboarding
+- [x] Task 2.3: Store `candidate_id`, `candidate_handle`, and `candidate_version` in workflow version metadata on onboarding
   - Dependencies: Task 2.2
-- [ ] Task 2.4: Add backend tests for `/api/candidates` response shape and onboarding metadata persistence
+- [x] Task 2.4: Add backend tests for `/api/candidates` response shape and onboarding metadata persistence
   - Dependencies: Task 2.3
 
 ---
@@ -63,15 +63,15 @@ Add a package-style update lifecycle for candidate colleagues. Candidate workflo
 
 #### Task Checklist
 
-- [ ] Task 3.1: Add request/response schema for updating a workflow from a candidate
+- [x] Task 3.1: Add request/response schema for updating a workflow from a candidate
   - Dependencies: Milestone 2
-- [ ] Task 3.2: Validate workflow ownership, workspace scope, candidate source match, and version ordering before mutation
+- [x] Task 3.2: Validate workflow ownership, workspace scope, candidate source match, and version ordering before mutation
   - Dependencies: Task 3.1
-- [ ] Task 3.3: Reuse candidate script ingestion, runnable config normalization, plugin checks, and Mermaid rendering to append the new workflow version
+- [x] Task 3.3: Reuse candidate script ingestion, runnable config normalization, plugin checks, and Mermaid rendering to append the new workflow version
   - Dependencies: Task 3.2
-- [ ] Task 3.4: Preserve workflow shell identity, team assignment, credentials, workspace bindings, and execution history
+- [x] Task 3.4: Preserve workflow shell identity, team assignment, credentials, workspace bindings, and execution history
   - Dependencies: Task 3.3
-- [ ] Task 3.5: Add integration tests for successful update, wrong candidate id, already-current version, unversioned candidate, invalid config, missing plugins, and failed-ingestion rollback behavior
+- [x] Task 3.5: Add integration tests for successful update, wrong candidate id, already-current version, unversioned candidate, invalid config, missing plugins, and failed-ingestion rollback behavior
   - Dependencies: Task 3.4
 
 ---
@@ -82,19 +82,19 @@ Add a package-style update lifecycle for candidate colleagues. Candidate workflo
 
 #### Task Checklist
 
-- [ ] Task 4.1: Extend Studio candidate and workflow version types with source candidate version metadata
+- [x] Task 4.1: Extend Studio candidate and workflow version types with source candidate version metadata
   - Dependencies: Milestone 2
-- [ ] Task 4.2: Compute update availability for onboarded colleague cards using strict SemVer comparison
+- [x] Task 4.2: Compute update availability for onboarded colleague cards using strict SemVer comparison
   - Dependencies: Task 4.1
-- [ ] Task 4.3: Add update button to onboarded colleague cards only when a newer candidate version is available
+- [x] Task 4.3: Add update button to onboarded colleague cards only when a newer candidate version is available
   - Dependencies: Task 4.2
-- [ ] Task 4.4: Add hover/focus popover with current version, latest version, concise summary, and first migration warning
+- [x] Task 4.4: Add hover/focus popover with current version, latest version, concise summary, and first migration warning
   - Dependencies: Task 4.3
-- [ ] Task 4.5: Add confirmation dialog with full crossed-version update notes and stronger major-update warning
+- [x] Task 4.5: Add confirmation dialog with full crossed-version update notes and stronger major-update warning
   - Dependencies: Task 4.4
-- [ ] Task 4.6: Wire confirm action to the update endpoint and refresh gallery/workflow caches on success
+- [x] Task 4.6: Wire confirm action to the update endpoint and refresh gallery/workflow caches on success
   - Dependencies: Task 4.5
-- [ ] Task 4.7: Add Vitest coverage for update visibility, popover content, dialog content, cancel behavior, and successful update call
+- [x] Task 4.7: Add Vitest coverage for update visibility, popover content, dialog content, cancel behavior, and successful update call
   - Dependencies: Task 4.6
 
 ---
@@ -105,11 +105,11 @@ Add a package-style update lifecycle for candidate colleagues. Candidate workflo
 
 #### Task Checklist
 
-- [ ] Task 5.1: Document candidate frontmatter fields with examples for `version` and `updates`
+- [x] Task 5.1: Document candidate frontmatter fields with examples for `version` and `updates`
   - Dependencies: Milestone 1
-- [ ] Task 5.2: Define author guidance for patch, minor, and major version bump expectations
+- [x] Task 5.2: Define author guidance for patch, minor, and major version bump expectations
   - Dependencies: Task 5.1
-- [ ] Task 5.3: Add migration-note writing guidance for risky or manual updates
+- [x] Task 5.3: Add migration-note writing guidance for risky or manual updates
   - Dependencies: Task 5.2
 - [ ] Task 5.4: Add version/update metadata to a small set of official candidates for staging validation
   - Dependencies: Milestone 4

--- a/tests/backend/test_candidates_service.py
+++ b/tests/backend/test_candidates_service.py
@@ -23,6 +23,12 @@ _WORKFLOW_WITH_FRONTMATTER = (
     '# description = "Publishes posts to LinkedIn."\n'
     '# avatar = "avatar-07"\n'
     '# subtitle = "AI Social Media"\n'
+    '# version = "1.2.0"\n'
+    "#\n"
+    "# [[updates]]\n"
+    '# version = "1.2.0"\n'
+    '# summary = "Adds publishing guardrails."\n'
+    '# migration = "Review scheduled posting windows."\n'
     "# ///\n"
     "\n"
     "graph = object()\n"
@@ -71,6 +77,14 @@ def test_parse_tarball_extracts_candidate_metadata() -> None:
     assert item.avatar == "avatar-07"
     assert item.subtitle == "AI Social Media"
     assert item.description == "Publishes posts to LinkedIn."
+    assert item.version == "1.2.0"
+    assert [note.model_dump() for note in item.updates] == [
+        {
+            "version": "1.2.0",
+            "summary": "Adds publishing guardrails.",
+            "migration": "Review scheduled posting windows.",
+        }
+    ]
 
 
 def test_parse_tarball_handles_nested_dirs_and_missing_frontmatter() -> None:

--- a/tests/backend/test_routers_candidates.py
+++ b/tests/backend/test_routers_candidates.py
@@ -9,8 +9,13 @@ from fastapi import HTTPException
 from orcheo.models import Workflow, WorkflowDraftAccess
 from orcheo_backend.app.candidates_service import CandidateFetchError
 from orcheo_backend.app.routers import candidates as candidates_router
-from orcheo_backend.app.routers.candidates import list_candidates, onboard_candidate
-from orcheo_backend.app.routers.candidates import CandidateOnboardRequest
+from orcheo_backend.app.routers.candidates import (
+    CandidateOnboardRequest,
+    CandidateUpdateRequest,
+    list_candidates,
+    onboard_candidate,
+    update_candidate_workflow,
+)
 from orcheo_backend.app.schemas.candidates import CandidateItem
 
 
@@ -26,6 +31,14 @@ _SAMPLE = CandidateItem(
         "graph.add_node('run', lambda x: x)"
     ),
     entrypoint="graph",
+    version="1.2.0",
+    updates=[
+        {
+            "version": "1.2.0",
+            "summary": "Adds stronger insight checks.",
+            "migration": None,
+        }
+    ],
 )
 
 _MOCK_WORKSPACE = SimpleNamespace(workspace_id=uuid4(), workspace_slug="acme")
@@ -99,8 +112,10 @@ class _Repository:
     def __init__(
         self,
         existing_workflow: Workflow | None = None,
+        latest_metadata: dict | None = None,
     ) -> None:
         self._existing = existing_workflow
+        self._latest_metadata = latest_metadata
         self.created_workflow: Workflow | None = None
         self.versions_created: int = 0
         self.last_metadata: dict | None = None
@@ -161,7 +176,22 @@ class _Repository:
             workflow_id=wf_id,
             version=self.versions_created,
             graph=graph,
+            metadata=metadata,
             created_by=created_by,
+            created_at=datetime.now(tz=UTC),
+            updated_at=datetime.now(tz=UTC),
+        )
+
+    async def get_latest_version(self, workflow_id):
+        from orcheo.models import WorkflowVersion
+
+        return WorkflowVersion(
+            id=uuid4(),
+            workflow_id=workflow_id,
+            version=1,
+            graph={},
+            metadata=self._latest_metadata or {},
+            created_by="onboard",
             created_at=datetime.now(tz=UTC),
             updated_at=datetime.now(tz=UTC),
         )
@@ -193,6 +223,12 @@ async def test_onboard_candidate_creates_workflow_and_version(
     assert repo.versions_created == 1
     assert repo.last_version_graph is not None
     assert repo.last_version_graph.get("format") == "langgraph-script"
+    assert repo.last_metadata is not None
+    assert repo.last_metadata["source"] == "candidate-onboard"
+    assert repo.last_metadata["candidate_id"] == "insight-analyst"
+    assert repo.last_metadata["candidate_handle"] == "insight-analyst"
+    assert repo.last_metadata["candidate_version"] == "1.2.0"
+    assert repo.last_metadata["candidate_source_ref"] == "main"
 
 
 @pytest.mark.asyncio()
@@ -666,3 +702,300 @@ async def test_onboard_candidate_handle_conflict_raises_409(
         )
 
     assert exc_info.value.status_code == 409
+
+
+@pytest.mark.asyncio()
+async def test_update_candidate_workflow_appends_new_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    existing_wf = _make_workflow(uuid4())
+    existing_wf = existing_wf.model_copy(update={"handle": "insight-analyst"})
+
+    async def fake_get_candidates() -> list[CandidateItem]:
+        return [_SAMPLE]
+
+    monkeypatch.setattr(candidates_router, "get_candidates", fake_get_candidates)
+
+    repo = _Repository(
+        existing_workflow=existing_wf,
+        latest_metadata={
+            "source": "candidate-onboard",
+            "candidate_id": "insight-analyst",
+            "candidate_handle": "insight-analyst",
+            "candidate_version": "1.1.0",
+        },
+    )
+
+    result = await update_candidate_workflow(
+        CandidateUpdateRequest(
+            workflow_id=existing_wf.id,
+            candidate_id="insight-analyst",
+        ),
+        repo,  # type: ignore[arg-type]
+        _MOCK_WORKSPACE,  # type: ignore[arg-type]
+    )
+
+    assert result.id == existing_wf.id
+    assert repo.versions_created == 1
+    assert repo.last_metadata is not None
+    assert repo.last_metadata["candidate_version"] == "1.2.0"
+
+
+@pytest.mark.asyncio()
+async def test_update_candidate_workflow_rejects_wrong_candidate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    existing_wf = _make_workflow(uuid4())
+
+    async def fake_get_candidates() -> list[CandidateItem]:
+        return [_SAMPLE]
+
+    monkeypatch.setattr(candidates_router, "get_candidates", fake_get_candidates)
+    repo = _Repository(
+        existing_workflow=existing_wf,
+        latest_metadata={
+            "source": "candidate-onboard",
+            "candidate_id": "other-candidate",
+            "candidate_handle": "other-candidate",
+            "candidate_version": "1.1.0",
+        },
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await update_candidate_workflow(
+            CandidateUpdateRequest(
+                workflow_id=existing_wf.id,
+                candidate_id="insight-analyst",
+            ),
+            repo,  # type: ignore[arg-type]
+            _MOCK_WORKSPACE,  # type: ignore[arg-type]
+        )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail["code"] == "candidate.source_mismatch"
+    assert repo.versions_created == 0
+
+
+@pytest.mark.asyncio()
+async def test_update_candidate_workflow_rejects_already_current(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    existing_wf = _make_workflow(uuid4())
+
+    async def fake_get_candidates() -> list[CandidateItem]:
+        return [_SAMPLE]
+
+    monkeypatch.setattr(candidates_router, "get_candidates", fake_get_candidates)
+    repo = _Repository(
+        existing_workflow=existing_wf,
+        latest_metadata={
+            "source": "candidate-onboard",
+            "candidate_id": "insight-analyst",
+            "candidate_handle": "insight-analyst",
+            "candidate_version": "1.2.0",
+        },
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await update_candidate_workflow(
+            CandidateUpdateRequest(
+                workflow_id=existing_wf.id,
+                candidate_id="insight-analyst",
+            ),
+            repo,  # type: ignore[arg-type]
+            _MOCK_WORKSPACE,  # type: ignore[arg-type]
+        )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail["code"] == "candidate.no_update_available"
+    assert repo.versions_created == 0
+
+
+@pytest.mark.asyncio()
+async def test_update_candidate_workflow_rejects_unversioned_candidate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    existing_wf = _make_workflow(uuid4())
+    unversioned = _SAMPLE.model_copy(update={"version": None, "updates": []})
+
+    async def fake_get_candidates() -> list[CandidateItem]:
+        return [unversioned]
+
+    monkeypatch.setattr(candidates_router, "get_candidates", fake_get_candidates)
+    repo = _Repository(
+        existing_workflow=existing_wf,
+        latest_metadata={
+            "source": "candidate-onboard",
+            "candidate_id": "insight-analyst",
+            "candidate_handle": "insight-analyst",
+            "candidate_version": "1.1.0",
+        },
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await update_candidate_workflow(
+            CandidateUpdateRequest(
+                workflow_id=existing_wf.id,
+                candidate_id="insight-analyst",
+            ),
+            repo,  # type: ignore[arg-type]
+            _MOCK_WORKSPACE,  # type: ignore[arg-type]
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail["code"] == "candidate.unversioned"
+    assert repo.versions_created == 0
+
+
+@pytest.mark.asyncio()
+async def test_update_candidate_workflow_rejects_unknown_installed_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    existing_wf = _make_workflow(uuid4())
+
+    async def fake_get_candidates() -> list[CandidateItem]:
+        return [_SAMPLE]
+
+    monkeypatch.setattr(candidates_router, "get_candidates", fake_get_candidates)
+    repo = _Repository(
+        existing_workflow=existing_wf,
+        latest_metadata={
+            "source": "candidate-onboard",
+            "candidate_id": "insight-analyst",
+            "candidate_handle": "insight-analyst",
+        },
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await update_candidate_workflow(
+            CandidateUpdateRequest(
+                workflow_id=existing_wf.id,
+                candidate_id="insight-analyst",
+            ),
+            repo,  # type: ignore[arg-type]
+            _MOCK_WORKSPACE,  # type: ignore[arg-type]
+        )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail["code"] == "candidate.installed_version_unknown"
+    assert repo.versions_created == 0
+
+
+@pytest.mark.asyncio()
+async def test_update_candidate_workflow_rejects_invalid_config_without_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    existing_wf = _make_workflow(uuid4())
+    candidate = _SAMPLE.model_copy(update={"config": {"configurable": "not-a-mapping"}})
+
+    async def fake_get_candidates() -> list[CandidateItem]:
+        return [candidate]
+
+    monkeypatch.setattr(candidates_router, "get_candidates", fake_get_candidates)
+    repo = _Repository(
+        existing_workflow=existing_wf,
+        latest_metadata={
+            "source": "candidate-onboard",
+            "candidate_id": "insight-analyst",
+            "candidate_handle": "insight-analyst",
+            "candidate_version": "1.1.0",
+        },
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await update_candidate_workflow(
+            CandidateUpdateRequest(
+                workflow_id=existing_wf.id,
+                candidate_id="insight-analyst",
+            ),
+            repo,  # type: ignore[arg-type]
+            _MOCK_WORKSPACE,  # type: ignore[arg-type]
+        )
+
+    assert exc_info.value.status_code == 400
+    assert repo.versions_created == 0
+
+
+@pytest.mark.asyncio()
+async def test_update_candidate_workflow_rejects_missing_plugins_without_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    existing_wf = _make_workflow(uuid4())
+    candidate = _SAMPLE.model_copy(
+        update={
+            "metadata": {
+                "template": {
+                    "requiredPlugins": ["orcheo-plugin-lark-listener"],
+                }
+            }
+        }
+    )
+
+    async def fake_get_candidates() -> list[CandidateItem]:
+        return [candidate]
+
+    monkeypatch.setattr(candidates_router, "get_candidates", fake_get_candidates)
+    monkeypatch.setattr(
+        candidates_router,
+        "missing_required_plugins",
+        lambda required_plugins: list(required_plugins),
+    )
+    repo = _Repository(
+        existing_workflow=existing_wf,
+        latest_metadata={
+            "source": "candidate-onboard",
+            "candidate_id": "insight-analyst",
+            "candidate_handle": "insight-analyst",
+            "candidate_version": "1.1.0",
+        },
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await update_candidate_workflow(
+            CandidateUpdateRequest(
+                workflow_id=existing_wf.id,
+                candidate_id="insight-analyst",
+            ),
+            repo,  # type: ignore[arg-type]
+            _MOCK_WORKSPACE,  # type: ignore[arg-type]
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail["code"] == "candidate.missing_plugins"
+    assert repo.versions_created == 0
+
+
+@pytest.mark.asyncio()
+async def test_update_candidate_workflow_rejects_script_ingestion_without_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    existing_wf = _make_workflow(uuid4())
+    candidate = _SAMPLE.model_copy(update={"script": "invalid python {{{"})
+
+    async def fake_get_candidates() -> list[CandidateItem]:
+        return [candidate]
+
+    monkeypatch.setattr(candidates_router, "get_candidates", fake_get_candidates)
+    repo = _Repository(
+        existing_workflow=existing_wf,
+        latest_metadata={
+            "source": "candidate-onboard",
+            "candidate_id": "insight-analyst",
+            "candidate_handle": "insight-analyst",
+            "candidate_version": "1.1.0",
+        },
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await update_candidate_workflow(
+            CandidateUpdateRequest(
+                workflow_id=existing_wf.id,
+                candidate_id="insight-analyst",
+            ),
+            repo,  # type: ignore[arg-type]
+            _MOCK_WORKSPACE,  # type: ignore[arg-type]
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail["code"] == "candidate.script_ingestion_failed"
+    assert repo.versions_created == 0

--- a/tests/sdk/test_cli_workflow_frontmatter.py
+++ b/tests/sdk/test_cli_workflow_frontmatter.py
@@ -92,6 +92,10 @@ def test_workflow_frontmatter_is_not_empty_when_populated() -> None:
     assert not frontmatter.WorkflowFrontmatter(subtitle="x").is_empty
     assert not frontmatter.WorkflowFrontmatter(notes="x").is_empty
     assert not frontmatter.WorkflowFrontmatter(metadata={"a": "b"}).is_empty
+    assert not frontmatter.WorkflowFrontmatter(version="1.0.0").is_empty
+    assert not frontmatter.WorkflowFrontmatter(
+        updates=[frontmatter.WorkflowUpdateNote(version="1.0.0", summary="x")]
+    ).is_empty
 
 
 def test_parse_returns_empty_when_no_block() -> None:
@@ -144,6 +148,59 @@ def test_parse_extracts_notes_and_metadata_table() -> None:
         "required_plugins": ["telegram-plugin"],
     }
     assert not fm.is_empty
+
+
+def test_parse_extracts_version_and_sorted_update_notes() -> None:
+    source = (
+        "# /// orcheo\n"
+        '# name = "Versioned"\n'
+        '# version = "1.3.0"\n'
+        "#\n"
+        "# [[updates]]\n"
+        '# version = "1.2.0"\n'
+        '# summary = "Improves summaries."\n'
+        "#\n"
+        "# [[updates]]\n"
+        '# version = "1.3.0"\n'
+        '# summary = "Adds source checks."\n'
+        '# migration = "Review custom prompts."\n'
+        "# ///\n"
+    )
+
+    fm = frontmatter.parse_workflow_frontmatter(source)
+
+    assert fm.version == "1.3.0"
+    assert fm.updates == [
+        frontmatter.WorkflowUpdateNote(
+            version="1.3.0",
+            summary="Adds source checks.",
+            migration="Review custom prompts.",
+        ),
+        frontmatter.WorkflowUpdateNote(
+            version="1.2.0",
+            summary="Improves summaries.",
+            migration=None,
+        ),
+    ]
+
+
+@pytest.mark.parametrize("version", ["1", "v1.2.3", "1.2", "1.2.3-beta", "01.2.3"])
+def test_parse_rejects_invalid_semver(version: str) -> None:
+    source = f'# /// orcheo\n# version = "{version}"\n# ///\n'
+    with pytest.raises(frontmatter.CLIError, match="strict SemVer"):
+        frontmatter.parse_workflow_frontmatter(source)
+
+
+def test_parse_rejects_malformed_update_notes() -> None:
+    source = '# /// orcheo\n# [[updates]]\n# version = "1.0.0"\n# ///\n'
+    with pytest.raises(frontmatter.CLIError, match="requires 'summary'"):
+        frontmatter.parse_workflow_frontmatter(source)
+
+
+def test_compare_strict_semver_orders_segments() -> None:
+    assert frontmatter.compare_strict_semver("2.0.0", "1.9.9") == 1
+    assert frontmatter.compare_strict_semver("1.3.0", "1.3.0") == 0
+    assert frontmatter.compare_strict_semver("1.2.9", "1.3.0") == -1
 
 
 def test_parse_rejects_non_table_metadata() -> None:


### PR DESCRIPTION
## Summary

- Add strict candidate workflow version metadata and update notes to SDK frontmatter parsing, candidate schemas, and onboarding metadata.
- Add a backend candidate update endpoint that validates source identity and SemVer progression before appending a new workflow version from the latest candidate release.
- Surface candidate update availability in the Studio workflow gallery with tooltip context, major-update warnings, release-note details, and update/refresh wiring.
- Document the new candidate version frontmatter fields and include planning artifacts for the candidate workflow version update initiative.

## Testing

- `uv run pytest tests/backend/test_candidates_service.py tests/backend/test_routers_candidates.py tests/sdk/test_cli_workflow_frontmatter.py -q`
- `npm test -- --run src/features/workflow/lib/candidate-version-updates.test.ts src/features/workflow/pages/workflow-gallery/workflow-card.test.tsx src/features/workflow/pages/workflow-gallery/workflow-gallery-tabs.test.tsx`