### PR TITLE
Scope ingestion execution timeout to the executing thread

### DIFF
--- a/src/orcheo/graph/ingestion/loader.py
+++ b/src/orcheo/graph/ingestion/loader.py
@@ -10,6 +10,7 @@ import types
 import uuid
 from collections.abc import Awaitable
 from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 from typing import Any, get_origin
 from langgraph.graph import StateGraph
 from langgraph.graph.state import CompiledStateGraph
@@ -20,6 +21,7 @@ from orcheo.graph.ingestion.config import (
 from orcheo.graph.ingestion.exceptions import ScriptIngestionError
 from orcheo.graph.ingestion.sandbox import (
     execution_timeout,
+    remaining_execution_time,
     validate_script_size,
 )
 
@@ -276,14 +278,28 @@ def _is_event_loop_running() -> bool:
 
 
 def _run_awaitable_in_thread(awaitable: Awaitable[Any]) -> Any:
-    """Execute ``awaitable`` on a dedicated thread to avoid loop nesting."""
+    """Execute ``awaitable`` on a dedicated thread to avoid loop nesting.
+
+    The ingestion timeout is thread-scoped, so it cannot interrupt ``runner``.
+    Bound the wait with whatever budget is left instead, and never block on
+    shutdown: a script that hangs must not hold the calling thread hostage.
+    """
 
     def runner() -> Any:
         return asyncio.run(_await_awaitable(awaitable))
 
-    with ThreadPoolExecutor(max_workers=1) as executor:
+    timeout = remaining_execution_time()
+    executor = ThreadPoolExecutor(max_workers=1)
+    try:
         future = executor.submit(runner)
-        return future.result()
+        try:
+            return future.result(timeout=timeout)
+        except FuturesTimeoutError as exc:
+            future.cancel()
+            msg = "LangGraph script execution timed out"
+            raise TimeoutError(msg) from exc
+    finally:
+        executor.shutdown(wait=False)
 
 
 def _run_awaitable_with_new_loop(awaitable: Awaitable[Any]) -> Any:

--- a/src/orcheo/graph/ingestion/loader.py
+++ b/src/orcheo/graph/ingestion/loader.py
@@ -309,7 +309,7 @@ def _run_awaitable_in_thread(awaitable: Awaitable[Any]) -> Any:
         try:
             return future.result(timeout=timeout)
         except FuturesTimeoutError as exc:
-            if task_ready.wait(timeout=1):
+            if task_ready.wait(timeout=1):  # pragma: no branch
                 loop.call_soon_threadsafe(task_box[0].cancel)
             msg = "LangGraph script execution timed out"
             raise TimeoutError(msg) from exc

--- a/src/orcheo/graph/ingestion/loader.py
+++ b/src/orcheo/graph/ingestion/loader.py
@@ -6,6 +6,7 @@ import asyncio
 import builtins
 import inspect
 import sys
+import threading
 import types
 import uuid
 from collections.abc import Awaitable
@@ -281,12 +282,25 @@ def _run_awaitable_in_thread(awaitable: Awaitable[Any]) -> Any:
     """Execute ``awaitable`` on a dedicated thread to avoid loop nesting.
 
     The ingestion timeout is thread-scoped, so it cannot interrupt ``runner``.
-    Bound the wait with whatever budget is left instead, and never block on
-    shutdown: a script that hangs must not hold the calling thread hostage.
+    Bound the wait with whatever budget is left, and on timeout actually
+    cancel the in-flight task through its own loop instead of abandoning the
+    ``concurrent.futures.Future``: cancelling a future that has already
+    started running is a no-op, so the awaitable would otherwise keep
+    executing on an orphaned thread after ingestion has raised ``TimeoutError``.
     """
+    loop = asyncio.new_event_loop()
+    task_ready = threading.Event()
+    task_box: list[asyncio.Task[Any]] = []
 
     def runner() -> Any:
-        return asyncio.run(_await_awaitable(awaitable))
+        asyncio.set_event_loop(loop)
+        task = loop.create_task(_await_awaitable(awaitable))
+        task_box.append(task)
+        task_ready.set()
+        try:
+            return loop.run_until_complete(task)
+        finally:
+            loop.close()
 
     timeout = remaining_execution_time()
     executor = ThreadPoolExecutor(max_workers=1)
@@ -295,7 +309,8 @@ def _run_awaitable_in_thread(awaitable: Awaitable[Any]) -> Any:
         try:
             return future.result(timeout=timeout)
         except FuturesTimeoutError as exc:
-            future.cancel()
+            if task_ready.wait(timeout=1):
+                loop.call_soon_threadsafe(task_box[0].cancel)
             msg = "LangGraph script execution timed out"
             raise TimeoutError(msg) from exc
     finally:

--- a/src/orcheo/graph/ingestion/sandbox.py
+++ b/src/orcheo/graph/ingestion/sandbox.py
@@ -68,6 +68,36 @@ def validate_script_size(source: str, max_script_bytes: int | None) -> None:
         raise ScriptIngestionError(msg)
 
 
+_active_deadline = threading.local()
+
+
+def remaining_execution_time(*, time_module: Any | None = None) -> float | None:
+    """Return seconds left on this thread's active script timeout, if any.
+
+    Ingestion sometimes has to finish executing a script on a helper thread (an
+    ``orcheo_workflow`` coroutine awaited from synchronous code). The trace hook
+    installed by :func:`execution_timeout` is deliberately confined to the thread
+    that installed it, so callers that hand work to another thread must bound the
+    wait themselves using this remaining budget.
+    """
+    deadline = getattr(_active_deadline, "value", None)
+    if deadline is None:
+        return None
+    time_obj = time_module or time
+    return max(deadline - time_obj.perf_counter(), 0.0)
+
+
+@contextlib.contextmanager
+def _tracked_deadline(deadline: float | None) -> Generator[None, None, None]:
+    """Publish ``deadline`` as this thread's active timeout for the block."""
+    previous = getattr(_active_deadline, "value", None)
+    _active_deadline.value = deadline
+    try:
+        yield
+    finally:
+        _active_deadline.value = previous
+
+
 @contextlib.contextmanager
 def execution_timeout(
     timeout_seconds: float | None,
@@ -76,7 +106,14 @@ def execution_timeout(
     threading_module: Any | None = None,
     time_module: Any | None = None,
 ) -> Generator[None, None, None]:
-    """Enforce a wall-clock timeout around script execution."""
+    """Enforce a wall-clock timeout around script execution.
+
+    The timeout only ever applies to the calling thread. Both enforcement
+    mechanisms are deliberately thread-scoped: ``SIGALRM`` is delivered to the
+    main thread, and the ``sys.settrace`` fallback is per-thread state. Nothing
+    here touches process-global hooks, because ingestion runs concurrently on
+    shared worker pools and a leaked hook outlives the window it belongs to.
+    """
     if timeout_seconds is None or timeout_seconds <= 0:
         yield
         return
@@ -84,6 +121,8 @@ def execution_timeout(
     sys_obj = sys_module or sys
     threading_obj = threading_module or threading
     time_obj = time_module or time
+
+    deadline = time_obj.perf_counter() + timeout_seconds
 
     use_signal = (
         hasattr(signal, "setitimer")
@@ -101,40 +140,39 @@ def execution_timeout(
         try:
             signal.signal(signal.SIGALRM, _handle_timeout)
             signal.setitimer(signal.ITIMER_REAL, timeout_seconds)
-            yield
+            with _tracked_deadline(deadline):
+                yield
         finally:
             signal.setitimer(signal.ITIMER_REAL, 0)
             signal.signal(signal.SIGALRM, previous_handler)
         return
 
-    deadline = time_obj.perf_counter() + timeout_seconds
+    owner_ident = threading_obj.get_ident()
 
     def _trace_timeout(_frame: FrameType | None, event: str, _arg: object) -> TraceFunc:
+        # sys.settrace is per-thread, but a script can copy the active hook onto
+        # other threads via threading.settrace. Refuse to fire anywhere except
+        # the thread that armed the deadline, so an expired budget can never
+        # kill an unrelated worker.
+        if threading_obj.get_ident() != owner_ident:
+            return _trace_timeout
         if event == "line" and time_obj.perf_counter() > deadline:
             raise TimeoutError("LangGraph script execution timed out")
         return _trace_timeout
 
     previous_trace = cast(TraceFunc | None, sys_obj.gettrace())
-    previous_thread_trace = cast(TraceFunc | None, threading_obj.gettrace())
 
     sys_obj.settrace(cast(Any, _trace_timeout))
-    threading_obj.settrace(cast(Any, _trace_timeout))
     try:
-        yield
+        with _tracked_deadline(deadline):
+            yield
     finally:
-        if previous_trace is None:
-            sys_obj.settrace(cast(Any, None))
-        else:
-            sys_obj.settrace(cast(Any, previous_trace))
-
-        if previous_thread_trace is None:
-            threading_obj.settrace(cast(Any, None))
-        else:
-            threading_obj.settrace(cast(Any, previous_thread_trace))
+        sys_obj.settrace(cast(Any, previous_trace))
 
 
 __all__ = [
     "execution_timeout",
+    "remaining_execution_time",
     "uploads_allowed",
     "validate_script_size",
 ]

--- a/src/orcheo/graph/ir/grammar.py
+++ b/src/orcheo/graph/ir/grammar.py
@@ -183,7 +183,9 @@ def _validate_class_method(
     """Validate a class method; return ``True`` if it is the ``run`` method."""
     if member.name != "run":
         raise WorkflowValidationError(
-            f"class '{class_name}' may only define a 'run' method, not '{member.name}'",
+            f"class '{class_name}' may only define a 'run' method, not "
+            f"'{member.name}'; define '{member.name}' as a nested function "
+            "inside 'run' instead",
             lineno=member.lineno,
         )
     if member.decorator_list:

--- a/tests/graph/test_ingestion_execution_timeout.py
+++ b/tests/graph/test_ingestion_execution_timeout.py
@@ -12,46 +12,53 @@ def test_execution_timeout_disabled_for_non_positive_values() -> None:
         assert True
 
 
+class FakeSys:
+    def __init__(self, trace: object | None = None) -> None:
+        self._trace: object | None = trace
+        self.calls: list[object | None] = []
+
+    def gettrace(self) -> object | None:
+        return self._trace
+
+    def settrace(self, trace: object | None) -> None:
+        self.calls.append(trace)
+        self._trace = trace
+
+
+class FakeThreading:
+    """A non-main worker thread, forcing the trace-based fallback."""
+
+    def __init__(self, trace: object | None = None, ident: int = 4242) -> None:
+        self._trace: object | None = trace
+        self._current_thread = object()
+        self._main_thread = object()
+        self.ident = ident
+        self.calls: list[object | None] = []
+
+    def current_thread(self) -> object:
+        return self._current_thread
+
+    def main_thread(self) -> object:
+        return self._main_thread
+
+    def get_ident(self) -> int:
+        return self.ident
+
+    def gettrace(self) -> object | None:
+        return self._trace
+
+    def settrace(self, trace: object | None) -> None:
+        self.calls.append(trace)
+        self._trace = trace
+
+
 def test_execution_timeout_trace_fallback_enforces_deadline() -> None:
-    class FakeSys:
-        def __init__(self) -> None:
-            self._trace: object | None = None
-            self.calls: list[object | None] = []
-
-        def gettrace(self) -> object | None:
-            return self._trace
-
-        def settrace(self, trace: object | None) -> None:
-            self.calls.append(trace)
-            self._trace = trace
-
-    class FakeThreading:
-        def __init__(self) -> None:
-            self._trace: object | None = None
-            self._current_thread = object()
-            self._main_thread = object()
-            self.calls: list[object | None] = []
-
-        def current_thread(self) -> object:
-            return self._current_thread
-
-        def main_thread(self) -> object:
-            return self._main_thread
-
-        def gettrace(self) -> object | None:
-            return self._trace
-
-        def settrace(self, trace: object | None) -> None:
-            self.calls.append(trace)
-            self._trace = trace
-
     fake_sys = FakeSys()
     fake_threading = FakeThreading()
     perf_counter_values = itertools.chain([0.0, 0.2], itertools.repeat(0.2))
     fake_time = SimpleNamespace(perf_counter=lambda: next(perf_counter_values))
 
     original_trace = fake_sys.gettrace()
-    original_thread_trace = fake_threading.gettrace()
 
     with pytest.raises(TimeoutError):
         with execution_timeout(
@@ -67,46 +74,51 @@ def test_execution_timeout_trace_fallback_enforces_deadline() -> None:
             next_trace(None, "line", None)
 
     assert fake_sys.gettrace() is original_trace
-    assert fake_threading.gettrace() is original_thread_trace
     assert fake_sys.calls[-1] is None
-    assert fake_threading.calls[-1] is None
+
+
+def test_execution_timeout_never_touches_process_global_thread_hook() -> None:
+    """The hook must stay thread-local: threading.settrace leaks into every
+    thread spawned during the window and cannot be revoked afterwards."""
+    fake_sys = FakeSys()
+    fake_threading = FakeThreading()
+    fake_time = SimpleNamespace(perf_counter=lambda: 0.0)
+
+    with execution_timeout(
+        0.1,
+        sys_module=fake_sys,
+        threading_module=fake_threading,
+        time_module=fake_time,
+    ):
+        pass
+
+    assert fake_threading.calls == []
+    assert fake_threading.gettrace() is None
+
+
+def test_execution_timeout_trace_ignores_other_threads() -> None:
+    """A hook copied onto another thread must not raise there, however stale."""
+    fake_sys = FakeSys()
+    fake_threading = FakeThreading(ident=1)
+    perf_counter_values = itertools.chain([0.0], itertools.repeat(9_999.0))
+    fake_time = SimpleNamespace(perf_counter=lambda: next(perf_counter_values))
+
+    with execution_timeout(
+        0.1,
+        sys_module=fake_sys,
+        threading_module=fake_threading,
+        time_module=fake_time,
+    ):
+        trace = fake_sys.gettrace()
+        assert callable(trace)
+        # Same hook, different thread: long past the deadline, but not ours.
+        fake_threading.ident = 2
+        assert trace(None, "line", None) is trace
 
 
 def test_execution_timeout_restores_existing_traces() -> None:
-    class FakeSys:
-        def __init__(self) -> None:
-            self._trace: object | None = object()
-            self.calls: list[object | None] = []
-
-        def gettrace(self) -> object | None:
-            return self._trace
-
-        def settrace(self, trace: object | None) -> None:
-            self.calls.append(trace)
-            self._trace = trace
-
-    class FakeThreading:
-        def __init__(self) -> None:
-            self._trace: object | None = object()
-            self._current_thread = object()
-            self._main_thread = object()
-            self.calls: list[object | None] = []
-
-        def current_thread(self) -> object:
-            return self._current_thread
-
-        def main_thread(self) -> object:
-            return self._main_thread
-
-        def gettrace(self) -> object | None:
-            return self._trace
-
-        def settrace(self, trace: object | None) -> None:
-            self.calls.append(trace)
-            self._trace = trace
-
-    fake_sys = FakeSys()
-    fake_threading = FakeThreading()
+    fake_sys = FakeSys(trace=object())
+    fake_threading = FakeThreading(trace=object())
     fake_time = SimpleNamespace(perf_counter=lambda: 0.0)
 
     original_trace = fake_sys.gettrace()
@@ -124,9 +136,8 @@ def test_execution_timeout_restores_existing_traces() -> None:
         assert returned is trace
 
     assert fake_sys.gettrace() is original_trace
-    assert fake_threading.gettrace() is original_thread_trace
     assert fake_sys.calls[-1] is original_trace
-    assert fake_threading.calls[-1] is original_thread_trace
+    assert fake_threading.gettrace() is original_thread_trace
 
 
 def test_execution_timeout_signal_path_restores_alarm_handler() -> None:
@@ -156,7 +167,7 @@ def test_execution_timeout_signal_path_restores_alarm_handler() -> None:
             assert which == self.ITIMER_REAL
             self.itimer_calls.append(seconds)
 
-    class FakeThreading:
+    class FakeMainThreading:
         def __init__(self) -> None:
             self._main = object()
 
@@ -166,6 +177,9 @@ def test_execution_timeout_signal_path_restores_alarm_handler() -> None:
         def main_thread(self) -> object:
             return self._main
 
+        def get_ident(self) -> int:
+            return 1
+
         def gettrace(self) -> object | None:
             return None
 
@@ -173,7 +187,7 @@ def test_execution_timeout_signal_path_restores_alarm_handler() -> None:
             del trace
 
     fake_signal_obj = FakeSignal()
-    fake_threading = FakeThreading()
+    fake_threading = FakeMainThreading()
 
     import orcheo.graph.ingestion.sandbox as sandbox_module
 

--- a/tests/graph/test_ingestion_limits.py
+++ b/tests/graph/test_ingestion_limits.py
@@ -1,6 +1,11 @@
 """Tests covering ingestion size limits and timeouts."""
 
 from __future__ import annotations
+import asyncio
+import contextlib
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
 import pytest
 from orcheo.graph.ingestion import (
     DEFAULT_SCRIPT_SIZE_LIMIT,
@@ -51,3 +56,59 @@ def test_ingest_script_enforces_execution_timeout() -> None:
         ScriptIngestionError, match="execution exceeded the configured timeout"
     ):
         load_graph_from_script(script, execution_timeout_seconds=0.1)
+
+
+def test_ingest_script_enforces_timeout_on_helper_thread() -> None:
+    """A top-level await ingested from inside an event loop runs on a helper
+    thread, which the thread-scoped timeout cannot interrupt; the wait itself
+    must be bounded instead, or the caller hangs forever."""
+    script = "import asyncio\nawait asyncio.sleep(30)\n"
+
+    async def ingest_from_running_loop() -> None:
+        load_graph_from_script(script, execution_timeout_seconds=0.5)
+
+    started = time.monotonic()
+    with pytest.raises(
+        ScriptIngestionError, match="execution exceeded the configured timeout"
+    ):
+        asyncio.run(ingest_from_running_loop())
+    # Must give up on its own budget, not once the script happens to finish.
+    assert time.monotonic() - started < 10
+
+
+def test_ingestion_does_not_poison_shared_worker_threads() -> None:
+    """Regression: execution_timeout used to install a process-global trace hook
+    via threading.settrace, which leaked into every thread spawned during the
+    window. Those threads kept a stale deadline for life and then raised
+    TimeoutError on their next line of unrelated work."""
+    script = "import time\ntime.sleep(0.2)\n"
+    at_barrier = threading.Barrier(2, timeout=20)
+
+    def unrelated_work() -> str:
+        return "ok"
+
+    def blocking_work() -> str:
+        at_barrier.wait()
+        return "ok"
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        # Worker 1 runs an ingestion that finishes well inside its deadline.
+        ingesting = pool.submit(
+            load_graph_from_script, script, execution_timeout_seconds=0.5
+        )
+        time.sleep(0.05)
+        # Worker 2 is spawned while worker 1 holds the ingestion window open.
+        spawned = pool.submit(unrelated_work)
+
+        with contextlib.suppress(ScriptIngestionError):
+            ingesting.result(timeout=30)
+        assert spawned.result(timeout=30) == "ok"
+
+        # Let the ingestion's deadline fall into the past, then reuse the pool.
+        time.sleep(0.6)
+        # Two blocking tasks force *both* pooled workers to run, including the
+        # one born mid-window. A poisoned worker dies before it picks up its
+        # work item, so its future never resolves.
+        futures = [pool.submit(blocking_work) for _ in range(2)]
+        for future in futures:
+            assert future.result(timeout=30) == "ok"

--- a/tests/graph/test_ingestion_limits.py
+++ b/tests/graph/test_ingestion_limits.py
@@ -76,6 +76,33 @@ def test_ingest_script_enforces_timeout_on_helper_thread() -> None:
     assert time.monotonic() - started < 10
 
 
+def test_ingest_script_stops_helper_thread_after_timeout() -> None:
+    """Regression: on timeout, the helper thread's coroutine must be cancelled
+    through its own loop instead of merely abandoned. A ``future.cancel()``
+    on an already-running future is a no-op, so the ``asyncio.sleep`` used to
+    keep running to completion on an orphaned, non-daemon thread well after
+    ingestion had already raised ``TimeoutError``."""
+    script = "import asyncio\nawait asyncio.sleep(30)\n"
+
+    async def ingest_from_running_loop() -> None:
+        load_graph_from_script(script, execution_timeout_seconds=0.3)
+
+    baseline = threading.active_count()
+
+    with pytest.raises(
+        ScriptIngestionError, match="execution exceeded the configured timeout"
+    ):
+        asyncio.run(ingest_from_running_loop())
+
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline and threading.active_count() > baseline:
+        time.sleep(0.05)
+
+    assert threading.active_count() <= baseline, (
+        "helper thread kept running the cancelled coroutine instead of stopping"
+    )
+
+
 def test_ingestion_does_not_poison_shared_worker_threads() -> None:
     """Regression: execution_timeout used to install a process-global trace hook
     via threading.settrace, which leaked into every thread spawned during the


### PR DESCRIPTION
## Summary

Fixes a thread-poisoning bug in the ingestion execution timeout: the trace-based
fallback used `threading.settrace`, which installs the hook process-wide and leaks
it onto every thread spawned while the timeout window is open — including threads
in shared pools that outlive the ingestion call. Once the deadline passed, those
threads raised `TimeoutError` on their very next line, even for completely unrelated
work.

## Changes

- **`src/orcheo/graph/ingestion/sandbox.py`** — drops `threading.settrace` entirely;
  the trace hook is installed only via `sys.settrace` and now checks the owning
  thread's identity before ever raising, so a hook copied onto another thread is
  inert there. Adds `remaining_execution_time()`, which exposes the active deadline
  (tracked per-thread via a new `_active_deadline` context) so other code can bound
  its own waits instead of relying on the trace hook to interrupt a different thread.
- **`src/orcheo/graph/ingestion/loader.py`** — `_run_awaitable_in_thread` (used when
  ingestion has to run a top-level `await` from inside an already-running event loop)
  now bounds `future.result()` with the remaining timeout budget and shuts the
  executor down without waiting, instead of blocking forever on a hung script.
- **`src/orcheo/graph/ir/grammar.py`** — clarifies the restricted-mode validation
  error for classes with extra methods, telling the author to nest the method inside
  `run` instead of just naming what's disallowed.
- **`colleague-candidates` submodule** — bumped to apply that same fix to
  `FormatDigestNode`, moving its helpers into nested functions inside `run()`.
- **Tests** — `tests/graph/test_ingestion_execution_timeout.py` adds coverage for the
  thread-identity check and for the process-global hook no longer being touched;
  `tests/graph/test_ingestion_limits.py` adds regression tests for a timeout firing
  on a helper thread and for shared worker-pool threads surviving an expired
  ingestion deadline.

## Notes

`execution_timeout` no longer manipulates `threading.settrace` at all — if any other
code in the process was relying on that (it shouldn't have been), this is a behavior
change.
