### PR TITLE
Add host-installed CLI coding-agent workflow nodes

### DIFF
--- a/apps/desktop/macos/README.md
+++ b/apps/desktop/macos/README.md
@@ -56,6 +56,12 @@ bash apps/desktop/macos/scripts/clean.sh
 Postgres, and Playwright Chromium under `apps/desktop/macos/bundle/`, compiles
 the Swift shell, and assembles `apps/desktop/macos/build/Orcheo.app`.
 
+The bundled Chromium version is pinned by the `playwright` package version in
+`uv.lock` (Playwright maps 1:1 to a Chromium revision). Resources are staged
+with `uv run --frozen`, so the browser cannot silently drift from the locked
+dependencies; bump it by updating `playwright` in `uv.lock`. The resolved
+revision is printed during the build (`Bundled Playwright browser: chromium-…`).
+
 `dev.sh` skips packaging entirely: it builds Studio and runs the shell from the
 checkout with `swift run`, resolving the repo root from the working directory.
 

--- a/apps/desktop/macos/scripts/prepare-resources.sh
+++ b/apps/desktop/macos/scripts/prepare-resources.sh
@@ -104,10 +104,13 @@ if [[ "${ORCHEO_MACOS_BUNDLE_PLAYWRIGHT:-true}" != "false" ]]; then
   # use macOS's standard versioned framework layout whose internal symlinks
   # must be preserved as-is (dereferencing would duplicate the framework
   # payload 2-3x over).
+  # --frozen: install against the committed uv.lock without re-locking, so the
+  # bundled Chromium cannot silently drift from the locked dependencies (see
+  # README). Fails loudly if pyproject.toml/uv.lock are out of sync.
   (
     cd "${ROOT_DIR}"
     PLAYWRIGHT_BROWSERS_PATH="${STAGED_PLAYWRIGHT}" \
-      uv run python -m playwright install chromium chromium-headless-shell
+      uv run --frozen python -m playwright install chromium chromium-headless-shell
   )
 fi
 

--- a/apps/desktop/tauri/README.md
+++ b/apps/desktop/tauri/README.md
@@ -60,6 +60,15 @@ Studio with `VITE_ORCHEO_AUTH_DISABLED=true` unless that variable is already
 set, then stage a trimmed repo, bundled Postgres, and Playwright Chromium under
 `apps/desktop/tauri/bundle/` for inclusion in the Tauri app.
 
+The bundled Chromium version is pinned by the `playwright` package version
+(Playwright maps 1:1 to a Chromium revision). Local-source builds stage it with
+`uv run --frozen` against `uv.lock`, and the published-release build
+(`ORCHEO_TAURI_USE_PUBLISHED_RELEASES`) resolves it from the released Orcheo
+packages; both print the resolved revision during the build
+(`Bundled Playwright browser: chromium-…`). The Tauri UI itself renders in the
+OS WebView (WKWebView / WebView2 / WebKitGTK), which is provided by the platform
+and is not pinnable.
+
 If the build fails with `failed to run 'cargo metadata'`, Cargo is not available
 on `PATH`; install Rust with rustup and restart the shell before rebuilding.
 

--- a/apps/desktop/tauri/scripts/prepare-resources.mjs
+++ b/apps/desktop/tauri/scripts/prepare-resources.mjs
@@ -316,10 +316,14 @@ if (process.env.ORCHEO_TAURI_BUNDLE_PLAYWRIGHT !== "false") {
       },
     );
   } else {
+    // --frozen: install against the committed uv.lock without re-locking, so
+    // the bundled Chromium cannot silently drift from the locked dependencies
+    // (see README). Fails loudly if pyproject.toml/uv.lock are out of sync.
     run(
       "uv",
       [
         "run",
+        "--frozen",
         "python",
         "-m",
         "playwright",

--- a/docs/cli_agent_nodes.md
+++ b/docs/cli_agent_nodes.md
@@ -1,0 +1,126 @@
+# CLI Coding-Agent Nodes
+
+Orcheo can drive a **host-installed, pre-authenticated CLI coding agent**
+(Codex, Claude Code, Antigravity) as a non-interactive workflow step. Each node
+resolves the provider binary on `PATH`, runs it once with your prompt, and
+returns its captured output.
+
+| Node | Binary | Provider CLI |
+| --- | --- | --- |
+| `CodexNode` | `codex` | OpenAI Codex CLI |
+| `ClaudeCodeNode` | `claude` | Claude Code |
+| `AntigravityNode` | `agy` | Antigravity CLI |
+
+!!! danger "Trusted workflows only — runs unsandboxed with the worker's privileges"
+
+    These nodes invoke their CLI with **all safety rails disabled**
+    (`--dangerously-bypass-approvals-and-sandbox` /
+    `--dangerously-skip-permissions`). The agent executes arbitrary commands
+    with the **worker process's own host privileges** — no sandbox, no approval
+    prompts.
+
+    - They register as **restricted** (`NodeMetadata(restricted=True)`), so
+      [restricted-mode](sandboxed_custom_workflows.md) (untrusted-author)
+      ingestion rejects them. They are only available to trusted, first-party
+      workflows.
+    - `restricted=True` only stops an untrusted *author* from registering the
+      node. It does **not** stop a trusted workflow from piping untrusted
+      *data* into it at runtime. `prompt`, `system_prompt`, and
+      `working_directory` are ordinary template-interpolated fields
+      (`{{...}}`), so interpolating a webhook body, an inbound message, or
+      upstream tool output into them hands an unattended coding agent
+      attacker-controlled instructions.
+    - **Only populate these fields from trusted, workflow-controlled values.**
+      Never feed unsanitized external input into a CLI agent node.
+
+## Host setup
+
+The node does **not** install or authenticate anything. Before a workflow can
+use it, an operator must install and log in to the provider CLI on **every
+worker host** that runs the workflow:
+
+```bash
+# Claude Code — install, then create a long-lived token
+npm install -g @anthropic-ai/claude-code
+claude setup-token
+
+# OpenAI Codex — install, then authenticate
+npm install -g @openai/codex
+codex login
+
+# Antigravity — install and authenticate per the provider's instructions
+```
+
+No credentials are materialized, probed, or injected by the node — it only
+resolves the executable on `PATH` and runs it. If the binary is missing the node
+raises before spawning any subprocess:
+
+```text
+'claude' was not found on PATH. Install and authenticate the claude CLI on this
+host before running node '<name>'.
+```
+
+## Configuration
+
+All three nodes share the same fields (from `CLIAgentNode`):
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `prompt` | `str` | *(required)* | Task instructions sent to the agent. |
+| `system_prompt` | `str \| None` | `None` | Optional system instructions. Providers without a dedicated flag fold this into the prompt as `System instructions:\n…\n\nTask:\n…`. |
+| `working_directory` | `str \| None` | `None` | Directory the CLI runs in. Defaults to the worker's cwd; must exist on the host or the node raises. |
+| `timeout_seconds` | `int` | `600` | Max time to wait for the process. On timeout the whole process group is terminated (`SIGTERM`, then `SIGKILL`). |
+| `raise_on_error` | `bool` | `True` | Raise if the CLI exits non-zero or times out. Set `False` to surface the failure in the output instead. |
+
+## Output contract
+
+On success the node returns:
+
+| Key | Type | Description |
+| --- | --- | --- |
+| `output` | `str` | Captured stdout. |
+| `stderr` | `str` | Captured stderr. |
+| `exit_code` | `int \| None` | Process exit code (`None` if it timed out before exiting). |
+| `timed_out` | `bool` | Whether the run hit `timeout_seconds`. |
+| `duration_seconds` | `float` | Wall-clock run time. |
+
+## Error contract
+
+- **Missing binary** or **non-existent `working_directory`** → `RuntimeError`
+  before any subprocess is spawned.
+- With `raise_on_error=True` (default), a **non-zero exit** or **timeout**
+  raises `RuntimeError` carrying the captured `stderr` (or `stdout`).
+- With `raise_on_error=False`, the same failures are reported through the output
+  fields (`exit_code`, `timed_out`, `stderr`) without raising.
+- If the workflow run is **cancelled**, the node terminates the CLI process
+  group before propagating the cancellation, so the unsandboxed agent cannot
+  keep mutating the working tree after the run is reported cancelled.
+
+## Example
+
+```python
+from orcheo.graph import StateGraph, START, END
+from orcheo.graph.state import State
+from orcheo.nodes import ClaudeCodeNode
+
+
+async def orcheo_workflow() -> StateGraph:
+    graph = StateGraph(State)
+    graph.add_node(
+        "fix_lint",
+        ClaudeCodeNode(
+            name="fix_lint",
+            # Trusted, workflow-controlled instruction — NOT external input.
+            prompt="Run the linter and fix every reported issue.",
+            system_prompt="Only touch files under src/. Keep changes minimal.",
+            working_directory="/srv/checkouts/my-repo",
+            timeout_seconds=900,
+        ),
+    )
+    graph.add_edge(START, "fix_lint")
+    graph.add_edge("fix_lint", END)
+    return graph
+```
+
+Swap `ClaudeCodeNode` for `CodexNode` or `AntigravityNode` — the fields are
+identical.

--- a/docs/node_catalog.md
+++ b/docs/node_catalog.md
@@ -1,6 +1,6 @@
 # Built-in Node Catalog
 
-Orcheo currently ships with **138 built-in nodes** across **21 categories**.
+Orcheo currently ships with **145 built-in nodes** across **21 categories**.
 
 This catalog is sourced from runtime node registry metadata. Run `orcheo node list` to inspect the nodes available in your environment, including custom registrations.
 
@@ -8,7 +8,7 @@ This catalog is sourced from runtime node registry metadata. Run `orcheo node li
 
 | Category | Node Count |
 |---|---:|
-| AI (`ai`) | 4 |
+| AI (`ai`) | 7 |
 | Agentensor (`agentensor`) | 1 |
 | Base (`base`) | 1 |
 | Browser (`browser`) | 6 |
@@ -19,13 +19,13 @@ This catalog is sourced from runtime node registry metadata. Run `orcheo node li
 | Lark (`lark`) | 2 |
 | LinkedIn (`linkedin`) | 1 |
 | Logic (`logic`) | 3 |
-| Messaging (`messaging`) | 4 |
+| Messaging (`messaging`) | 6 |
 | MongoDB (`mongodb`) | 9 |
 | RSS (`rss`) | 1 |
 | Slack (`slack`) | 2 |
 | Storage (`storage`) | 3 |
 | Telegram (`telegram`) | 1 |
-| Trigger (`trigger`) | 7 |
+| Trigger (`trigger`) | 9 |
 | Utility (`utility`) | 5 |
 | WeCom (`wecom`) | 9 |
 | Workflow (`workflow`) | 17 |
@@ -36,6 +36,9 @@ This catalog is sourced from runtime node registry metadata. Run `orcheo node li
 |---|---|
 | **AgentNode** | Execute an AI agent with tools |
 | **AgentReplyExtractorNode** | Extract the final assistant reply from agent messages |
+| **AntigravityNode** | Execute the Antigravity CLI as a non-interactive coding-agent step. Runs unsandboxed with the worker's privileges; trusted workflows only. |
+| **ClaudeCodeNode** | Execute Claude Code as a non-interactive coding-agent step. Runs unsandboxed with the worker's privileges; trusted workflows only. |
+| **CodexNode** | Execute the Codex CLI as a non-interactive coding-agent step. Runs unsandboxed with the worker's privileges; trusted workflows only. |
 | **DeepAgentNode** | Execute an autonomous deep-research agent with configurable iteration depth for multi-step tool use and synthesis |
 | **LLMNode** | Execute a text-only LLM call |
 
@@ -173,6 +176,8 @@ This catalog is sourced from runtime node registry metadata. Run `orcheo node li
 | **MessageQQNode** | Send a message to QQ using AppID and client secret. |
 | **MessageTelegramNode** | Send message to Telegram |
 | **TelegramSendDocumentNode** | Send a document file to Telegram |
+| **WechatReplyNode** | Reply to WeChat messages through OpenClaw HTTP APIs. |
+| **WeixinReplyNode** | Backwards-compatible alias for WechatReplyNode. |
 
 ## MongoDB Nodes
 
@@ -226,6 +231,8 @@ This catalog is sourced from runtime node registry metadata. Run `orcheo node li
 | **QQBotListenerNode** | Receive QQ bot messages through the managed Gateway. |
 | **TelegramBotListenerNode** | Receive Telegram bot updates through managed long polling. |
 | **WebhookTriggerNode** | Configure an HTTP webhook trigger. |
+| **WechatListenerPluginNode** | Receive WeChat events through the plugin contract. |
+| **WeixinListenerPluginNode** | Backwards-compatible alias for WechatListenerPluginNode. |
 
 ## Utility Nodes
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
       - Releasing: releasing.md
   - Reference:
       - Node Catalog: node_catalog.md
+      - CLI Coding-Agent Nodes: cli_agent_nodes.md
       - Workflow Config Annotations: workflow_config_annotations.md
       - CLI Reference: cli_reference.md
       - SDK Reference: sdk_reference.md

--- a/src/orcheo/nodes/__init__.py
+++ b/src/orcheo/nodes/__init__.py
@@ -2,6 +2,7 @@
 
 from orcheo.nodes.ai import AgentNode, AgentReplyExtractorNode, LLMNode
 from orcheo.nodes.ai.agentensor import AgentensorNode
+from orcheo.nodes.ai.cli import AntigravityNode, ClaudeCodeNode, CodexNode
 from orcheo.nodes.ai.deep_agent import DeepAgentNode
 from orcheo.nodes.browser import (
     BrowserActionNode,
@@ -129,6 +130,9 @@ __all__ = [
     "BrowserScriptNode",
     "BrowserCloseNode",
     "AgentensorNode",
+    "ClaudeCodeNode",
+    "CodexNode",
+    "AntigravityNode",
     "HttpRequestNode",
     "HtmlTextTransformNode",
     "JsonProcessingNode",

--- a/src/orcheo/nodes/ai/__init__.py
+++ b/src/orcheo/nodes/ai/__init__.py
@@ -33,6 +33,7 @@ from .agent import (
     random,
 )
 from .agentensor import AgentensorNode
+from .cli import AntigravityNode, ClaudeCodeNode, CLIAgentNode, CodexNode
 from .deep_agent import DeepAgentNode
 
 
@@ -59,6 +60,10 @@ __all__ = [
     "random",
     "AgentensorNode",
     "DeepAgentNode",
+    "ClaudeCodeNode",
+    "CodexNode",
+    "CLIAgentNode",
+    "AntigravityNode",
     "_create_workflow_tool_func",
     "build_ai_trace_metadata",
     "_llm_trace_metadata",

--- a/src/orcheo/nodes/ai/cli/__init__.py
+++ b/src/orcheo/nodes/ai/cli/__init__.py
@@ -1,0 +1,15 @@
+"""Host-installed CLI coding-agent nodes."""
+
+from __future__ import annotations
+from orcheo.nodes.ai.cli.antigravity import AntigravityNode
+from orcheo.nodes.ai.cli.base import CLIAgentNode
+from orcheo.nodes.ai.cli.claude_code import ClaudeCodeNode
+from orcheo.nodes.ai.cli.codex import CodexNode
+
+
+__all__ = [
+    "AntigravityNode",
+    "CLIAgentNode",
+    "ClaudeCodeNode",
+    "CodexNode",
+]

--- a/src/orcheo/nodes/ai/cli/antigravity.py
+++ b/src/orcheo/nodes/ai/cli/antigravity.py
@@ -1,0 +1,38 @@
+"""Antigravity CLI workflow node."""
+
+from __future__ import annotations
+from orcheo.nodes.ai.cli.base import CLIAgentNode
+from orcheo.nodes.registry import NodeMetadata, registry
+
+
+@registry.register(
+    NodeMetadata(
+        name="AntigravityNode",
+        description=(
+            "Execute the Antigravity CLI as a non-interactive coding-agent step."
+        ),
+        category="ai",
+        restricted=True,
+    )
+)
+class AntigravityNode(CLIAgentNode):
+    """Workflow node for a pre-authenticated, host-installed Antigravity CLI."""
+
+    executable_name = "agy"
+
+    def build_command(self, executable: str) -> list[str]:
+        """Build a non-interactive Antigravity CLI invocation."""
+        combined_prompt = self.prompt
+        if self.system_prompt:
+            combined_prompt = (
+                f"System instructions:\n{self.system_prompt.strip()}\n\n"
+                f"Task:\n{self.prompt}"
+            )
+        return [
+            executable,
+            "--dangerously-skip-permissions",
+            "--print-timeout",
+            f"{self.timeout_seconds}s",
+            "--print",
+            combined_prompt,
+        ]

--- a/src/orcheo/nodes/ai/cli/antigravity.py
+++ b/src/orcheo/nodes/ai/cli/antigravity.py
@@ -9,30 +9,31 @@ from orcheo.nodes.registry import NodeMetadata, registry
     NodeMetadata(
         name="AntigravityNode",
         description=(
-            "Execute the Antigravity CLI as a non-interactive coding-agent step."
+            "Execute the Antigravity CLI as a non-interactive coding-agent step. "
+            "Runs unsandboxed with the worker's privileges; trusted workflows only."
         ),
         category="ai",
         restricted=True,
     )
 )
 class AntigravityNode(CLIAgentNode):
-    """Workflow node for a pre-authenticated, host-installed Antigravity CLI."""
+    """Workflow node for a pre-authenticated, host-installed Antigravity CLI.
+
+    Invoked with ``--dangerously-skip-permissions``: the agent runs with no
+    permission prompts and the worker's host privileges. See
+    :class:`CLIAgentNode` for the runtime-input warning — never feed unsanitized
+    external data into ``prompt``/``system_prompt``/``working_directory``.
+    """
 
     executable_name = "agy"
 
     def build_command(self, executable: str) -> list[str]:
         """Build a non-interactive Antigravity CLI invocation."""
-        combined_prompt = self.prompt
-        if self.system_prompt:
-            combined_prompt = (
-                f"System instructions:\n{self.system_prompt.strip()}\n\n"
-                f"Task:\n{self.prompt}"
-            )
         return [
             executable,
             "--dangerously-skip-permissions",
             "--print-timeout",
             f"{self.timeout_seconds}s",
             "--print",
-            combined_prompt,
+            self._combined_prompt(),
         ]

--- a/src/orcheo/nodes/ai/cli/base.py
+++ b/src/orcheo/nodes/ai/cli/base.py
@@ -1,0 +1,198 @@
+"""Base class for nodes that run a host-installed CLI coding agent.
+
+These nodes assume the provider CLI (Codex, Claude Code, Antigravity, ...) is
+already installed and authenticated on the host running the workflow worker
+by an operator (e.g. via ``claude setup-token`` or ``codex login``). No
+credentials are materialized, probed, or injected by the node itself — it
+only resolves the executable on ``PATH`` and runs it non-interactively.
+
+Because the node executes an arbitrary host subprocess with the worker's own
+privileges, every concrete subclass registers with ``NodeMetadata(restricted=
+True)`` so restricted-mode (untrusted-author) workflow ingestion rejects it;
+see ``orcheo.graph.ir.node_policy``. It is only available to trusted,
+first-party workflow sources.
+"""
+
+from __future__ import annotations
+import asyncio
+import os
+import shutil
+import signal
+import time
+from abc import abstractmethod
+from pathlib import Path
+from typing import Any, ClassVar
+from langchain_core.runnables import RunnableConfig
+from pydantic import BaseModel, Field
+from orcheo.graph.state import State
+from orcheo.nodes.base import TaskNode
+
+
+class ProcessExecutionResult(BaseModel):
+    """Captured result of a managed subprocess invocation."""
+
+    command: list[str]
+    stdout: str = ""
+    stderr: str = ""
+    exit_code: int | None = None
+    timed_out: bool = False
+    duration_seconds: float
+
+
+async def _read_stream(
+    stream: asyncio.StreamReader | None,
+    chunks: list[bytes],
+) -> None:
+    """Read one process stream until EOF."""
+    if stream is None:
+        return
+    while True:
+        chunk = await stream.read(4096)
+        if not chunk:
+            return
+        chunks.append(chunk)
+
+
+async def _terminate_process_group(process: asyncio.subprocess.Process) -> int | None:
+    """Terminate a subprocess process group and return the final exit code."""
+    if process.returncode is not None:
+        return process.returncode
+
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:  # pragma: no cover - race with exit
+        return await process.wait()
+
+    try:
+        return await asyncio.wait_for(process.wait(), timeout=2)
+    except TimeoutError:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:  # pragma: no cover - race with exit
+            pass
+        return await process.wait()
+
+
+async def execute_process(
+    command: list[str],
+    *,
+    cwd: Path | None = None,
+    timeout_seconds: int | float | None = None,
+) -> ProcessExecutionResult:
+    """Execute ``command``, capturing output and enforcing an optional timeout."""
+    started_at = time.monotonic()
+    process = await asyncio.create_subprocess_exec(
+        *command,
+        cwd=str(cwd) if cwd is not None else None,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        start_new_session=True,
+    )
+
+    stdout_chunks: list[bytes] = []
+    stderr_chunks: list[bytes] = []
+    stdout_task = asyncio.create_task(_read_stream(process.stdout, stdout_chunks))
+    stderr_task = asyncio.create_task(_read_stream(process.stderr, stderr_chunks))
+
+    timed_out = False
+    exit_code: int | None
+    try:
+        if timeout_seconds is None:
+            exit_code = await process.wait()
+        else:
+            exit_code = await asyncio.wait_for(process.wait(), timeout_seconds)
+    except TimeoutError:
+        timed_out = True
+        exit_code = await _terminate_process_group(process)
+
+    await asyncio.gather(stdout_task, stderr_task)
+    duration_seconds = time.monotonic() - started_at
+    return ProcessExecutionResult(
+        command=command,
+        stdout=b"".join(stdout_chunks).decode("utf-8", errors="replace"),
+        stderr=b"".join(stderr_chunks).decode("utf-8", errors="replace"),
+        exit_code=exit_code,
+        timed_out=timed_out,
+        duration_seconds=duration_seconds,
+    )
+
+
+class CLIAgentNode(TaskNode):
+    """Run a pre-authenticated, host-installed CLI coding agent non-interactively."""
+
+    executable_name: ClassVar[str]
+    """Binary name resolved via ``PATH``; set by each provider subclass."""
+
+    prompt: str = Field(description="Task instructions sent to the CLI agent.")
+    system_prompt: str | None = Field(
+        default=None,
+        description="Optional system instructions prepended to the task prompt.",
+    )
+    working_directory: str | None = Field(
+        default=None,
+        description="Directory the CLI process runs in. Defaults to the worker's cwd.",
+    )
+    timeout_seconds: int = Field(
+        default=600,
+        gt=0,
+        description="Maximum time in seconds to wait for the CLI process to finish.",
+    )
+    raise_on_error: bool = Field(
+        default=True,
+        description="Raise if the CLI exits non-zero or the run times out.",
+    )
+
+    @abstractmethod
+    def build_command(self, executable: str) -> list[str]:
+        """Return the non-interactive CLI invocation for this provider."""
+
+    def _resolve_executable(self) -> str:
+        """Locate the provider CLI on ``PATH``."""
+        resolved = shutil.which(self.executable_name)
+        if resolved is None:
+            msg = (
+                f"'{self.executable_name}' was not found on PATH. Install and "
+                f"authenticate the {self.executable_name} CLI on this host "
+                f"before running node '{self.name}'."
+            )
+            raise RuntimeError(msg)
+        return resolved
+
+    def _resolve_working_directory(self) -> Path | None:
+        """Validate and return the configured working directory, if any."""
+        if not self.working_directory:
+            return None
+        cwd = Path(self.working_directory)
+        if not cwd.is_dir():
+            msg = (
+                f"working_directory '{cwd}' does not exist on this host. Set "
+                f"it to a real directory before running node '{self.name}'."
+            )
+            raise RuntimeError(msg)
+        return cwd
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Run the CLI agent as a subprocess and return its captured output."""
+        executable = self._resolve_executable()
+        command = self.build_command(executable)
+        cwd = self._resolve_working_directory()
+        result = await execute_process(
+            command, cwd=cwd, timeout_seconds=self.timeout_seconds
+        )
+
+        if self.raise_on_error and (result.timed_out or result.exit_code != 0):
+            reason = "timed out" if result.timed_out else f"exited {result.exit_code}"
+            detail = result.stderr.strip() or result.stdout.strip()
+            msg = f"'{self.executable_name}' {reason}: {detail}"
+            raise RuntimeError(msg)
+
+        return {
+            "output": result.stdout,
+            "stderr": result.stderr,
+            "exit_code": result.exit_code,
+            "timed_out": result.timed_out,
+            "duration_seconds": result.duration_seconds,
+        }
+
+
+__all__ = ["CLIAgentNode", "ProcessExecutionResult", "execute_process"]

--- a/src/orcheo/nodes/ai/cli/base.py
+++ b/src/orcheo/nodes/ai/cli/base.py
@@ -39,6 +39,13 @@ class ProcessExecutionResult(BaseModel):
     duration_seconds: float
 
 
+# Grace period for draining stdout/stderr after the process has been waited on.
+# Readers normally hit EOF immediately once the process exits; this only bounds
+# the pathological case where a detached grandchild keeps the inherited pipe
+# open, so the node can never hang past its timeout.
+_READER_DRAIN_TIMEOUT = 5.0
+
+
 async def _read_stream(
     stream: asyncio.StreamReader | None,
     chunks: list[bytes],
@@ -51,6 +58,28 @@ async def _read_stream(
         if not chunk:
             return
         chunks.append(chunk)
+
+
+async def _drain_readers(
+    tasks: list[asyncio.Task[None]],
+    *,
+    timeout: float | None,
+) -> None:
+    """Wait for the stream readers to finish, cancelling any that overrun.
+
+    Normally the readers hit EOF and complete the moment the process exits. A
+    detached grandchild that inherited the stdout/stderr pipe can keep its write
+    end open after the main process is gone, so the wait is bounded to avoid
+    blocking forever on output that will never arrive.
+    """
+    if not tasks:
+        return
+    try:
+        await asyncio.wait_for(asyncio.gather(*tasks, return_exceptions=True), timeout)
+    except TimeoutError:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
 
 
 async def _terminate_process_group(process: asyncio.subprocess.Process) -> int | None:
@@ -91,8 +120,10 @@ async def execute_process(
 
     stdout_chunks: list[bytes] = []
     stderr_chunks: list[bytes] = []
-    stdout_task = asyncio.create_task(_read_stream(process.stdout, stdout_chunks))
-    stderr_task = asyncio.create_task(_read_stream(process.stderr, stderr_chunks))
+    reader_tasks = [
+        asyncio.create_task(_read_stream(process.stdout, stdout_chunks)),
+        asyncio.create_task(_read_stream(process.stderr, stderr_chunks)),
+    ]
 
     timed_out = False
     exit_code: int | None
@@ -104,8 +135,17 @@ async def execute_process(
     except TimeoutError:
         timed_out = True
         exit_code = await _terminate_process_group(process)
+    except asyncio.CancelledError:
+        # Cancellation (e.g. the workflow run was cancelled) bypasses the
+        # timeout cleanup path. These CLIs run with sandbox/permission bypasses,
+        # so leaving the process group alive would let it keep mutating the
+        # working tree after Orcheo reports the run cancelled. Tear the group
+        # and its readers down, then propagate the cancellation.
+        await _terminate_process_group(process)
+        await _drain_readers(reader_tasks, timeout=_READER_DRAIN_TIMEOUT)
+        raise
 
-    await asyncio.gather(stdout_task, stderr_task)
+    await _drain_readers(reader_tasks, timeout=_READER_DRAIN_TIMEOUT)
     duration_seconds = time.monotonic() - started_at
     return ProcessExecutionResult(
         command=command,
@@ -118,12 +158,32 @@ async def execute_process(
 
 
 class CLIAgentNode(TaskNode):
-    """Run a pre-authenticated, host-installed CLI coding agent non-interactively."""
+    """Run a pre-authenticated, host-installed CLI coding agent non-interactively.
+
+    .. warning::
+
+        Provider subclasses invoke the CLI with its sandbox/permission guards
+        disabled, so the agent runs arbitrary commands with the worker's own
+        host privileges. ``restricted=True`` only blocks an untrusted *author*
+        from registering the node during restricted-mode ingestion — it does not
+        stop a trusted workflow from piping untrusted *data* into it at runtime.
+        ``prompt``, ``system_prompt``, and ``working_directory`` are ordinary
+        template-interpolated fields (``{{...}}``), so feeding unsanitized
+        external input (a webhook body, an inbound message, tool output, ...)
+        into them hands an unattended coding agent attacker-controlled
+        instructions. Only ever populate these fields from trusted, workflow-
+        controlled values.
+    """
 
     executable_name: ClassVar[str]
     """Binary name resolved via ``PATH``; set by each provider subclass."""
 
-    prompt: str = Field(description="Task instructions sent to the CLI agent.")
+    prompt: str = Field(
+        description=(
+            "Task instructions sent to the CLI agent. Runs unsandboxed with the "
+            "worker's privileges — never interpolate unsanitized external input."
+        )
+    )
     system_prompt: str | None = Field(
         default=None,
         description="Optional system instructions prepended to the task prompt.",
@@ -146,6 +206,18 @@ class CLIAgentNode(TaskNode):
     def build_command(self, executable: str) -> list[str]:
         """Return the non-interactive CLI invocation for this provider."""
 
+    def _combined_prompt(self) -> str:
+        """Fold ``system_prompt`` into the task prompt.
+
+        Used by providers whose CLI has no dedicated system-prompt flag.
+        """
+        if not self.system_prompt:
+            return self.prompt
+        return (
+            f"System instructions:\n{self.system_prompt.strip()}\n\n"
+            f"Task:\n{self.prompt}"
+        )
+
     def _resolve_executable(self) -> str:
         """Locate the provider CLI on ``PATH``."""
         resolved = shutil.which(self.executable_name)
@@ -160,9 +232,10 @@ class CLIAgentNode(TaskNode):
 
     def _resolve_working_directory(self) -> Path | None:
         """Validate and return the configured working directory, if any."""
-        if not self.working_directory:
+        configured = (self.working_directory or "").strip()
+        if not configured:
             return None
-        cwd = Path(self.working_directory)
+        cwd = Path(configured)
         if not cwd.is_dir():
             msg = (
                 f"working_directory '{cwd}' does not exist on this host. Set "

--- a/src/orcheo/nodes/ai/cli/claude_code.py
+++ b/src/orcheo/nodes/ai/cli/claude_code.py
@@ -8,13 +8,22 @@ from orcheo.nodes.registry import NodeMetadata, registry
 @registry.register(
     NodeMetadata(
         name="ClaudeCodeNode",
-        description="Execute Claude Code as a non-interactive coding-agent step.",
+        description=(
+            "Execute Claude Code as a non-interactive coding-agent step. Runs "
+            "unsandboxed with the worker's privileges; trusted workflows only."
+        ),
         category="ai",
         restricted=True,
     )
 )
 class ClaudeCodeNode(CLIAgentNode):
-    """Workflow node for a pre-authenticated, host-installed Claude Code CLI."""
+    """Workflow node for a pre-authenticated, host-installed Claude Code CLI.
+
+    Invoked with ``--dangerously-skip-permissions``: the agent runs with no
+    permission prompts and the worker's host privileges. See
+    :class:`CLIAgentNode` for the runtime-input warning — never feed unsanitized
+    external data into ``prompt``/``system_prompt``/``working_directory``.
+    """
 
     executable_name = "claude"
 

--- a/src/orcheo/nodes/ai/cli/claude_code.py
+++ b/src/orcheo/nodes/ai/cli/claude_code.py
@@ -1,0 +1,33 @@
+"""Claude Code CLI workflow node."""
+
+from __future__ import annotations
+from orcheo.nodes.ai.cli.base import CLIAgentNode
+from orcheo.nodes.registry import NodeMetadata, registry
+
+
+@registry.register(
+    NodeMetadata(
+        name="ClaudeCodeNode",
+        description="Execute Claude Code as a non-interactive coding-agent step.",
+        category="ai",
+        restricted=True,
+    )
+)
+class ClaudeCodeNode(CLIAgentNode):
+    """Workflow node for a pre-authenticated, host-installed Claude Code CLI."""
+
+    executable_name = "claude"
+
+    def build_command(self, executable: str) -> list[str]:
+        """Build a non-interactive Claude Code invocation."""
+        command = [
+            executable,
+            "--dangerously-skip-permissions",
+            "--print",
+            self.prompt,
+            "--output-format",
+            "text",
+        ]
+        if self.system_prompt:
+            command.extend(["--append-system-prompt", self.system_prompt])
+        return command

--- a/src/orcheo/nodes/ai/cli/codex.py
+++ b/src/orcheo/nodes/ai/cli/codex.py
@@ -1,0 +1,35 @@
+"""Codex CLI workflow node."""
+
+from __future__ import annotations
+from orcheo.nodes.ai.cli.base import CLIAgentNode
+from orcheo.nodes.registry import NodeMetadata, registry
+
+
+@registry.register(
+    NodeMetadata(
+        name="CodexNode",
+        description="Execute the Codex CLI as a non-interactive coding-agent step.",
+        category="ai",
+        restricted=True,
+    )
+)
+class CodexNode(CLIAgentNode):
+    """Workflow node for a pre-authenticated, host-installed Codex CLI."""
+
+    executable_name = "codex"
+
+    def build_command(self, executable: str) -> list[str]:
+        """Build a non-interactive Codex CLI invocation."""
+        combined_prompt = self.prompt
+        if self.system_prompt:
+            combined_prompt = (
+                f"System instructions:\n{self.system_prompt.strip()}\n\n"
+                f"Task:\n{self.prompt}"
+            )
+        return [
+            executable,
+            "exec",
+            "--dangerously-bypass-approvals-and-sandbox",
+            "--skip-git-repo-check",
+            combined_prompt,
+        ]

--- a/src/orcheo/nodes/ai/cli/codex.py
+++ b/src/orcheo/nodes/ai/cli/codex.py
@@ -8,28 +8,31 @@ from orcheo.nodes.registry import NodeMetadata, registry
 @registry.register(
     NodeMetadata(
         name="CodexNode",
-        description="Execute the Codex CLI as a non-interactive coding-agent step.",
+        description=(
+            "Execute the Codex CLI as a non-interactive coding-agent step. Runs "
+            "unsandboxed with the worker's privileges; trusted workflows only."
+        ),
         category="ai",
         restricted=True,
     )
 )
 class CodexNode(CLIAgentNode):
-    """Workflow node for a pre-authenticated, host-installed Codex CLI."""
+    """Workflow node for a pre-authenticated, host-installed Codex CLI.
+
+    Invoked with ``--dangerously-bypass-approvals-and-sandbox``: the agent runs
+    with no sandbox and the worker's host privileges. See :class:`CLIAgentNode`
+    for the runtime-input warning — never feed unsanitized external data into
+    ``prompt``/``system_prompt``/``working_directory``.
+    """
 
     executable_name = "codex"
 
     def build_command(self, executable: str) -> list[str]:
         """Build a non-interactive Codex CLI invocation."""
-        combined_prompt = self.prompt
-        if self.system_prompt:
-            combined_prompt = (
-                f"System instructions:\n{self.system_prompt.strip()}\n\n"
-                f"Task:\n{self.prompt}"
-            )
         return [
             executable,
             "exec",
             "--dangerously-bypass-approvals-and-sandbox",
             "--skip-git-repo-check",
-            combined_prompt,
+            self._combined_prompt(),
         ]

--- a/tests/graph/ir/test_node_policy.py
+++ b/tests/graph/ir/test_node_policy.py
@@ -49,6 +49,13 @@ def test_browser_nodes_blocked_by_metadata() -> None:
     assert restricted_mode_rejection_reason("BrowserScriptNode") is not None
 
 
+def test_cli_agent_nodes_blocked_by_metadata() -> None:
+    """Host CLI agent nodes opt into restricted-mode rejection through metadata."""
+    assert restricted_mode_rejection_reason("CodexNode") is not None
+    assert restricted_mode_rejection_reason("ClaudeCodeNode") is not None
+    assert restricted_mode_rejection_reason("AntigravityNode") is not None
+
+
 @pytest.mark.parametrize(
     "node_type",
     [
@@ -118,6 +125,18 @@ def test_compile_blocks_disallowed_node_by_default() -> None:
                 "from orcheo.nodes.evaluation.datasets import "
                 "MultiDoc2DialCorpusLoaderNode"
             ),
+        ),
+        (
+            'CodexNode(name="n", prompt="fix the bug")',
+            "from orcheo.nodes.ai.cli import CodexNode",
+        ),
+        (
+            'ClaudeCodeNode(name="n", prompt="fix the bug")',
+            "from orcheo.nodes.ai.cli import ClaudeCodeNode",
+        ),
+        (
+            'AntigravityNode(name="n", prompt="fix the bug")',
+            "from orcheo.nodes.ai.cli import AntigravityNode",
         ),
     ],
 )

--- a/tests/nodes/ai/cli/test_base.py
+++ b/tests/nodes/ai/cli/test_base.py
@@ -1,0 +1,238 @@
+"""Tests covering CLIAgentNode subprocess execution behavior."""
+
+from __future__ import annotations
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+import pytest
+from langchain_core.runnables import RunnableConfig
+from orcheo.graph.state import State
+from orcheo.nodes.ai.cli.base import CLIAgentNode, ProcessExecutionResult
+
+
+class EchoAgentNode(CLIAgentNode):
+    """Minimal concrete CLIAgentNode used for testing the base class."""
+
+    executable_name = "echo-agent"
+
+    def build_command(self, executable: str) -> list[str]:
+        """Return a trivial invocation echoing the prompt."""
+        return [executable, self.prompt]
+
+
+def _config() -> RunnableConfig:
+    return RunnableConfig()
+
+
+@pytest.mark.asyncio
+async def test_run_raises_when_executable_missing() -> None:
+    """A missing CLI binary raises before any subprocess is spawned."""
+    node = EchoAgentNode(name="agent", prompt="hello")
+    state = State({"node_results": {}})
+
+    with (
+        patch("shutil.which", return_value=None),
+        pytest.raises(RuntimeError, match="not found on PATH"),
+    ):
+        await node.run(state, _config())
+
+
+@pytest.mark.asyncio
+async def test_run_raises_when_working_directory_missing() -> None:
+    """A configured working_directory that doesn't exist raises a clear error."""
+    node = EchoAgentNode(
+        name="agent", prompt="hello", working_directory="/no/such/directory"
+    )
+    state = State({"node_results": {}})
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/echo-agent"),
+        pytest.raises(RuntimeError, match="does not exist on this host"),
+    ):
+        await node.run(state, _config())
+
+
+@pytest.mark.asyncio
+async def test_run_treats_empty_working_directory_as_unset(tmp_path: Path) -> None:
+    """An empty working_directory string does not attempt to validate a cwd."""
+    node = EchoAgentNode(name="agent", prompt="hello", working_directory="")
+    state = State({"node_results": {}})
+    result = ProcessExecutionResult(
+        command=["echo-agent", "hello"],
+        stdout="done",
+        stderr="",
+        exit_code=0,
+        timed_out=False,
+        duration_seconds=0.1,
+    )
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/echo-agent"),
+        patch(
+            "orcheo.nodes.ai.cli.base.execute_process",
+            new=AsyncMock(return_value=result),
+        ) as mock_execute,
+    ):
+        await node.run(state, _config())
+
+    assert mock_execute.call_args.kwargs["cwd"] is None
+
+
+@pytest.mark.asyncio
+async def test_run_uses_existing_working_directory(tmp_path: Path) -> None:
+    """An existing working_directory is passed through to execute_process."""
+    node = EchoAgentNode(name="agent", prompt="hello", working_directory=str(tmp_path))
+    state = State({"node_results": {}})
+    result = ProcessExecutionResult(
+        command=["echo-agent", "hello"],
+        stdout="done",
+        stderr="",
+        exit_code=0,
+        timed_out=False,
+        duration_seconds=0.1,
+    )
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/echo-agent"),
+        patch(
+            "orcheo.nodes.ai.cli.base.execute_process",
+            new=AsyncMock(return_value=result),
+        ) as mock_execute,
+    ):
+        await node.run(state, _config())
+
+    assert mock_execute.call_args.kwargs["cwd"] == tmp_path
+
+
+@pytest.mark.asyncio
+async def test_run_returns_output_on_success() -> None:
+    """A zero-exit run returns captured stdout/stderr without raising."""
+    node = EchoAgentNode(name="agent", prompt="hello")
+    state = State({"node_results": {}})
+    result = ProcessExecutionResult(
+        command=["echo-agent", "hello"],
+        stdout="done",
+        stderr="",
+        exit_code=0,
+        timed_out=False,
+        duration_seconds=0.1,
+    )
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/echo-agent"),
+        patch(
+            "orcheo.nodes.ai.cli.base.execute_process",
+            new=AsyncMock(return_value=result),
+        ),
+    ):
+        output = await node.run(state, _config())
+
+    assert output == {
+        "output": "done",
+        "stderr": "",
+        "exit_code": 0,
+        "timed_out": False,
+        "duration_seconds": 0.1,
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_raises_on_nonzero_exit_by_default() -> None:
+    """A non-zero exit code raises with the captured stderr by default."""
+    node = EchoAgentNode(name="agent", prompt="hello")
+    state = State({"node_results": {}})
+    result = ProcessExecutionResult(
+        command=["echo-agent", "hello"],
+        stdout="",
+        stderr="boom",
+        exit_code=1,
+        timed_out=False,
+        duration_seconds=0.1,
+    )
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/echo-agent"),
+        patch(
+            "orcheo.nodes.ai.cli.base.execute_process",
+            new=AsyncMock(return_value=result),
+        ),
+        pytest.raises(RuntimeError, match="boom"),
+    ):
+        await node.run(state, _config())
+
+
+@pytest.mark.asyncio
+async def test_run_does_not_raise_when_raise_on_error_disabled() -> None:
+    """Disabling raise_on_error surfaces failure details in the output instead."""
+    node = EchoAgentNode(name="agent", prompt="hello", raise_on_error=False)
+    state = State({"node_results": {}})
+    result = ProcessExecutionResult(
+        command=["echo-agent", "hello"],
+        stdout="",
+        stderr="boom",
+        exit_code=1,
+        timed_out=False,
+        duration_seconds=0.1,
+    )
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/echo-agent"),
+        patch(
+            "orcheo.nodes.ai.cli.base.execute_process",
+            new=AsyncMock(return_value=result),
+        ),
+    ):
+        output = await node.run(state, _config())
+
+    assert output["exit_code"] == 1
+    assert output["stderr"] == "boom"
+
+
+@pytest.mark.asyncio
+async def test_run_raises_on_timeout() -> None:
+    """A timed-out run raises even when the captured exit code is None."""
+    node = EchoAgentNode(name="agent", prompt="hello")
+    state = State({"node_results": {}})
+    result = ProcessExecutionResult(
+        command=["echo-agent", "hello"],
+        stdout="partial",
+        stderr="",
+        exit_code=None,
+        timed_out=True,
+        duration_seconds=600.0,
+    )
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/echo-agent"),
+        patch(
+            "orcheo.nodes.ai.cli.base.execute_process",
+            new=AsyncMock(return_value=result),
+        ),
+        pytest.raises(RuntimeError, match="timed out"),
+    ):
+        await node.run(state, _config())
+
+
+@pytest.mark.asyncio
+async def test_execute_process_captures_stdout_and_exit_code() -> None:
+    """execute_process runs a real subprocess and captures its output."""
+    from orcheo.nodes.ai.cli.base import execute_process
+
+    result = await execute_process(["python3", "-c", "print('hi')"])
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "hi"
+    assert not result.timed_out
+
+
+@pytest.mark.asyncio
+async def test_execute_process_times_out() -> None:
+    """execute_process terminates a process that exceeds the timeout."""
+    from orcheo.nodes.ai.cli.base import execute_process
+
+    result = await execute_process(
+        ["python3", "-c", "import time; time.sleep(5)"],
+        timeout_seconds=0.1,
+    )
+
+    assert result.timed_out is True
+    assert result.exit_code is not None

--- a/tests/nodes/ai/cli/test_base.py
+++ b/tests/nodes/ai/cli/test_base.py
@@ -317,6 +317,62 @@ async def test_execute_process_terminates_process_group_on_cancel() -> None:
 
 
 @pytest.mark.asyncio
+async def test_read_stream_returns_immediately_for_none_stream() -> None:
+    """_read_stream is a no-op when the process has no such stream (e.g. DEVNULL)."""
+    from orcheo.nodes.ai.cli.base import _read_stream
+
+    chunks: list[bytes] = []
+    await _read_stream(None, chunks)
+
+    assert chunks == []
+
+
+@pytest.mark.asyncio
+async def test_drain_readers_returns_immediately_for_no_tasks() -> None:
+    """_drain_readers is a no-op when there are no reader tasks to wait on."""
+    from orcheo.nodes.ai.cli.base import _drain_readers
+
+    await _drain_readers([], timeout=5.0)
+
+
+@pytest.mark.asyncio
+async def test_terminate_process_group_returns_existing_exit_code() -> None:
+    """A process that already exited is not signalled again."""
+    from orcheo.nodes.ai.cli.base import _terminate_process_group
+
+    process = await asyncio.create_subprocess_exec(
+        "true", stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL
+    )
+    await process.wait()
+
+    exit_code = await _terminate_process_group(process)
+
+    assert exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_terminate_process_group_sigkills_process_that_ignores_sigterm() -> None:
+    """A process that ignores SIGTERM is force-killed after the grace period."""
+    from orcheo.nodes.ai.cli.base import _terminate_process_group
+
+    process = await asyncio.create_subprocess_exec(
+        "python3",
+        "-c",
+        "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(30)",
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    # Let the signal handler get installed before we send SIGTERM.
+    await asyncio.sleep(0.3)
+
+    exit_code = await _terminate_process_group(process)
+
+    assert exit_code is not None
+    assert exit_code != 0
+
+
+@pytest.mark.asyncio
 async def test_execute_process_times_out_despite_inherited_pipe() -> None:
     """A grandchild holding the pipe open cannot defeat the timeout bound."""
     from orcheo.nodes.ai.cli.base import execute_process

--- a/tests/nodes/ai/cli/test_base.py
+++ b/tests/nodes/ai/cli/test_base.py
@@ -1,6 +1,8 @@
 """Tests covering CLIAgentNode subprocess execution behavior."""
 
 from __future__ import annotations
+import asyncio
+import time
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 import pytest
@@ -75,6 +77,42 @@ async def test_run_treats_empty_working_directory_as_unset(tmp_path: Path) -> No
         await node.run(state, _config())
 
     assert mock_execute.call_args.kwargs["cwd"] is None
+
+
+@pytest.mark.asyncio
+async def test_run_treats_whitespace_working_directory_as_unset() -> None:
+    """A whitespace-only working_directory is ignored like an empty string."""
+    node = EchoAgentNode(name="agent", prompt="hello", working_directory="   ")
+    state = State({"node_results": {}})
+    result = ProcessExecutionResult(
+        command=["echo-agent", "hello"],
+        stdout="done",
+        exit_code=0,
+        duration_seconds=0.1,
+    )
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/echo-agent"),
+        patch(
+            "orcheo.nodes.ai.cli.base.execute_process",
+            new=AsyncMock(return_value=result),
+        ) as mock_execute,
+    ):
+        await node.run(state, _config())
+
+    assert mock_execute.call_args.kwargs["cwd"] is None
+
+
+def test_combined_prompt_folds_system_prompt() -> None:
+    """_combined_prompt prepends stripped system instructions when present."""
+    node = EchoAgentNode(name="agent", prompt="do it", system_prompt="  Be terse.  ")
+    assert node._combined_prompt() == "System instructions:\nBe terse.\n\nTask:\ndo it"
+
+
+def test_combined_prompt_without_system_prompt() -> None:
+    """_combined_prompt returns the bare task prompt when no system prompt."""
+    node = EchoAgentNode(name="agent", prompt="do it")
+    assert node._combined_prompt() == "do it"
 
 
 @pytest.mark.asyncio
@@ -236,3 +274,66 @@ async def test_execute_process_times_out() -> None:
 
     assert result.timed_out is True
     assert result.exit_code is not None
+
+
+@pytest.mark.asyncio
+async def test_drain_readers_cancels_overrunning_tasks() -> None:
+    """_drain_readers cancels reader tasks that overrun the bounded timeout."""
+    from orcheo.nodes.ai.cli.base import _drain_readers
+
+    async def _never_finishes() -> None:
+        await asyncio.sleep(3600)
+
+    tasks = [asyncio.create_task(_never_finishes())]
+    await _drain_readers(tasks, timeout=0.05)
+
+    assert tasks[0].done()
+    assert tasks[0].cancelled()
+
+
+@pytest.mark.asyncio
+async def test_execute_process_terminates_process_group_on_cancel() -> None:
+    """Cancelling execute_process tears down the CLI process group and re-raises."""
+    from orcheo.nodes.ai.cli import base
+
+    terminated: list[object] = []
+    real_terminate = base._terminate_process_group
+
+    async def _spy(process: object) -> int | None:
+        terminated.append(process)
+        return await real_terminate(process)  # type: ignore[arg-type]
+
+    with patch.object(base, "_terminate_process_group", _spy):
+        task = asyncio.create_task(
+            base.execute_process(["python3", "-c", "import time; time.sleep(30)"])
+        )
+        # Let the subprocess actually start before cancelling.
+        await asyncio.sleep(0.3)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert terminated, "cancellation must terminate the process group"
+
+
+@pytest.mark.asyncio
+async def test_execute_process_times_out_despite_inherited_pipe() -> None:
+    """A grandchild holding the pipe open cannot defeat the timeout bound."""
+    from orcheo.nodes.ai.cli.base import execute_process
+
+    # The parent spawns a detached ``sleep`` that inherits the stdout/stderr
+    # pipe, then blocks itself. Terminating the whole process group on timeout
+    # kills both, so the call returns near ``timeout_seconds`` rather than
+    # waiting out the 10s children.
+    code = (
+        "import subprocess, sys, time;"
+        "subprocess.Popen(['sleep', '10'], stdout=sys.stdout, stderr=sys.stderr);"
+        "time.sleep(10)"
+    )
+
+    started = time.monotonic()
+    result = await execute_process(["python3", "-c", code], timeout_seconds=0.3)
+    elapsed = time.monotonic() - started
+
+    assert result.timed_out is True
+    assert elapsed < 5

--- a/tests/nodes/ai/cli/test_providers.py
+++ b/tests/nodes/ai/cli/test_providers.py
@@ -1,0 +1,77 @@
+"""Tests covering CLI invocation building for CLI agent provider nodes."""
+
+from __future__ import annotations
+from orcheo.nodes.ai.cli.antigravity import AntigravityNode
+from orcheo.nodes.ai.cli.claude_code import ClaudeCodeNode
+from orcheo.nodes.ai.cli.codex import CodexNode
+from orcheo.nodes.registry import registry
+
+
+def test_codex_node_build_command_without_system_prompt() -> None:
+    node = CodexNode(name="codex", prompt="fix the bug")
+    command = node.build_command("/usr/bin/codex")
+    assert command == [
+        "/usr/bin/codex",
+        "exec",
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--skip-git-repo-check",
+        "fix the bug",
+    ]
+
+
+def test_codex_node_build_command_with_system_prompt() -> None:
+    node = CodexNode(name="codex", prompt="fix the bug", system_prompt="Be terse.")
+    command = node.build_command("/usr/bin/codex")
+    assert command[-1] == "System instructions:\nBe terse.\n\nTask:\nfix the bug"
+
+
+def test_claude_code_node_build_command_without_system_prompt() -> None:
+    node = ClaudeCodeNode(name="claude", prompt="fix the bug")
+    command = node.build_command("/usr/bin/claude")
+    assert command == [
+        "/usr/bin/claude",
+        "--dangerously-skip-permissions",
+        "--print",
+        "fix the bug",
+        "--output-format",
+        "text",
+    ]
+
+
+def test_claude_code_node_build_command_with_system_prompt() -> None:
+    node = ClaudeCodeNode(
+        name="claude", prompt="fix the bug", system_prompt="Be terse."
+    )
+    command = node.build_command("/usr/bin/claude")
+    assert command[-2:] == ["--append-system-prompt", "Be terse."]
+
+
+def test_antigravity_node_build_command_without_system_prompt() -> None:
+    node = AntigravityNode(
+        name="antigravity", prompt="fix the bug", timeout_seconds=900
+    )
+    command = node.build_command("/usr/bin/agy")
+    assert command == [
+        "/usr/bin/agy",
+        "--dangerously-skip-permissions",
+        "--print-timeout",
+        "900s",
+        "--print",
+        "fix the bug",
+    ]
+
+
+def test_antigravity_node_build_command_with_system_prompt() -> None:
+    node = AntigravityNode(
+        name="antigravity", prompt="fix the bug", system_prompt="Be terse."
+    )
+    command = node.build_command("/usr/bin/agy")
+    assert command[-1] == "System instructions:\nBe terse.\n\nTask:\nfix the bug"
+
+
+def test_provider_nodes_are_registered_restricted_ai_nodes() -> None:
+    for node_type in ("CodexNode", "ClaudeCodeNode", "AntigravityNode"):
+        metadata = registry.get_metadata(node_type)
+        assert metadata is not None
+        assert metadata.category == "ai"
+        assert metadata.restricted is True


### PR DESCRIPTION
## Summary

Adds workflow nodes that drive host-installed, pre-authenticated CLI coding
agents (Codex, Claude Code, Antigravity) as non-interactive workflow steps. A
shared `CLIAgentNode` base handles subprocess execution, timeouts, and output
capture; each provider subclass only supplies the command line. All three nodes
are registered as restricted so untrusted-author (restricted-mode) ingestion
rejects them — they run an arbitrary host subprocess with the worker's
privileges and are only available to trusted, first-party workflows.

## Changes

- **New `orcheo.nodes.ai.cli` package** — introduces `CLIAgentNode`
  ([base.py](src/orcheo/nodes/ai/cli/base.py)), a `TaskNode` that resolves the
  provider binary on `PATH`, validates an optional `working_directory`, runs it
  via a managed `execute_process` helper, and returns `output`/`stderr`/
  `exit_code`/`timed_out`/`duration_seconds`. Exposes `prompt`, `system_prompt`,
  `working_directory`, `timeout_seconds`, and `raise_on_error` fields.
- **Managed subprocess execution** — `execute_process` runs the CLI in its own
  session (`start_new_session=True`), streams stdout/stderr, and on timeout
  terminates the whole process group with `SIGTERM`, escalating to `SIGKILL`
  after a grace period.
- **Provider nodes** — `CodexNode` ([codex.py](src/orcheo/nodes/ai/cli/codex.py),
  `codex exec`), `ClaudeCodeNode`
  ([claude_code.py](src/orcheo/nodes/ai/cli/claude_code.py), `claude --print`),
  and `AntigravityNode`
  ([antigravity.py](src/orcheo/nodes/ai/cli/antigravity.py), `agy --print`) each
  build their own non-interactive invocation, folding `system_prompt` into the
  prompt where the CLI has no dedicated flag.
- **Restricted-mode enforcement** — every provider registers with
  `NodeMetadata(restricted=True)`, and the nodes are re-exported from
  [nodes/__init__.py](src/orcheo/nodes/__init__.py) and
  [nodes/ai/__init__.py](src/orcheo/nodes/ai/__init__.py).
- **Desktop docs** — clarifies in the macOS and Tauri desktop READMEs that the
  bundled Playwright Chromium revision is pinned by the `playwright` package
  version and printed during the build, and that the Tauri UI itself renders in
  the non-pinnable OS WebView.

## Testing

- `tests/nodes/ai/cli/test_base.py` — covers missing binary, missing/empty/valid
  `working_directory`, success output, non-zero exit (raise and non-raise),
  timeout raising, and real-subprocess capture/timeout via `execute_process`.
- `tests/nodes/ai/cli/test_providers.py` — asserts each provider's built command
  with and without a system prompt, and that all three register as restricted
  `ai` nodes.
- `tests/graph/ir/test_node_policy.py` — confirms `CodexNode`, `ClaudeCodeNode`,
  and `AntigravityNode` are rejected in restricted mode and blocked by default
  during compilation.
