### PR TITLE
Add hosted app publish controls and archive actions

### DIFF
--- a/apps/app_gateway/src/orcheo_app_gateway/main.py
+++ b/apps/app_gateway/src/orcheo_app_gateway/main.py
@@ -477,10 +477,9 @@ def create_app() -> FastAPI:  # noqa: C901, PLR0915
     @app.get("/__orcheo/auth/start", include_in_schema=False)
     async def start_app_auth(request: Request, return_to: str = "/") -> Response:
         """Start central member authorization with a gateway-owned PKCE verifier."""
+        request_host = request.headers.get("host", "")
         try:
-            host, alias = canonical_app_host(
-                request.headers.get("host", ""), base_domain
-            )
+            host, alias = canonical_app_host(request_host, base_domain)
         except AliasValidationError as exc:
             raise HTTPException(status_code=404, detail="Unknown hosted app.") from exc
         if not backend_url or not gateway_secret:
@@ -498,7 +497,12 @@ def create_app() -> FastAPI:  # noqa: C901, PLR0915
         )
         state = secrets.token_urlsafe(32)
         scheme = "http" if host.endswith(".localhost") else "https"
-        redirect_uri = f"{scheme}://{host}/__orcheo/auth/callback"
+        callback_host = (
+            request_host.strip().lower().rstrip(".")
+            if host.endswith(".localhost")
+            else host
+        )
+        redirect_uri = f"{scheme}://{callback_host}/__orcheo/auth/callback"
         transaction = encode_auth_transaction(
             {
                 "host": host,

--- a/apps/backend/src/orcheo_backend/app/hosted_apps/auth_routes.py
+++ b/apps/backend/src/orcheo_backend/app/hosted_apps/auth_routes.py
@@ -1,6 +1,7 @@
 """Central authenticated authorization endpoint for Hosted Apps PKCE."""
 
 from __future__ import annotations
+import os
 from typing import Annotated, Any
 from urllib.parse import urlencode
 from uuid import UUID
@@ -55,6 +56,10 @@ async def authorize_app(
     allowed_callbacks = {f"https://{body.host}/__orcheo/auth/callback"}
     if body.host.endswith(".localhost"):
         allowed_callbacks.add(f"http://{body.host}/__orcheo/auth/callback")
+        gateway_port = os.getenv("ORCHEO_APP_GATEWAY_PORT", "2030")
+        allowed_callbacks.add(
+            f"http://{body.host}:{gateway_port}/__orcheo/auth/callback"
+        )
     if body.redirect_uri not in allowed_callbacks:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/apps/backend/src/orcheo_backend/app/routers/apps.py
+++ b/apps/backend/src/orcheo_backend/app/routers/apps.py
@@ -72,6 +72,21 @@ def _not_found() -> HTTPException:
     )
 
 
+def _unavailable() -> HTTPException:
+    """Return a clear response when Hosted Apps is disabled for a workspace."""
+    return HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail={
+            "code": "hosted_apps.unavailable",
+            "message": (
+                "Hosted Apps are not enabled for this workspace. Ask an "
+                "administrator to enable Hosted Apps or add this workspace to "
+                "the Hosted Apps allowlist."
+            ),
+        },
+    )
+
+
 def _encode_app_cursor(app: HostedApp) -> str:
     raw = f"{app.updated_at.isoformat()}|{app.id}".encode()
     return base64.urlsafe_b64encode(raw).decode().rstrip("=")
@@ -108,7 +123,7 @@ def _ensure_enabled(workspace: WorkspaceContextDep) -> None:
     if not settings.enabled or not settings.allows_workspace(
         str(workspace.workspace_id)
     ):
-        raise _not_found()
+        raise _unavailable()
 
 
 def _binding_response(binding: AppBinding) -> AppBindingResponse:

--- a/apps/backend/src/orcheo_backend/app/routers/apps.py
+++ b/apps/backend/src/orcheo_backend/app/routers/apps.py
@@ -899,12 +899,13 @@ async def publish_app(
         bindings = await run_in_threadpool(
             repository.list_bindings, workspace.workspace_id, app_id
         )
+    visibility = request.visibility or app.visibility
     collections = await run_in_threadpool(
         repository.list_collections, workspace.workspace_id, app_id
     )
     snapshot = {
         "permission_revision": request.acknowledged_permission_revision,
-        "visibility": app.visibility.value,
+        "visibility": visibility.value,
         "bindings": [
             item.model_dump(mode="json", exclude={"workspace_id", "app_id"})
             for item in bindings
@@ -923,7 +924,7 @@ async def publish_app(
         app_id=app_id,
         deployment_id=deployment_id,
         permission_revision=request.acknowledged_permission_revision,
-        visibility=app.visibility,
+        visibility=visibility,
         capability_snapshot=snapshot,
         csp_snapshot={"external_origins": list(app.external_origins)},
         snapshot_sha256=snapshot_sha256,

--- a/apps/backend/src/orcheo_backend/app/schemas/apps.py
+++ b/apps/backend/src/orcheo_backend/app/schemas/apps.py
@@ -102,11 +102,12 @@ class HostedAppListResponse(BaseModel):
 
 
 class AppPublishRequest(BaseModel):
-    """Exact draft capability revision acknowledged by an administrator."""
+    """Release settings acknowledged and selected by an administrator."""
 
     model_config = ConfigDict(extra="forbid")
 
     acknowledged_permission_revision: int = Field(ge=1)
+    visibility: AppVisibility | None = None
 
 
 class AppPublishResponse(BaseModel):

--- a/apps/studio/src/features/apps/components/app-card.test.tsx
+++ b/apps/studio/src/features/apps/components/app-card.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { HostedApp } from "../data/sample-apps";
+import { AppCard } from "./app-card";
+
+const app: HostedApp = {
+  id: "app-1",
+  name: "Portal",
+  alias: "portal",
+  url: "http://portal.apps.localhost:2030/",
+  visibility: "public",
+  state: "draft",
+  health: "unknown",
+  updated: "just now",
+  deployments: [],
+  bindings: [],
+  collections: [],
+  permissionRevision: 1,
+};
+
+describe("AppCard", () => {
+  it("starts the archive flow from its Delete action", async () => {
+    const user = userEvent.setup();
+    const onArchiveApp = vi.fn();
+
+    render(
+      <AppCard
+        app={app}
+        onOpen={vi.fn()}
+        onTogglePublish={vi.fn()}
+        onArchiveApp={onArchiveApp}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "App actions" }));
+    await user.click(screen.getByRole("menuitem", { name: "Delete" }));
+
+    expect(onArchiveApp).toHaveBeenCalledWith(app);
+  });
+});

--- a/apps/studio/src/features/apps/components/app-card.tsx
+++ b/apps/studio/src/features/apps/components/app-card.tsx
@@ -31,9 +31,15 @@ interface AppCardProps {
   app: HostedApp;
   onOpen: (app: HostedApp) => void;
   onTogglePublish: (app: HostedApp) => void;
+  onArchiveApp: (app: HostedApp) => void;
 }
 
-export function AppCard({ app, onOpen, onTogglePublish }: AppCardProps) {
+export function AppCard({
+  app,
+  onOpen,
+  onTogglePublish,
+  onArchiveApp,
+}: AppCardProps) {
   const activeDeployment = app.deployments.find((d) => d.active);
   const publishAllowed = canPublishApp(app);
 
@@ -119,7 +125,11 @@ export function AppCard({ app, onOpen, onTogglePublish }: AppCardProps) {
               </DropdownMenuItem>
             )}
             <DropdownMenuSeparator />
-            <DropdownMenuItem className="text-destructive">
+            <DropdownMenuItem
+              className="text-destructive"
+              disabled={app.state === "archived"}
+              onClick={() => onArchiveApp(app)}
+            >
               <Trash2 className="mr-2 h-4 w-4" />
               Delete
             </DropdownMenuItem>

--- a/apps/studio/src/features/apps/components/archive-app-dialog.tsx
+++ b/apps/studio/src/features/apps/components/archive-app-dialog.tsx
@@ -1,0 +1,52 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/design-system/ui/alert-dialog";
+
+interface ArchiveAppDialogProps {
+  open: boolean;
+  appName: string;
+  isPending?: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => Promise<void> | void;
+}
+
+export function ArchiveAppDialog({
+  open,
+  appName,
+  isPending = false,
+  onOpenChange,
+  onConfirm,
+}: ArchiveAppDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete app?</AlertDialogTitle>
+          <AlertDialogDescription>
+            {`"${appName}" will be archived and will stop serving traffic. Its alias and release history will be retained so an administrator can restore it later.`}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            disabled={isPending}
+            onClick={(event) => {
+              event.preventDefault();
+              void onConfirm();
+            }}
+          >
+            {isPending ? "Deleting…" : "Delete app"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/studio/src/features/apps/components/publish-app-dialog.tsx
+++ b/apps/studio/src/features/apps/components/publish-app-dialog.tsx
@@ -1,0 +1,119 @@
+import { useState } from "react";
+import { Check, Globe, Lock } from "lucide-react";
+
+import { Button } from "@/design-system/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/design-system/ui/dialog";
+import { cn } from "@/lib/utils";
+import type { AppVisibility } from "../data/sample-apps";
+
+interface PublishOption {
+  value: AppVisibility;
+  title: string;
+  description: string;
+  icon: typeof Globe;
+}
+
+const PUBLISH_OPTIONS: PublishOption[] = [
+  {
+    value: "public",
+    title: "Public",
+    description: "Anyone with the link can open and use the app.",
+    icon: Globe,
+  },
+  {
+    value: "private",
+    title: "Workspace only",
+    description: "Only signed-in members of this workspace can use the app.",
+    icon: Lock,
+  },
+];
+
+interface PublishAppDialogProps {
+  open: boolean;
+  isPending?: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (visibility: AppVisibility) => Promise<void> | void;
+}
+
+export function PublishAppDialog({
+  open,
+  isPending = false,
+  onOpenChange,
+  onConfirm,
+}: PublishAppDialogProps) {
+  const [selected, setSelected] = useState<AppVisibility>("public");
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      setSelected("public");
+    }
+    onOpenChange(nextOpen);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Publish app</DialogTitle>
+          <DialogDescription>
+            Choose who can access the published app.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-3 py-2">
+          {PUBLISH_OPTIONS.map((option) => {
+            const Icon = option.icon;
+            const isSelected = selected === option.value;
+            return (
+              <button
+                key={option.value}
+                type="button"
+                aria-pressed={isSelected}
+                onClick={() => setSelected(option.value)}
+                disabled={isPending}
+                className={cn(
+                  "flex items-start gap-3 rounded-lg border p-3 text-left transition-colors",
+                  isSelected
+                    ? "border-primary bg-primary/5"
+                    : "border-border hover:bg-muted/40",
+                )}
+              >
+                <Icon className="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" />
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-medium">{option.title}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {option.description}
+                  </p>
+                </div>
+                {isSelected ? (
+                  <Check className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+            disabled={isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={() => void onConfirm(selected)}
+            disabled={isPending}
+          >
+            {isPending ? "Publishing…" : "Publish"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/studio/src/features/apps/data/apps-api.ts
+++ b/apps/studio/src/features/apps/data/apps-api.ts
@@ -158,6 +158,7 @@ export const publishHostedApp = (
   appId: string,
   deploymentId: string,
   permissionRevision: number,
+  visibility: HostedAppApi["visibility"],
 ): Promise<AppPublishApi> =>
   request<AppPublishApi>(
     `/api/apps/${appId}/deployments/${deploymentId}/publish`,
@@ -165,6 +166,7 @@ export const publishHostedApp = (
       method: "POST",
       body: JSON.stringify({
         acknowledged_permission_revision: permissionRevision,
+        visibility,
       }),
     },
   );

--- a/apps/studio/src/features/apps/data/apps-api.ts
+++ b/apps/studio/src/features/apps/data/apps-api.ts
@@ -151,6 +151,9 @@ export const listAppAudit = (id: string): Promise<AppAuditApi[]> =>
 export const unpublishHostedApp = (id: string): Promise<HostedAppApi> =>
   request<HostedAppApi>(`/api/apps/${id}/unpublish`, { method: "POST" });
 
+export const archiveHostedApp = (id: string): Promise<HostedAppApi> =>
+  request<HostedAppApi>(`/api/apps/${id}/archive`, { method: "POST" });
+
 export const publishHostedApp = (
   appId: string,
   deploymentId: string,

--- a/apps/studio/src/features/apps/data/apps-store.test.ts
+++ b/apps/studio/src/features/apps/data/apps-store.test.ts
@@ -6,6 +6,7 @@ import {
   canPublishApp,
   createApp,
   getPublishBlockedReason,
+  toggleAppPublish,
   useApp,
   useApps,
 } from "./apps-store";
@@ -102,6 +103,47 @@ describe("Hosted Apps workspace data", () => {
     await archiveApp(app.id);
 
     expect(api.archiveHostedApp).toHaveBeenCalledWith(app.id);
+  });
+
+  it("publishes with the visibility chosen by the publisher", async () => {
+    vi.mocked(api.publishHostedApp).mockResolvedValue({
+      app_id: app.id,
+      active_release_id: "release-1",
+      active_deployment_id: "deployment-1",
+      published_permission_revision: app.permission_revision,
+      state: "published",
+      url: app.url,
+    });
+    const readyApp = {
+      ...app,
+      deployments: [
+        {
+          id: "deployment-1",
+          version: "deployment 1",
+          digest: "sha256:test",
+          size: "—",
+          files: 1,
+          created: "now",
+          active: false,
+          status: "ready" as const,
+        },
+      ],
+      bindings: [],
+      collections: [],
+      health: "unknown" as const,
+      updated: "now",
+      permissionRevision: app.permission_revision,
+      state: "draft" as const,
+    };
+
+    await toggleAppPublish(readyApp, "private");
+
+    expect(api.publishHostedApp).toHaveBeenCalledWith(
+      app.id,
+      "deployment-1",
+      app.permission_revision,
+      "private",
+    );
   });
 
   it("blocks invalid lifecycle states and apps without a ready deployment", () => {

--- a/apps/studio/src/features/apps/data/apps-store.test.ts
+++ b/apps/studio/src/features/apps/data/apps-store.test.ts
@@ -2,6 +2,7 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as api from "./apps-api";
 import {
+  archiveApp,
   canPublishApp,
   createApp,
   getPublishBlockedReason,
@@ -10,6 +11,7 @@ import {
 } from "./apps-store";
 
 vi.mock("./apps-api", () => ({
+  archiveHostedApp: vi.fn(),
   createHostedApp: vi.fn(),
   getHostedApp: vi.fn(),
   listAppAudit: vi.fn(),
@@ -68,6 +70,23 @@ describe("Hosted Apps workspace data", () => {
     expect(result.current.error).toBe("App access denied.");
   });
 
+  it("hides archived apps from the normal list", async () => {
+    vi.mocked(api.listHostedApps).mockResolvedValue([
+      app,
+      {
+        ...app,
+        id: "archived-app",
+        state: "archived",
+        is_archived: true,
+      },
+    ]);
+
+    const { result } = renderHook(() => useApps("workspace-a"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.apps.map((item) => item.id)).toEqual([app.id]);
+  });
+
   it("creates through the authenticated API instead of local sample state", async () => {
     vi.mocked(api.createHostedApp).mockResolvedValue(app);
     await act(async () => {
@@ -75,6 +94,14 @@ describe("Hosted Apps workspace data", () => {
       expect(created.id).toBe("app-1");
     });
     expect(api.createHostedApp).toHaveBeenCalledWith("Portal", "portal");
+  });
+
+  it("archives through the authenticated API", async () => {
+    vi.mocked(api.archiveHostedApp).mockResolvedValue(app);
+
+    await archiveApp(app.id);
+
+    expect(api.archiveHostedApp).toHaveBeenCalledWith(app.id);
   });
 
   it("blocks invalid lifecycle states and apps without a ready deployment", () => {

--- a/apps/studio/src/features/apps/data/apps-store.ts
+++ b/apps/studio/src/features/apps/data/apps-store.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import {
+  archiveHostedApp,
   createHostedApp,
   getHostedApp,
   listAppAudit,
@@ -114,6 +115,11 @@ export const createApp = async (
   return created;
 };
 
+export const archiveApp = async (appId: string): Promise<void> => {
+  await archiveHostedApp(appId);
+  notify();
+};
+
 export const getPublishBlockedReason = (app: HostedApp): string | null => {
   if (app.state !== "draft" && app.state !== "unpublished") {
     return `A ${app.state} app cannot be published.`;
@@ -170,7 +176,9 @@ export function useApps(workspaceKey: string | undefined): {
         .then((items) => {
           if (active)
             setState({
-              apps: items.map((item) => appFromApi(item)),
+              apps: items
+                .filter((item) => !item.is_archived)
+                .map((item) => appFromApi(item)),
               loading: false,
               error: null,
             });

--- a/apps/studio/src/features/apps/data/apps-store.ts
+++ b/apps/studio/src/features/apps/data/apps-store.ts
@@ -17,7 +17,7 @@ import {
   type AppCollectionApi,
   type HostedAppApi,
 } from "./apps-api";
-import type { HostedApp } from "./sample-apps";
+import type { AppVisibility, HostedApp } from "./sample-apps";
 
 const listeners = new Set<() => void>();
 
@@ -133,7 +133,10 @@ export const getPublishBlockedReason = (app: HostedApp): string | null => {
 export const canPublishApp = (app: HostedApp): boolean =>
   getPublishBlockedReason(app) === null;
 
-export const toggleAppPublish = async (app: HostedApp): Promise<void> => {
+export const toggleAppPublish = async (
+  app: HostedApp,
+  visibility?: AppVisibility,
+): Promise<void> => {
   if (app.state === "published") {
     await unpublishHostedApp(app.id);
   } else {
@@ -145,7 +148,15 @@ export const toggleAppPublish = async (app: HostedApp): Promise<void> => {
     if (!ready) {
       throw new Error("Upload and validate a deployment before publishing.");
     }
-    await publishHostedApp(app.id, ready.id, app.permissionRevision);
+    if (!visibility) {
+      throw new Error("Choose who can access the app before publishing.");
+    }
+    await publishHostedApp(
+      app.id,
+      ready.id,
+      app.permissionRevision,
+      visibility,
+    );
   }
   notify();
 };

--- a/apps/studio/src/features/apps/pages/app-detail.tsx
+++ b/apps/studio/src/features/apps/pages/app-detail.tsx
@@ -25,12 +25,14 @@ import { usePageContext } from "@/hooks/use-page-context";
 import { getWorkspaceAppsPath } from "@/lib/workspace-routing";
 import { getHostedAppAddress } from "../data/sample-apps";
 import {
+  archiveApp,
   canPublishApp,
   getPublishBlockedReason,
   toggleAppPublish,
   uploadAppBundle,
   useApp,
 } from "../data/apps-store";
+import { ArchiveAppDialog } from "../components/archive-app-dialog";
 import {
   AppHealthBadge,
   AppStateBadge,
@@ -49,6 +51,8 @@ export default function AppDetail() {
   const [actionError, setActionError] = useState<string | null>(null);
   const [uploading, setUploading] = useState(false);
   const [publishing, setPublishing] = useState(false);
+  const [isArchiveDialogOpen, setIsArchiveDialogOpen] = useState(false);
+  const [archiving, setArchiving] = useState(false);
 
   useEffect(() => {
     setPageContext({ page: "other" });
@@ -108,6 +112,20 @@ export default function AppDetail() {
       );
     } finally {
       setUploading(false);
+    }
+  };
+  const handleArchive = async () => {
+    setActionError(null);
+    setArchiving(true);
+    try {
+      await archiveApp(app.id);
+      navigate(getWorkspaceAppsPath(workspaceSlug));
+    } catch (error) {
+      setActionError(
+        error instanceof Error ? error.message : "Unable to delete app.",
+      );
+    } finally {
+      setArchiving(false);
     }
   };
 
@@ -193,7 +211,11 @@ export default function AppDetail() {
                 Export bundle
               </DropdownMenuItem>
               <DropdownMenuSeparator />
-              <DropdownMenuItem className="text-destructive">
+              <DropdownMenuItem
+                className="text-destructive"
+                disabled={app.state === "archived"}
+                onClick={() => setIsArchiveDialogOpen(true)}
+              >
                 <Trash2 className="mr-2 h-4 w-4" />
                 Delete app
               </DropdownMenuItem>
@@ -420,6 +442,15 @@ export default function AppDetail() {
           </Card>
         </div>
       </div>
+      <ArchiveAppDialog
+        open={isArchiveDialogOpen}
+        appName={app.name}
+        isPending={archiving}
+        onOpenChange={(open) => {
+          if (!open && !archiving) setIsArchiveDialogOpen(false);
+        }}
+        onConfirm={handleArchive}
+      />
     </main>
   );
 }

--- a/apps/studio/src/features/apps/pages/app-detail.tsx
+++ b/apps/studio/src/features/apps/pages/app-detail.tsx
@@ -33,12 +33,14 @@ import {
   useApp,
 } from "../data/apps-store";
 import { ArchiveAppDialog } from "../components/archive-app-dialog";
+import { PublishAppDialog } from "../components/publish-app-dialog";
 import {
   AppHealthBadge,
   AppStateBadge,
   AppVisibilityBadge,
   IntentBadge,
 } from "../components/status-badges";
+import type { AppVisibility } from "../data/sample-apps";
 
 export default function AppDetail() {
   const { workspaceSlug, appId } = useParams<{
@@ -52,6 +54,7 @@ export default function AppDetail() {
   const [uploading, setUploading] = useState(false);
   const [publishing, setPublishing] = useState(false);
   const [isArchiveDialogOpen, setIsArchiveDialogOpen] = useState(false);
+  const [isPublishDialogOpen, setIsPublishDialogOpen] = useState(false);
   const [archiving, setArchiving] = useState(false);
 
   useEffect(() => {
@@ -82,17 +85,19 @@ export default function AppDetail() {
     manifestBindings !== null && manifestBindings !== undefined;
   const publishAllowed = canPublishApp(app);
   const publishBlockedReason = getPublishBlockedReason(app);
-  const handlePublish = async () => {
+  const handlePublish = async (visibility?: AppVisibility): Promise<boolean> => {
     setActionError(null);
     setPublishing(true);
     try {
-      await toggleAppPublish(app);
+      await toggleAppPublish(app, visibility);
+      return true;
     } catch (error) {
       setActionError(
         error instanceof Error
           ? error.message
           : "Unable to update publication.",
       );
+      return false;
     } finally {
       setPublishing(false);
     }
@@ -188,7 +193,7 @@ export default function AppDetail() {
             <Button
               disabled={publishing || !publishAllowed}
               title={publishBlockedReason ?? undefined}
-              onClick={() => void handlePublish()}
+              onClick={() => setIsPublishDialogOpen(true)}
             >
               <Rocket className="mr-2 h-4 w-4" />
               {publishing ? "Publishing…" : "Publish"}
@@ -450,6 +455,16 @@ export default function AppDetail() {
           if (!open && !archiving) setIsArchiveDialogOpen(false);
         }}
         onConfirm={handleArchive}
+      />
+      <PublishAppDialog
+        open={isPublishDialogOpen}
+        isPending={publishing}
+        onOpenChange={setIsPublishDialogOpen}
+        onConfirm={async (visibility) => {
+          if (await handlePublish(visibility)) {
+            setIsPublishDialogOpen(false);
+          }
+        }}
       />
     </main>
   );

--- a/apps/studio/src/features/apps/pages/apps-list.tsx
+++ b/apps/studio/src/features/apps/pages/apps-list.tsx
@@ -5,8 +5,14 @@ import { Button } from "@/design-system/ui/button";
 import { usePageContext } from "@/hooks/use-page-context";
 import { getWorkspaceAppPath } from "@/lib/workspace-routing";
 import { AppCard } from "../components/app-card";
+import { ArchiveAppDialog } from "../components/archive-app-dialog";
 import { CreateAppDialog } from "../components/create-app-dialog";
-import { createApp, toggleAppPublish, useApps } from "../data/apps-store";
+import {
+  archiveApp,
+  createApp,
+  toggleAppPublish,
+  useApps,
+} from "../data/apps-store";
 import type { HostedApp } from "../data/sample-apps";
 
 export default function AppsList() {
@@ -14,7 +20,9 @@ export default function AppsList() {
   const navigate = useNavigate();
   const { apps, loading, error } = useApps(workspaceSlug);
   const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [archiveTarget, setArchiveTarget] = useState<HostedApp | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [archiving, setArchiving] = useState(false);
   const { setPageContext } = usePageContext();
 
   useEffect(() => {
@@ -23,6 +31,22 @@ export default function AppsList() {
 
   const openApp = (app: HostedApp) => {
     navigate(getWorkspaceAppPath(workspaceSlug, app.id));
+  };
+
+  const handleArchive = async () => {
+    if (!archiveTarget) return;
+    setActionError(null);
+    setArchiving(true);
+    try {
+      await archiveApp(archiveTarget.id);
+      setArchiveTarget(null);
+    } catch (error) {
+      setActionError(
+        error instanceof Error ? error.message : "Unable to delete app.",
+      );
+    } finally {
+      setArchiving(false);
+    }
   };
 
   return (
@@ -58,6 +82,7 @@ export default function AppsList() {
                 key={app.id}
                 app={app}
                 onOpen={openApp}
+                onArchiveApp={setArchiveTarget}
                 onTogglePublish={(target) => {
                   setActionError(null);
                   void toggleAppPublish(target).catch(
@@ -83,6 +108,15 @@ export default function AppsList() {
           const app = await createApp(name, alias);
           navigate(getWorkspaceAppPath(workspaceSlug, app.id));
         }}
+      />
+      <ArchiveAppDialog
+        open={archiveTarget !== null}
+        appName={archiveTarget?.name ?? ""}
+        isPending={archiving}
+        onOpenChange={(open) => {
+          if (!open && !archiving) setArchiveTarget(null);
+        }}
+        onConfirm={handleArchive}
       />
     </main>
   );

--- a/apps/studio/src/features/apps/pages/apps-list.tsx
+++ b/apps/studio/src/features/apps/pages/apps-list.tsx
@@ -7,6 +7,7 @@ import { getWorkspaceAppPath } from "@/lib/workspace-routing";
 import { AppCard } from "../components/app-card";
 import { ArchiveAppDialog } from "../components/archive-app-dialog";
 import { CreateAppDialog } from "../components/create-app-dialog";
+import { PublishAppDialog } from "../components/publish-app-dialog";
 import {
   archiveApp,
   createApp,
@@ -23,6 +24,8 @@ export default function AppsList() {
   const [archiveTarget, setArchiveTarget] = useState<HostedApp | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [archiving, setArchiving] = useState(false);
+  const [publishTarget, setPublishTarget] = useState<HostedApp | null>(null);
+  const [publishing, setPublishing] = useState(false);
   const { setPageContext } = usePageContext();
 
   useEffect(() => {
@@ -85,6 +88,10 @@ export default function AppsList() {
                 onArchiveApp={setArchiveTarget}
                 onTogglePublish={(target) => {
                   setActionError(null);
+                  if (target.state !== "published") {
+                    setPublishTarget(target);
+                    return;
+                  }
                   void toggleAppPublish(target).catch(
                     (toggleError: unknown) => {
                       setActionError(
@@ -117,6 +124,30 @@ export default function AppsList() {
           if (!open && !archiving) setArchiveTarget(null);
         }}
         onConfirm={handleArchive}
+      />
+      <PublishAppDialog
+        open={publishTarget !== null}
+        isPending={publishing}
+        onOpenChange={(open) => {
+          if (!open && !publishing) setPublishTarget(null);
+        }}
+        onConfirm={async (visibility) => {
+          if (!publishTarget) return;
+          setActionError(null);
+          setPublishing(true);
+          try {
+            await toggleAppPublish(publishTarget, visibility);
+            setPublishTarget(null);
+          } catch (error) {
+            setActionError(
+              error instanceof Error
+                ? error.message
+                : "Unable to update publication state.",
+            );
+          } finally {
+            setPublishing(false);
+          }
+        }}
       />
     </main>
   );

--- a/src/orcheo/hosted_apps/postgres_store.py
+++ b/src/orcheo/hosted_apps/postgres_store.py
@@ -1053,6 +1053,7 @@ class PostgresHostedAppsRepository:  # pragma: no cover
                         release.created_at,
                     ),
                 )
+                app.visibility = release.visibility
                 app.active_release_id = release.id
                 app.publication_state = PublicationState.PUBLISHED
                 app.published_permission_revision = release.permission_revision

--- a/src/orcheo/hosted_apps/repository.py
+++ b/src/orcheo/hosted_apps/repository.py
@@ -487,6 +487,7 @@ class InMemoryHostedAppsRepository:
                 raise ValueError("Hosted app release already exists.")
             self._record_audit("release.publish", release.created_by, app)
             self._releases[release.id] = release.model_copy(deep=True)
+            app.visibility = release.visibility
             app.active_release_id = release.id
             app.publication_state = PublicationState.PUBLISHED
             app.published_permission_revision = release.permission_revision

--- a/tests/backend/test_app_hosted_apps.py
+++ b/tests/backend/test_app_hosted_apps.py
@@ -199,6 +199,20 @@ def test_central_pkce_authorization_requires_current_app_workspace_member(
         ).status_code
         == 200
     )
+    assert (
+        client.post(
+            "/api/hosted-apps/auth/authorize",
+            json={
+                "host": "private-portal.apps.localhost",
+                "redirect_uri": (
+                    "http://private-portal.apps.localhost:2030/__orcheo/auth/callback"
+                ),
+                "code_challenge": "c" * 43,
+                "state": state,
+            },
+        ).status_code
+        == 200
+    )
     monkeypatch.setenv("ORCHEO_APPS_BASE_DOMAIN", "apps.test")
     client.app.dependency_overrides[authenticate_request] = lambda: RequestContext(
         subject="not-a-member", identity_type="user"
@@ -322,15 +336,17 @@ def test_local_bundle_upload_validates_and_publishes(
 
     published = client.post(
         f"/api/apps/{created['id']}/deployments/{deployment['id']}/publish",
-        json={"acknowledged_permission_revision": created["permission_revision"]},
+        json={
+            "acknowledged_permission_revision": created["permission_revision"],
+            "visibility": "private",
+        },
     )
     assert published.status_code == 200
     assert published.json()["state"] == "published"
     assert published.json()["url"] == "https://example-upload.apps.test/"
-    assert (
-        client.get(f"/api/apps/{created['id']}").json()["url"]
-        == "https://example-upload.apps.test/"
-    )
+    app_response = client.get(f"/api/apps/{created['id']}").json()
+    assert app_response["url"] == "https://example-upload.apps.test/"
+    assert app_response["visibility"] == "private"
     assert (
         client.get(f"/api/apps/{created['id']}").json()["active_deployment_id"]
         == deployment["id"]

--- a/tests/backend/test_app_hosted_apps.py
+++ b/tests/backend/test_app_hosted_apps.py
@@ -844,7 +844,16 @@ def test_hosted_apps_route_error_contracts_and_configuration_guards(
     monkeypatch.setenv("ORCHEO_APP_BUNDLE_FILESYSTEM_ROOT", "/tmp/orcheo-test-apps")
     monkeypatch.setenv("ORCHEO_APP_BUNDLE_BACKEND", "filesystem")
     monkeypatch.setenv("ORCHEO_HOSTED_APPS_WORKSPACE_ALLOWLIST", str(uuid4()))
-    assert client.get("/api/apps").status_code == 404
+    unavailable = client.get("/api/apps")
+    assert unavailable.status_code == 404
+    assert unavailable.json()["detail"] == {
+        "code": "hosted_apps.unavailable",
+        "message": (
+            "Hosted Apps are not enabled for this workspace. Ask an administrator "
+            "to enable Hosted Apps or add this workspace to the Hosted Apps "
+            "allowlist."
+        ),
+    }
     monkeypatch.setenv(
         "ORCHEO_HOSTED_APPS_WORKSPACE_ALLOWLIST", str(created["workspace_id"])
     )

--- a/tests/hosted_apps/test_gateway_app.py
+++ b/tests/hosted_apps/test_gateway_app.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+from http.cookies import SimpleCookie
 from pathlib import Path
+from urllib.parse import parse_qs, urlparse
 from uuid import uuid4
 
 import httpx
@@ -347,3 +349,72 @@ def test_gateway_starts_pkce_login_with_signed_httponly_transaction(
     assert "HttpOnly" in cookie
     assert "Secure" in cookie
     assert "SameSite=lax" in cookie
+
+
+def test_gateway_local_auth_callback_returns_to_requested_app_path(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Local callback URIs retain the gateway port and redirect after exchange."""
+
+    class BackendClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def get(self, *_args, **_kwargs):
+            return httpx.Response(
+                200,
+                json={
+                    "deployment_id": str(uuid4()),
+                    "visibility": "private",
+                    "state": "published",
+                },
+            )
+
+        async def request(self, method, url, **_kwargs):
+            assert method == "POST"
+            assert url.endswith("/internal/hosted-apps/auth/exchange")
+            return httpx.Response(200, json={"session_secret": "session-secret"})
+
+    root = tmp_path / "bundles"
+    root.mkdir()
+    monkeypatch.setenv("ORCHEO_APPS_BASE_DOMAIN", "apps.localhost")
+    monkeypatch.setenv("ORCHEO_APP_BUNDLE_FILESYSTEM_ROOT", str(root))
+    monkeypatch.setenv("ORCHEO_APP_GATEWAY_BACKEND_URL", "http://backend")
+    monkeypatch.setenv("ORCHEO_APP_GATEWAY_SECRET", "g" * 64)
+    monkeypatch.setenv("ORCHEO_STUDIO_URL", "http://localhost:2026")
+    monkeypatch.setattr(
+        "orcheo_app_gateway.main.httpx.AsyncClient",
+        lambda **_kwargs: BackendClient(),
+    )
+    client = TestClient(create_app(), base_url="http://portal.apps.localhost:2030")
+
+    started = client.get(
+        "/__orcheo/auth/start",
+        params={"return_to": "/dashboard"},
+        headers={"host": "portal.apps.localhost:2030"},
+        follow_redirects=False,
+    )
+
+    authorize_params = parse_qs(urlparse(started.headers["location"]).query)
+    assert authorize_params["redirect_uri"] == [
+        "http://portal.apps.localhost:2030/__orcheo/auth/callback"
+    ]
+    transaction = SimpleCookie(started.headers["set-cookie"])[
+        "__Host-orcheo-app-auth"
+    ].value
+    callback = client.get(
+        "/__orcheo/auth/callback",
+        params={"code": "authorization-code", "state": authorize_params["state"][0]},
+        headers={
+            "host": "portal.apps.localhost:2030",
+            "cookie": f"__Host-orcheo-app-auth={transaction}",
+        },
+        follow_redirects=False,
+    )
+
+    assert callback.status_code == 302
+    assert callback.headers["location"] == "/dashboard"
+    assert "__Host-orcheo-app-session=session-secret" in callback.headers["set-cookie"]

--- a/tests/hosted_apps/test_repository.py
+++ b/tests/hosted_apps/test_repository.py
@@ -62,7 +62,7 @@ def test_publish_requires_ready_deployment_current_revision_and_ownership() -> N
         app_id=app.id,
         deployment_id=deployment.id,
         permission_revision=app.permission_revision,
-        visibility=AppVisibility.PUBLIC,
+        visibility=AppVisibility.PRIVATE,
         capability_snapshot={},
         csp_snapshot={},
         snapshot_sha256="a" * 64,
@@ -71,6 +71,7 @@ def test_publish_requires_ready_deployment_current_revision_and_ownership() -> N
     published = repository.publish_release(release)
     assert published.publication_state is PublicationState.PUBLISHED
     assert published.active_release_id == release.id
+    assert published.visibility is AppVisibility.PRIVATE
 
 
 def test_runtime_generation_fails_closed_and_invalidates_cache() -> None:


### PR DESCRIPTION
## Summary

Adds explicit publish visibility selection and confirmed archive actions for Hosted
Apps, with API and repository support that persist the selected visibility. It also
improves local gateway PKCE callback handling and makes disabled Hosted Apps workspaces
return an actionable error.

## Changes

- **Studio Hosted Apps controls** — adds publish and archive dialogs to the list and
  detail views, requires an access choice before publishing, and removes archived apps
  from the normal list.
- **Hosted Apps API and persistence** — accepts the selected visibility during release
  publishing and applies it to the active app in both repository implementations.
- **Gateway and availability feedback** — preserves the local gateway port in PKCE
  callbacks and returns a structured `hosted_apps.unavailable` response when a
  workspace is not enabled.
- **Coverage** — adds Studio, backend, gateway, and repository tests for the new
  publish, archive, availability, and local-auth behavior.
