### PR TITLE
Reconcile cron overlap state across worker processes

### DIFF
--- a/apps/backend/src/orcheo_backend/app/repository_postgres/_base.py
+++ b/apps/backend/src/orcheo_backend/app/repository_postgres/_base.py
@@ -399,24 +399,52 @@ class PostgresRepositoryBase:
                         )
 
     async def _refresh_cron_triggers(self) -> None:
-        """Refresh cron trigger configs to reflect the latest persisted state."""
+        """Refresh cron trigger configs to reflect the latest persisted state.
+
+        Also resyncs each workflow's cron overlap ("active run") tracking
+        against non-terminal cron-triggered runs in the database. That
+        in-memory tracking is normally advanced by register_cron_run /
+        release_cron_run, but those calls only mutate the state of the
+        worker process that makes them. Celery's prefork pool runs
+        dispatch_cron_triggers and execute_run in different OS processes,
+        so a run dispatched by one process is often completed by another,
+        whose release call never reaches the dispatcher's copy of the
+        state. Without this resync, the dispatcher's copy would believe
+        the run is still active forever, permanently blocking future
+        dispatches for that workflow.
+        """
         async with self._connection() as conn:
             cursor = await conn.execute(
                 """
-                SELECT c.workflow_id, c.config, c.last_dispatched_at
+                SELECT c.workflow_id,
+                       c.config,
+                       c.last_dispatched_at,
+                       COALESCE(
+                           ARRAY_AGG(r.id) FILTER (WHERE r.id IS NOT NULL),
+                           ARRAY[]::text[]
+                       ) AS active_cron_run_ids
                   FROM cron_triggers c
                   JOIN workflows w ON w.id = c.workflow_id
+                  LEFT JOIN workflow_runs r
+                    ON r.workflow_id = c.workflow_id
+                   AND r.triggered_by = 'cron'
+                   AND r.status IN ('pending', 'running')
                  WHERE w.is_archived = FALSE
+                 GROUP BY c.workflow_id, c.config, c.last_dispatched_at
                 """
             )
             rows = await cursor.fetchall()
 
         desired: dict[UUID, tuple[CronTriggerConfig, datetime | None]] = {}
+        active_runs: dict[UUID, set[UUID]] = {}
         for row in rows:
             workflow_id = UUID(row["workflow_id"])
             config = CronTriggerConfig.model_validate(row["config"])
             last_dispatched_at: datetime | None = row["last_dispatched_at"]
             desired[workflow_id] = (config, last_dispatched_at)
+            active_runs[workflow_id] = {
+                UUID(run_id) for run_id in (row.get("active_cron_run_ids") or [])
+            }
 
         current_states = self._trigger_layer._cron_states  # noqa: SLF001
         current_ids = set(current_states)
@@ -427,18 +455,16 @@ class PostgresRepositoryBase:
 
         for workflow_id, (config, last_dispatched_at) in desired.items():
             state = current_states.get(workflow_id)
-            if state is None:
-                self._trigger_layer.configure_cron(
-                    workflow_id, config, last_dispatched_at=last_dispatched_at
-                )
-                continue
-            if (
+            if state is None or (
                 state.config.model_dump(mode="json") != config.model_dump(mode="json")
                 or state.last_dispatched_at != last_dispatched_at
-            ):  # pragma: no branch
+            ):
                 self._trigger_layer.configure_cron(
                     workflow_id, config, last_dispatched_at=last_dispatched_at
                 )
+            self._trigger_layer.sync_cron_active_runs(
+                workflow_id, active_runs[workflow_id]
+            )
 
     async def close(self) -> None:
         """Close the connection pool."""

--- a/src/orcheo/hosted_apps/postgres_store.py
+++ b/src/orcheo/hosted_apps/postgres_store.py
@@ -837,14 +837,17 @@ class PostgresHostedAppsRepository:  # pragma: no cover
         with self._connect() as conn:
             rows = conn.execute(
                 """
-                SELECT DISTINCT app.*
+                SELECT app.*
                   FROM hosted_apps AS app
-                  JOIN hosted_app_bindings AS binding
-                    ON binding.workspace_id = app.workspace_id
-                   AND binding.app_id = app.id
-                 WHERE binding.workspace_id = %s
-                   AND binding.workflow_id = %s
-                   AND binding.deleted_at IS NULL
+                 WHERE app.workspace_id = %s
+                   AND EXISTS (
+                       SELECT 1
+                         FROM hosted_app_bindings AS binding
+                        WHERE binding.workspace_id = app.workspace_id
+                          AND binding.app_id = app.id
+                          AND binding.workflow_id = %s
+                          AND binding.deleted_at IS NULL
+                   )
                  FOR UPDATE OF app
                 """,
                 (workspace_id, workflow_id),

--- a/src/orcheo/triggers/cron.py
+++ b/src/orcheo/triggers/cron.py
@@ -248,6 +248,19 @@ class CronTriggerState:
         """Release an active run from overlap tracking."""
         self._active_runs.discard(run_id)
 
+    def sync_active_runs(self, run_ids: set[UUID]) -> None:
+        """Replace tracked active runs with an authoritative set.
+
+        Overlap tracking normally advances via register_run/release_run, but
+        those only mutate this process's in-memory state. A cron run is
+        often dispatched by one worker process and completed by another
+        (e.g. Celery's prefork pool), so the release never reaches this
+        copy and the trigger can appear permanently active. Callers should
+        periodically resync against a persisted source of truth (e.g. the
+        set of non-terminal runs for this workflow) to correct that drift.
+        """
+        self._active_runs = set(run_ids)
+
     def peek_due(self, *, now: datetime) -> datetime | None:
         """Return the next due execution time without advancing state."""
         self._ensure_next(now)

--- a/src/orcheo/triggers/layer/cron.py
+++ b/src/orcheo/triggers/layer/cron.py
@@ -153,5 +153,25 @@ class CronTriggerMixin(TriggerLayerState):
         if state is not None:
             state.release_run(run_id)
 
+    def sync_cron_active_runs(self, workflow_id: UUID, run_ids: set[UUID]) -> None:
+        """Reconcile a workflow's cron overlap tracking against persisted state.
+
+        See CronTriggerState.sync_active_runs for why this periodic
+        reconciliation (rather than relying solely on register/release
+        calls) is necessary when dispatch and execution can happen in
+        different worker processes.
+        """
+        state = self._cron_states.get(workflow_id)
+        if state is None:
+            return
+        state.sync_active_runs(run_ids)
+        self._cron_run_index = {
+            stored_run_id: stored_workflow_id
+            for stored_run_id, stored_workflow_id in self._cron_run_index.items()
+            if stored_workflow_id != workflow_id
+        }
+        for run_id in run_ids:
+            self._cron_run_index[run_id] = workflow_id
+
 
 __all__ = ["CronTriggerMixin"]

--- a/tests/backend/repository/test_postgres_repository.py
+++ b/tests/backend/repository/test_postgres_repository.py
@@ -1511,3 +1511,86 @@ async def test_refresh_cron_triggers_sync(monkeypatch: pytest.MonkeyPatch) -> No
 
     await repo._refresh_cron_triggers()
     assert w_id not in repo._trigger_layer._cron_states
+
+
+@pytest.mark.asyncio
+async def test_refresh_cron_triggers_reconciles_stale_active_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A run registered active by a different worker process, but already
+    completed, must not permanently block cron dispatch.
+
+    Celery's prefork pool runs dispatch_cron_triggers and execute_run in
+    separate OS processes, each with independent in-memory trigger-layer
+    state. register_cron_run happens in the dispatcher's process while
+    release_cron_run happens in the executor's process and never reaches
+    the dispatcher's copy of the state. _refresh_cron_triggers must resync
+    overlap tracking against the database so a completed run doesn't block
+    dispatch forever.
+    """
+    repo = make_repository(monkeypatch, [], initialized=True)
+    w_id = uuid4()
+    stale_run_id = uuid4()
+
+    cron_conf = CronTriggerConfig(expression="*/5 * * * *", timezone="UTC")
+    repo._trigger_layer.configure_cron(w_id, cron_conf)  # noqa: SLF001
+
+    # Simulate a cron run registered active by a *different* worker process
+    # (this process never received the corresponding release call).
+    repo._trigger_layer._cron_states[w_id]._active_runs.add(  # noqa: SLF001
+        stale_run_id
+    )
+    assert repo._trigger_layer._cron_states[w_id].can_dispatch() is False  # noqa: SLF001
+
+    # The database shows the run already completed (absent from the active set).
+    responses = [
+        {
+            "rows": [
+                {
+                    "workflow_id": str(w_id),
+                    "config": cron_conf.model_dump(mode="json"),
+                    "last_dispatched_at": None,
+                    "active_cron_run_ids": [],
+                }
+            ]
+        }
+    ]
+    repo._pool = FakePool(FakeConnection(responses))  # type: ignore
+
+    await repo._refresh_cron_triggers()
+
+    assert repo._trigger_layer._cron_states[w_id].can_dispatch() is True  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_refresh_cron_triggers_preserves_genuinely_active_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A run still pending/running in the database keeps blocking dispatch
+    after a refresh, even if this process never called register_cron_run
+    for it (e.g. it just hydrated mid-run)."""
+    repo = make_repository(monkeypatch, [], initialized=True)
+    w_id = uuid4()
+    active_run_id = uuid4()
+
+    cron_conf = CronTriggerConfig(expression="*/5 * * * *", timezone="UTC")
+    repo._trigger_layer.configure_cron(w_id, cron_conf)  # noqa: SLF001
+    assert repo._trigger_layer._cron_states[w_id].can_dispatch() is True  # noqa: SLF001
+
+    responses = [
+        {
+            "rows": [
+                {
+                    "workflow_id": str(w_id),
+                    "config": cron_conf.model_dump(mode="json"),
+                    "last_dispatched_at": None,
+                    "active_cron_run_ids": [str(active_run_id)],
+                }
+            ]
+        }
+    ]
+    repo._pool = FakePool(FakeConnection(responses))  # type: ignore
+
+    await repo._refresh_cron_triggers()
+
+    assert repo._trigger_layer._cron_states[w_id].can_dispatch() is False  # noqa: SLF001

--- a/tests/triggers_layer/test_cron.py
+++ b/tests/triggers_layer/test_cron.py
@@ -149,6 +149,19 @@ def test_commit_cron_dispatch_logs_and_reraises_failures(
     assert any("Failed to commit cron dispatch" in msg for msg in caplog.messages)
 
 
+def test_sync_cron_active_runs_noop_for_unconfigured_workflow() -> None:
+    """Syncing active runs for a workflow with no cron state is a no-op."""
+
+    layer = TriggerLayer()
+    workflow_id = uuid4()
+    run_id = uuid4()
+
+    layer.sync_cron_active_runs(workflow_id, {run_id})
+
+    assert layer._cron_states.get(workflow_id) is None
+    assert run_id not in layer._cron_run_index
+
+
 def test_concurrent_access_patterns() -> None:
     """Concurrent operations don't corrupt state."""
 


### PR DESCRIPTION
## Summary

Reconcile persisted cron-triggered run state during trigger refreshes so Celery workers do not retain stale in-memory overlap locks and permanently block future dispatches. The branch also tightens the hosted-app binding query and adds regression coverage for cron state reconciliation.

## Changes

- **Cron trigger refresh** — loads pending and running cron-triggered workflow runs from PostgreSQL and synchronizes each workflow's in-memory active-run set during `_refresh_cron_triggers`.
- **Trigger-layer state** — adds authoritative active-run synchronization to `CronTriggerState` and `CronTriggerMixin`, including replacement of stale run-index entries.
- **Hosted app repository** — replaces the binding join with an `EXISTS` filter while retaining row-level locking on hosted apps in `src/orcheo/hosted_apps/postgres_store.py`.
- **Regression tests** — verifies completed runs stop blocking dispatch and genuinely active runs continue to block it in `tests/backend/repository/test_postgres_repository.py`.

## Validation

- `uv run pytest tests/backend/repository/test_postgres_repository.py -q` — 50 passed
